### PR TITLE
fix rpm naming

### DIFF
--- a/contrib/fpm/create_package_rpm.sh
+++ b/contrib/fpm/create_package_rpm.sh
@@ -40,7 +40,7 @@ cp ./contrib/common/carbonapi.env "${TMPDIR}"/etc/sysconfig/carbonapi
 
 fpm -s dir -t rpm -n carbonapi -v ${VERSION} -C ${TMPDIR} \
     --iteration ${RELEASE} \
-    -p carbonapi_VERSION-ITERATION.ARCH.rpm \
+    -p carbonapi-VERSION-ITERATION.ARCH.rpm \
     -d "cairo" \
     --after-install contrib/fpm/systemd-reload.sh \
     --description "carbonapi: replacement graphite API server" \


### PR DESCRIPTION
Sorry for https://github.com/go-graphite/carbonapi/pull/287 :(
I forgot about "name-version" part