### PR TITLE
Update comment to reflect real value of "No cache"

### DIFF
--- a/carbonapi.example.yaml
+++ b/carbonapi.example.yaml
@@ -13,7 +13,7 @@ listen: "localhost:8081"
 # Max concurrent requests to CarbonZipper
 concurency: 20
 cache:
-   # Type of caching. Valid: "mem", "memcache", "none"
+   # Type of caching. Valid: "mem", "memcache", "null"
    type: "mem"
    # Cache limit in megabytes
    size_mb: 0


### PR DESCRIPTION
To disable cache the value "null" is used in the code. In the example file it is incorrectly named "none".