### PR TITLE
Fix integer overflow when building for 32 bit

### DIFF
--- a/expr/picture_params.go
+++ b/expr/picture_params.go
@@ -391,7 +391,7 @@ var DefaultParams = PictureParams{
 
 	Tz: time.Local,
 
-	ConnectedLimit: math.MaxUint32,
+	ConnectedLimit: math.MaxInt32,
 	LineMode:       LineModeSlope,
 	AreaMode:       AreaModeNone,
 	AreaAlpha:      math.NaN(),


### PR DESCRIPTION
When building for `arm` it fails with error:
```
expr/picture_params.go:394:16: constant 4294967295 overflows int
```

Probably it should be `math.MaxInt32` instead of `math.MaxUint32`