### PR TITLE
Parse "m" as minutes

### DIFF
--- a/expr/helper.go
+++ b/expr/helper.go
@@ -41,7 +41,7 @@ func IntervalString(s string, defaultSign int) (int32, error) {
 		switch unitStr {
 		case "s", "sec", "secs", "second", "seconds":
 			units = 1
-		case "min", "mins", "minute", "minutes":
+		case "m", "min", "mins", "minute", "minutes":
 			units = 60
 		case "h", "hour", "hours":
 			units = 60 * 60


### PR DESCRIPTION
Hi! Graphite-web can parse "m" symbol, for example in summarize function as minute unit. I want to add this feature in carbon-api too for backward compatibility.