### PR TITLE
Adding absolute(), averageAbove(), averageBelow(), and maxValue support for nonNegativeDerivative

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -217,8 +217,24 @@ func TestEvalExpression(t *testing.T) {
 			map[metricRequest][]*pb.FetchResponse{
 				metricRequest{"metric1", 0, 0}: []*pb.FetchResponse{makeResponse("metric1", []float64{2, 4, 6, 1, 4, math.NaN(), 8}, 1, now32)},
 			},
-			[]float64{math.NaN(), 2, 2, math.NaN(), 3, math.NaN(), 4},
+			[]float64{math.NaN(), 2, 2, math.NaN(), 3, math.NaN(), math.NaN()},
 			"nonNegativeDerivative(metric1)",
+		},
+		{
+			&expr{
+				target: "nonNegativeDerivative",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric1"},
+					&expr{val: 32, etype: etConst},
+				},
+				argString: "metric1,32",
+			},
+			map[metricRequest][]*pb.FetchResponse{
+				metricRequest{"metric1", 0, 0}: []*pb.FetchResponse{makeResponse("metric1", []float64{2, 4, 0, 10, 1, math.NaN(), 8, 40, 37}, 1, now32)},
+			},
+			[]float64{math.NaN(), 2, 29, 10, 24, math.NaN(), math.NaN(), 32, math.NaN()},
+			"nonNegativeDerivative(metric1,32)",
 		},
 		{
 			&expr{


### PR DESCRIPTION
Implemented a few functions, and modified nonNegativeDerivative base on the logic from 
http://nullege.com/codes/search/graphite_api.functions.nonNegativeDerivative

```
    def nonNegativeDerivative(requestContext, seriesList, maxValue=None):
"""
Same as the derivative function above, but ignores datapoints that trend
down. Useful for counters that increase for a long time, then wrap or
reset. (Such as if a network interface is destroyed and recreated by
unloading and re-loading a kernel module, common with USB / WiFi cards.

Example::

    &target=nonNegativederivative(
        company.server.application01.ifconfig.TXPackets)

"""
results = []

for series in seriesList:
    newValues = []
    prev = None

    for val in series:
        if None in (prev, val):
            newValues.append(None)
            prev = val
            continue

        diff = val - prev
        if diff >= 0:
            newValues.append(diff)
        elif maxValue is not None and maxValue >= val:
            newValues.append((maxValue - prev) + val + 1)
        else:
            newValues.append(None)

        prev = val

    newName = "nonNegativeDerivative(%s)" % series.name
    newSeries = TimeSeries(newName, series.start, series.end, series.step,
                           newValues)
    newSeries.pathExpression = newName
    results.append(newSeries)

return results
```
