### PR TITLE
expr diffSeries: allow subtracting series with different StepTimes

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -992,39 +992,43 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 		return []*MetricData{&r}, nil
 
 	case "diffSeries": // diffSeries(*seriesLists)
-		minuend, err := getSeriesArg(e.args[0], from, until, values)
+		minuends, err := getSeriesArg(e.args[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
 
 		subtrahends, err := getSeriesArgs(e.args[1:], from, until, values)
 		if err != nil {
-			if len(minuend) < 2 {
+			if len(minuends) < 2 {
 				return nil, err
 			}
-			subtrahends = minuend[1:]
+			subtrahends = minuends[1:]
 			err = nil
 		}
 
+		minuend := minuends[0]
+
 		// FIXME: need more error checking on minuend, subtrahends here
-		r := *minuend[0]
+		r := *minuend
 		r.Name = fmt.Sprintf("diffSeries(%s)", e.argString)
-		r.Values = make([]float64, len(minuend[0].Values))
-		r.IsAbsent = make([]bool, len(minuend[0].Values))
+		r.Values = make([]float64, len(minuend.Values))
+		r.IsAbsent = make([]bool, len(minuend.Values))
 
-		for i, v := range minuend[0].Values {
+		for i, v := range minuend.Values {
 
-			if minuend[0].IsAbsent[i] {
+			if minuend.IsAbsent[i] {
 				r.IsAbsent[i] = true
 				continue
 			}
 
 			var sub float64
 			for _, s := range subtrahends {
-				if s.IsAbsent[i] {
+				iSubtrahend := (int32(i) * minuend.StepTime) / s.StepTime
+
+				if s.IsAbsent[iSubtrahend] {
 					continue
 				}
-				sub += s.Values[i]
+				sub += s.Values[iSubtrahend]
 			}
 
 			r.Values[i] = v - sub

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -1395,6 +1395,24 @@ func TestEvalExpression(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "diffSeries",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric*"},
+				},
+				argString: "metric*",
+			},
+			map[MetricRequest][]*MetricData{
+				{"metric*", 0, 1}: {
+					makeResponse("metric1", []float64{1, 2, math.NaN(), 3, 4, math.NaN()}, 1, now32),
+					makeResponse("metric2", []float64{5, math.NaN(), 6}, 2, now32),
+				},
+			},
+			[]*MetricData{makeResponse("diffSeries(metric*)",
+				[]float64{-4, -3, math.NaN(), 3, -2, math.NaN()}, 1, now32)},
+		},
+		{
+			&expr{
 				target: "rangeOfSeries",
 				etype:  etFunc,
 				args: []*expr{


### PR DESCRIPTION
when you subtract series with different step times in carbonapi
or python graphite you'll get an exception.

but it's usefult to assume that, if the subtrahend step time is a
multiple of the minuend step time, the minuend is the average value
for a range.

this can be used on comparing data that has some seasonality.

    diffSeries(some.metric, summarize(some.metric, 'period', 'avg'))

the result will be that every period of that will be normalized
to the same average.

I expect to use this result with ifft(fft()) so we can create
predictions.