### PR TITLE
Adding codacy config file for better control of codacy checks.

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,4 @@
+---
+exclude_paths:
+  - '*.pb.go'
+  - vendor/**


### PR DESCRIPTION
Using it to specify files to be skipped, which are set to be the
vendor directory and all pb.go files(auto-generated).