### PR TITLE
fix function parameters without defaults

### DIFF
--- a/expr/types/list.go
+++ b/expr/types/list.go
@@ -113,33 +113,33 @@ type Suggestion struct {
 	Value interface{}
 }
 
-func NewSuggestion(arg interface{}) Suggestion {
+func NewSuggestion(arg interface{}) *Suggestion {
 	switch v := arg.(type) {
 	case int:
-		return Suggestion{Type: SString, Value: v}
+		return &Suggestion{Type: SInt, Value: v}
 	case int32:
-		return Suggestion{Type: SInt32, Value: v}
+		return &Suggestion{Type: SInt32, Value: v}
 	case int64:
-		return Suggestion{Type: SInt64, Value: v}
+		return &Suggestion{Type: SInt64, Value: v}
 	case uint:
-		return Suggestion{Type: SUint, Value: v}
+		return &Suggestion{Type: SUint, Value: v}
 	case uint32:
-		return Suggestion{Type: SUint32, Value: v}
+		return &Suggestion{Type: SUint32, Value: v}
 	case uint64:
-		return Suggestion{Type: SUint64, Value: v}
+		return &Suggestion{Type: SUint64, Value: v}
 	case float64:
-		return Suggestion{Type: SFloat64, Value: v}
+		return &Suggestion{Type: SFloat64, Value: v}
 	case string:
-		return Suggestion{Type: SString, Value: v}
+		return &Suggestion{Type: SString, Value: v}
 	case bool:
-		return Suggestion{Type: SBool, Value: v}
+		return &Suggestion{Type: SBool, Value: v}
 	}
 
-	return Suggestion{Type: SNone}
+	return &Suggestion{Type: SNone}
 }
 
-func NewSuggestions(vaArgs ...interface{}) []Suggestion {
-	res := make([]Suggestion, 0, len(vaArgs))
+func NewSuggestions(vaArgs ...interface{}) []*Suggestion {
+	res := make([]*Suggestion, 0, len(vaArgs))
 
 	for _, a := range vaArgs {
 		res = append(res, NewSuggestion(a))
@@ -219,8 +219,8 @@ type FunctionParam struct {
 	Required    bool         `json:"required,omitempty"`
 	Type        FunctionType `json:"type,omitempty"`
 	Options     []string     `json:"options,omitempty"`
-	Suggestions []Suggestion `json:"suggestions,omitempty"`
-	Default     Suggestion   `json:"default,omitempty"`
+	Suggestions []*Suggestion `json:"suggestions,omitempty"`
+	Default     *Suggestion   `json:"default,omitempty"`
 }
 
 // FunctionDescription contains full function description.


### PR DESCRIPTION
/functions seems to be broken
```
2018/03/14 19:08:28 http: panic serving 127.0.0.1:64939: interface conversion: interface {} is nil, not int
goroutine 50 [running]:
net/http.(*conn).serve.func1(0xc4202e4000)
	/usr/local/Cellar/go/1.9/libexec/src/net/http/server.go:1697 +0xd0
panic(0x168a9c0, 0xc42027e540)
	/usr/local/Cellar/go/1.9/libexec/src/runtime/panic.go:491 +0x283
encoding/json.(*encodeState).marshal.func1(0xc420117570)
	/usr/local/Cellar/go/1.9/libexec/src/encoding/json/encode.go:288 +0x144
panic(0x168a9c0, 0xc42027e540)
	/usr/local/Cellar/go/1.9/libexec/src/runtime/panic.go:491 +0x283
github.com/go-graphite/carbonapi/expr/types.Suggestion.MarshalJSON(0x0, 0x0, 0x0, 0x1011233, 0x168cb80, 0x16c2620, 0x16c2601, 0x24000a0)
	/Users/oyumatrokhin/GoProjects/src/github.com/go-graphite/carbonapi/expr/types/list.go:155 +0x8c9
github.com/go-graphite/carbonapi/expr/types.(*Suggestion).MarshalJSON(0xc42028e680, 0x16c2620, 0xc42028e680, 0x24000a0, 0xc42028e680, 0x1)
	<autogenerated>:1 +0x52
encoding/json.marshalerEncoder(0xc4202d6210, 0x16c2620, 0xc42022e520, 0x199, 0x100)
	/usr/local/Cellar/go/1.9/libexec/src/encoding/json/encode.go:443 +0x9f
...
```

The problem is that `Default` and `Suggestions` can't be omitted during marshalling