### PR TITLE
Fix summarize for cases when bucketSize < stepTime

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -2981,6 +2981,19 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 			}
 			name += ")"
 
+			if arg.StepTime > bucketSize {
+				// We don't have enough data to do math
+				results = append(results, &MetricData{FetchResponse: pb.FetchResponse{
+					Name:      name,
+					Values:    arg.Values,
+					IsAbsent:  arg.IsAbsent,
+					StepTime:  arg.StepTime,
+					StartTime: arg.StartTime,
+					StopTime:  arg.StopTime,
+				}})
+				continue
+			}
+
 			r := MetricData{FetchResponse: pb.FetchResponse{
 				Name:      name,
 				Values:    make([]float64, buckets, buckets),

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -2653,6 +2653,27 @@ func TestEvalSummarize(t *testing.T) {
 					{target: "metric1"},
 					{valStr: "5s", etype: etString},
 				},
+				argString: "metric1,'5s'",
+			},
+			map[MetricRequest][]*MetricData{
+				{"metric1", 0, 1}: {makeResponse("metric1", []float64{
+					1, 2, 3, 4, 5,
+				}, 10, now32)},
+			},
+			[]float64{1, 2, 3, 4, 5},
+			"summarize(metric1,'5s')",
+			10,
+			now32,
+			now32 + 50,
+		},
+		{
+			&expr{
+				target: "summarize",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "5s", etype: etString},
+				},
 				namedArgs: map[string]*expr{
 					"func": {valStr: "avg", etype: etString},
 				},


### PR DESCRIPTION
We don't need to do anything with the data if requested
bucketSize < stepTime