### PR TITLE
Optimise render performance for graphite-clickhouse backend

### DIFF
--- a/carbonapi.example.yaml
+++ b/carbonapi.example.yaml
@@ -43,6 +43,12 @@ sendGlobsAsIs: false
 # For go-carbon you might want it to keep in some reasonable limits, 100 is good "safe" defaults
 #
 # For some backends (e.x. graphite-clickhouse) you might want to set it to some insanly high value, like 100000
+
+# If 'true', carbonapi will send requests as is, with globs and braces
+# even without checking maxBatchSize
+# in result it can increase performance for graphite-clickhouse by removing /metric/find request before calling /render
+alwaysSendGlobsAsIs: false
+
 functionsConfigs:
     graphiteWeb: ./graphiteWeb.example.yaml
 maxBatchSize: 100

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -298,7 +298,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 
 			if haveCacheData {
 				apiMetrics.FindCacheHits.Add(1)
-			} else {
+			} else if !config.AlwaysSendGlobsAsIs {
 				apiMetrics.FindCacheMisses.Add(1)
 				var err error
 				apiMetrics.FindRequests.Add(1)
@@ -321,7 +321,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			var sendGlobs = config.SendGlobsAsIs && len(glob.Matches) < config.MaxBatchSize
+			sendGlobs := config.AlwaysSendGlobsAsIs || (config.SendGlobsAsIs && len(glob.Matches) < config.MaxBatchSize)
 			accessLogDetails.SendGlobs = sendGlobs
 
 			if sendGlobs {

--- a/main.go
+++ b/main.go
@@ -248,6 +248,7 @@ var config = struct {
 	IdleConnections            int                `yaml:"idleConnections"`
 	PidFile                    string             `yaml:"pidFile"`
 	SendGlobsAsIs              bool               `yaml:"sendGlobsAsIs"`
+	AlwaysSendGlobsAsIs        bool               `yaml:"alwaysSendGlobsAsIs"`
 	MaxBatchSize               int                `yaml:"maxBatchSize"`
 	Zipper                     string             `yaml:"zipper"`
 	Upstreams                  realZipper.Config  `yaml:"upstreams"`
@@ -273,6 +274,7 @@ var config = struct {
 	Listen:                "[::]:8081",
 	Concurency:            20,
 	SendGlobsAsIs:         false,
+	AlwaysSendGlobsAsIs:   false,
 	MaxBatchSize:          100,
 	Cache: cacheConfig{
 		Type:              "mem",
@@ -670,6 +672,7 @@ func setUpViper(logger *zap.Logger) {
 	viper.SetDefault("cpus", 0)
 	viper.SetDefault("tz", "")
 	viper.SetDefault("sendGlobsAsIs", false)
+	viper.SetDefault("AlwaysSendGlobsAsIs", false)
 	viper.SetDefault("maxBatchSize", 100)
 	viper.SetDefault("graphite.host", "")
 	viper.SetDefault("graphite.interval", "60s")


### PR DESCRIPTION
For graphite-clickhouse backend calling `/find` before `/render` can hurt performance sometimes. This is especially true when you have lots of short-lived metrics.