### PR TITLE
Skip metrics with missing pair in reduceSeries

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -864,6 +864,25 @@ func TestEvalExpression(t *testing.T) {
 			},
 		},
 		{
+			parser.NewExpr("reduceSeries",
+				// list of arguments
+				parser.NewExpr("mapSeries",
+					"devops.service.*.filter.received.*.count", 2,
+				),
+				parser.ArgValue("asPercent"), 5, parser.ArgValue("valid"), parser.ArgValue("total"),
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"devops.service.*.filter.received.*.count", 0, 1}: {
+					types.MakeMetricData("devops.service.server1.filter.received.total.count", []float64{8, 2, 4}, 1, now32),
+					types.MakeMetricData("devops.service.server2.filter.received.valid.count", []float64{3, 9, 12}, 1, now32),
+					types.MakeMetricData("devops.service.server2.filter.received.total.count", []float64{12, 9, 3}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("devops.service.server2.filter.received.reduce.asPercent.count", []float64{25, 100, 400}, 1, now32),
+			},
+		},
+		{
 			parser.NewExpr("transformNull",
 				"metric1",
 				parser.NamedArgs{

--- a/expr/functions/reduce/function.go
+++ b/expr/functions/reduce/function.go
@@ -83,12 +83,16 @@ func (f *reduce) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 		valueKey := parser.MetricRequest{series.Name, from, until}
 		reducedValues[valueKey] = append(reducedValues[valueKey], series)
 	}
-
+AliasLoop:
 	for _, aliasName := range aliasNames {
 
 		reducedNodes := make([]parser.Expr, len(reduceMatchers))
 		for i, reduceMatcher := range reduceMatchers {
-			reducedNodes[i] = parser.NewTargetExpr(reduceGroups[aliasName][reduceMatcher].Name)
+			matched, ok := reduceGroups[aliasName][reduceMatcher]
+			if !ok {
+				continue AliasLoop
+			}
+			reducedNodes[i] = parser.NewTargetExpr(matched.Name)
 		}
 
 		result, err := f.Evaluator.EvalExpr(parser.NewExprTyped("alias", []parser.Expr{


### PR DESCRIPTION
related to https://github.com/graphite-project/graphite-web/issues/1516

Currently if reduceSeries can't find pair for matcher it will panic. Probably a better way is to skip completely metrics without pair.