### PR TITLE
divideSeries: support seriesList in dividends

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -1073,13 +1073,12 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 			return nil, ErrMissingTimeseries
 		}
 
-		var results []*MetricData
 		firstArg, err := getSeriesArg(e.args[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
 
-		var useMetricNames = false
+		var useMetricNames bool
 
 		var numerators []*MetricData
 		var denominator *MetricData
@@ -1104,10 +1103,11 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 
 		for _, numerator := range numerators {
 			if numerator.StepTime != denominator.StepTime || len(numerator.Values) != len(denominator.Values) {
-				return nil, errors.New("series must have the same length")
+				return nil, errors.New(fmt.Sprintf("series %s must have the same length as %s", numerator.Name, denominator.Name))
 			}
 		}
 
+		var results []*MetricData
 		for _, numerator := range numerators {
 			r := *numerator
 			if useMetricNames {

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -1073,14 +1073,19 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 			return nil, ErrMissingTimeseries
 		}
 
-		numerators, err := getSeriesArg(e.args[0], from, until, values)
+		var results []*MetricData
+		firstArg, err := getSeriesArg(e.args[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
 
-		var numerator, denominator *MetricData
-		if len(numerators) == 1 && len(e.args) == 2 {
-			numerator = numerators[0]
+		var useMetricNames = false
+
+		var numerators []*MetricData
+		var denominator *MetricData
+		if len(e.args) == 2 {
+			useMetricNames = true
+			numerators = firstArg
 			denominators, err := getSeriesArg(e.args[1], from, until, values)
 			if err != nil {
 				return nil, err
@@ -1090,32 +1095,42 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 			}
 
 			denominator = denominators[0]
-		} else if len(numerators) == 2 && len(e.args) == 1 {
-			numerator = numerators[0]
-			denominator = numerators[1]
+		} else if len(firstArg) == 2 && len(e.args) == 1 {
+			numerators = append(numerators, firstArg[0])
+			denominator = firstArg[1]
 		} else {
 			return nil, errors.New("must be called with 2 series or a wildcard that matches exactly 2 series")
 		}
 
-		if numerator.StepTime != denominator.StepTime || len(numerator.Values) != len(denominator.Values) {
-			return nil, errors.New("series must have the same length")
-		}
-
-		r := *numerator
-		r.Name = fmt.Sprintf("divideSeries(%s)", e.argString)
-		r.Values = make([]float64, len(numerator.Values))
-		r.IsAbsent = make([]bool, len(numerator.Values))
-
-		for i, v := range numerator.Values {
-
-			if numerator.IsAbsent[i] || denominator.IsAbsent[i] || denominator.Values[i] == 0 {
-				r.IsAbsent[i] = true
-				continue
+		for _, numerator := range numerators {
+			if numerator.StepTime != denominator.StepTime || len(numerator.Values) != len(denominator.Values) {
+				return nil, errors.New("series must have the same length")
 			}
-
-			r.Values[i] = v / denominator.Values[i]
 		}
-		return []*MetricData{&r}, nil
+
+		for _, numerator := range numerators {
+			r := *numerator
+			if useMetricNames {
+				r.Name = fmt.Sprintf("divideSeries(%s,%s)", numerator.Name, denominator.Name)
+			} else {
+				r.Name = fmt.Sprintf("divideSeries(%s)", e.argString)
+			}
+			r.Values = make([]float64, len(numerator.Values))
+			r.IsAbsent = make([]bool, len(numerator.Values))
+
+			for i, v := range numerator.Values {
+
+				if numerator.IsAbsent[i] || denominator.IsAbsent[i] || denominator.Values[i] == 0 {
+					r.IsAbsent[i] = true
+					continue
+				}
+
+				r.Values[i] = v / denominator.Values[i]
+			}
+			results = append(results, &r)
+		}
+
+		return results, nil
 
 	case "multiplySeries": // multiplySeries(factorsSeriesList)
 		r := MetricData{

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -3028,6 +3028,34 @@ func TestEvalMultipleReturns(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "divideSeries",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric[12]"},
+					{target: "metric2"},
+				},
+				argString: "metric[12],metric2",
+			},
+			map[MetricRequest][]*MetricData{
+				{"metric[12]", 0, 1}: {
+					makeResponse("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
+					makeResponse("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
+				},
+				{"metric1", 0, 1}: {
+					makeResponse("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
+				},
+				{"metric2", 0, 1}: {
+					makeResponse("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
+				},
+			},
+			"divideSeries",
+			map[string][]*MetricData{
+				"divideSeries(metric1,metric2)": {makeResponse("divideSeries(metric1,metric2)", []float64{0.5, 0.5, 0.5, 0.5, 0.5}, 1, now32)},
+				"divideSeries(metric2,metric2)": {makeResponse("divideSeries(metric2,metric2)", []float64{1, 1, 1, 1, 1}, 1, now32)},
+			},
+		},
+		{
+			&expr{
 				target: "applyByNode",
 				etype:  etFunc,
 				args: []*expr{


### PR DESCRIPTION
Fixes https://github.com/go-graphite/carbonapi/issues/203

For back-compat, introduces a flag to use the old way of naming the new metric
based on the argString; otherwise uses the underlying metric names to generate
the new metric name.