### PR TITLE
Correctly set name field for toplevel completer queries

### DIFF
--- a/main.go
+++ b/main.go
@@ -719,6 +719,8 @@ func findCompleter(globs pb.GlobResponse) ([]byte, error) {
 
 		if i != -1 {
 			c.Name = c.Path[i+1:]
+		} else {
+			c.Name = g.Path
 		}
 
 		complete = append(complete, c)


### PR DESCRIPTION
So that both `name` and `path` fields are set when you request `/metrics/find?format=completer&query=*`.

This matches the behaviour of graphite-web.