### PR TITLE
Fix frange rounding errors when generating ylabels.

### DIFF
--- a/expr/cairo.go
+++ b/expr/cairo.go
@@ -363,6 +363,13 @@ var xAxisConfigs = []xAxisStruct{
 	},
 }
 
+// We accept values fractionally outside of nominal limits, so that
+// rounding errors don't cause weird effects. Since our goal is to
+// create plots, and the maximum resolution of the plots is likely to
+// be less than 10000 pixels, errors smaller than this size shouldn't
+// create any visible effects.
+const floatEpsilon = 0.00000000001
+
 func getCairoFontItalic(s FontSlant) cairo.FontSlant {
 	if s == FontSlantItalic {
 		return cairo.FontSlantItalic
@@ -1437,7 +1444,7 @@ func makeLabel(yValue, yStep, ySpan float64, yUnitSystem string) string {
 	case yValue < 1.0:
 		return fmt.Sprintf("%.2f %s", yValue, prefix)
 	case ySpan > 10 || spanPrefix != prefix:
-		if yValue-math.Floor(yValue) < 0.00000000001 {
+		if yValue-math.Floor(yValue) < floatEpsilon {
 			return fmt.Sprintf("%.1f %s", yValue, prefix)
 		}
 		return fmt.Sprintf("%d %s", int(yValue), prefix)
@@ -1657,14 +1664,14 @@ func formatUnits(v, step float64, system string) (float64, string) {
 		fsize := float64(p.size)
 		if condition(fsize) {
 			v2 := v / fsize
-			if (v2-math.Floor(v2)) < 0.00000000001 && v > 1 {
+			if (v2-math.Floor(v2)) < floatEpsilon && v > 1 {
 				v2 = math.Floor(v2)
 			}
 			return v2, p.prefix
 		}
 	}
 
-	if (v-math.Floor(v)) < 0.00000000001 && v > 1 {
+	if (v-math.Floor(v)) < floatEpsilon && v > 1 {
 		v = math.Floor(v)
 	}
 	return v, ""

--- a/expr/cairo.go
+++ b/expr/cairo.go
@@ -1551,8 +1551,8 @@ func setupYAxis(cr *cairoSurfaceContext, params *Params, results []*MetricData) 
 
 	params.yStep = yStep
 
-	params.yBottom = params.yStep * math.Floor(yMinValue/params.yStep) // start labels at the greatest multiple of yStep <= yMinValue
-	params.yTop = params.yStep * math.Ceil(yMaxValue/params.yStep)     // Extend the top of our graph to the lowest yStep multiple >= yMaxValue
+	params.yBottom = params.yStep * math.Floor(yMinValue/params.yStep+floatEpsilon) // start labels at the greatest multiple of yStep <= yMinValue
+	params.yTop = params.yStep * math.Ceil(yMaxValue/params.yStep-floatEpsilon)     // Extend the top of our graph to the lowest yStep multiple >= yMaxValue
 
 	if params.logBase != 0 {
 		if yMinValue > 0 {
@@ -1703,7 +1703,7 @@ func logrange(base, scaleMin, scaleMax float64) []float64 {
 func frange(start, end, step float64) []float64 {
 	var vals []float64
 	f := start
-	for f <= end {
+	for f <= (end + floatEpsilon) {
 		vals = append(vals, f)
 		f += step
 		// Protect against rounding errors on very small float ranges


### PR DESCRIPTION
For example, when `yMin=0`, `yMax=7` and `yStep=1.2`, the calculated `yTop=7.199999999999999`

How it is worked out is `1.2 * Ceil(7/1.2)`.

This results in frange returning (0.0 .. 6.0) instead of the expected (0.0 .. 7.2).