### PR TITLE
Don't set basepath in treejson output if '.' not found name

### DIFF
--- a/main.go
+++ b/main.go
@@ -772,6 +772,8 @@ func findTreejson(globs pb.GlobResponse) ([]byte, error) {
 
 	if i := strings.LastIndex(basepath, "."); i != -1 {
 		basepath = basepath[:i+1]
+	} else {
+		basepath = ""
 	}
 
 	for _, g := range globs.Matches {


### PR DESCRIPTION
The `id` returned by treejson is a concatenation of `basepath + name`.

If there's no `.` in the name (its aready a basepath), this meant that you'd get a wrong response for e.g: `query=foo*` would return `id: "foo*foobar"` instead of `id: "foobar"`.