### PR TITLE
Fix 249

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -529,10 +529,6 @@ func getSeriesArg(arg *expr, from, until int32, values map[MetricRequest][]*Metr
 		return nil, err
 	}
 
-	if len(a) == 0 {
-		return nil, ErrSeriesDoesNotExist
-	}
-
 	return a, nil
 }
 


### PR DESCRIPTION
Fix missing time series argument error when applying function on empty result of another function. Makes this consistent with graphite api.

Fixes #249 