### PR TITLE
add a new expression: removeBetweenEpochs

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -196,6 +196,7 @@ removeAbovePercentile(seriesList, n)                                      |  0.9
 removeAboveValue(seriesList, n)                                           |  0.9.10 | Supported
 removeBelowPercentile(seriesList, n)                                      |  0.9.10 | Supported
 removeBelowValue(seriesList, n)                                           |  0.9.10 | Supported
+removeBetweenEpochs(seriesList, fromEpoch, untilEpoch)                    | not in graphite | Experimental
 removeBetweenPercentile(seriesList, n)                                    |  1.0.0  |
 removeEmptySeries(seriesList)                                             |  1.0.0  | Supported
 removeZeroSeries(seriesList)                                              |  0.9.14 | Supported

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -3613,6 +3613,48 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 
 		return results, nil
 
+	case "removeBetweenEpochs": // removeBetweenEpochs(seriesLists, fromEpoch, untilEpoch)
+		args, err := getSeriesArg(e.args[0], from, until, values)
+		if err != nil {
+			return nil, err
+		}
+
+		fromEpoch, err := getIntArg(e, 1)
+		if err != nil {
+			return nil, err
+		}
+
+		untilEpoch, err := getIntArg(e, 2)
+		if err != nil {
+			return nil, err
+		}
+
+		var results []*MetricData
+
+		for _, a := range args {
+			r := *a
+			r.Name = fmt.Sprintf("%s(%s, %d, %d)", e.target, a.Name, fromEpoch, untilEpoch)
+			r.IsAbsent = make([]bool, len(a.Values))
+			r.Values = make([]float64, len(a.Values))
+
+			epoch := int(a.StartTime)
+			for i, v := range a.Values {
+
+				if a.IsAbsent[i] || (epoch >= fromEpoch && epoch < untilEpoch) {
+					r.Values[i] = math.NaN()
+					r.IsAbsent[i] = true
+				} else {
+					r.Values[i] = v
+				}
+
+				epoch += int(a.StepTime)
+			}
+
+			results = append(results, &r)
+		}
+
+		return results, nil
+
 	case "cactiStyle": // cactiStyle(seriesList, system=None, units=None)
 		// Get the series data
 		original, err := getSeriesArg(e.args[0], from, until, values)

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -2259,6 +2259,23 @@ func TestEvalExpression(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "removeBetweenEpochs",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{val: 12, etype: etConst},
+					{val: 15, etype: etConst},
+				},
+				argString: "metric1",
+			},
+			map[MetricRequest][]*MetricData{
+				{"metric1", 0, 1}: {makeResponse("metric1", []float64{1, 2, -1, math.NaN(), 8, 20, 30, math.NaN()}, 1, 10)},
+			},
+			[]*MetricData{makeResponse("removeBetweenEpochs(metric1, 12, 15)",
+				[]float64{1, 2, math.NaN(), math.NaN(), math.NaN(), 20, 30, math.NaN()}, 1, now32)},
+		},
+		{
+			&expr{
 				target: "cactiStyle",
 				etype:  etFunc,
 				args: []*expr{


### PR DESCRIPTION
When summarizing over a long time period

    summarize(metric1, '1d')

sometimes we need to remove an interval where our data is wrong.

    summarize(removeBetweenEpochs(metric1, 1496079025, 1496079115), '1d')

so if you know that your graphite metrics are broken for a specific
interval, you don't need to rewrite their history or delete it entirely.