### PR TITLE
fix derivative if first values are missing

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -1036,18 +1036,14 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 
 	case "derivative": // derivative(seriesList)
 		return forEachSeriesDo(e, from, until, values, func(a *MetricData, r *MetricData) *MetricData {
-			prev := a.Values[0]
-			start := 0
+			prev := math.NaN()
 			for i, v := range a.Values {
-				if !a.IsAbsent[i] {
-					prev = v
-					start = i
-					break
-				}
-			}
-			for i, v := range a.Values {
-				if i <= start || a.IsAbsent[i] {
+				if a.IsAbsent[i] {
 					r.IsAbsent[i] = true
+					continue
+				} else if math.IsNaN(prev) {
+					r.IsAbsent[i] = true
+					prev = v
 					continue
 				}
 

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -1037,8 +1037,16 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 	case "derivative": // derivative(seriesList)
 		return forEachSeriesDo(e, from, until, values, func(a *MetricData, r *MetricData) *MetricData {
 			prev := a.Values[0]
+			start := 0
 			for i, v := range a.Values {
-				if i == 0 || a.IsAbsent[i] {
+				if !a.IsAbsent[i] {
+					prev = v
+					start = i
+					break
+				}
+			}
+			for i, v := range a.Values {
+				if i <= start || a.IsAbsent[i] {
 					r.IsAbsent[i] = true
 					continue
 				}

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -1201,6 +1201,20 @@ func TestEvalExpression(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "derivative",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				{"metric1", 0, 1}: {makeResponse("metric1", []float64{math.NaN(), 4, 6, 1, 4, math.NaN(), 8}, 1, now32)},
+			},
+			[]*MetricData{makeResponse("derivative(metric1)",
+				[]float64{math.NaN(), math.NaN(), 2, -5, 3, math.NaN(), 4}, 1, now32)},
+		},
+		{
+			&expr{
 				target: "avg",
 				etype:  etFunc,
 				args: []*expr{


### PR DESCRIPTION
If first values are missing derivative is working incorrectly. 

before fix (green derivative, yellow original)
![der1](https://user-images.githubusercontent.com/462486/33218477-249b5e2e-d14e-11e7-8b1d-523b56f21d60.png)

after
![der2](https://user-images.githubusercontent.com/462486/33218481-2a95849e-d14e-11e7-9b9c-af39b16afa6d.png)

