### PR TITLE
Gmagnusson/time shift

### DIFF
--- a/expr/functions/sum/function_test.go
+++ b/expr/functions/sum/function_test.go
@@ -1,0 +1,49 @@
+package sum
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestAbsolute(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			parser.NewExpr("sum",
+				"metric1",
+				"metric2",
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, -1, 2, -3, 4, 5}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{0, 1, -2, 3, -4, -5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2)",
+				[]float64{0, 0, 0, 0, 0, 0}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.E.Target() + "(" + tt.E.RawArgs() + ")"
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}

--- a/expr/functions/timeShift/function.go
+++ b/expr/functions/timeShift/function.go
@@ -35,9 +35,7 @@ func (f *timeShift) Do(e parser.Expr, from, until int64, values map[parser.Metri
 		return nil, err
 	}
 
-	fromNew := int64(int64(from) + int64(offs))
-	untilNew := int64(int64(from) + int64(offs))
-	arg, err := helper.GetSeriesArg(e.Args()[0], fromNew, untilNew, values)
+	arg, err := helper.GetSeriesArg(e.Args()[0], from+int64(offs), until+int64(offs), values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/timeShift/function_test.go
+++ b/expr/functions/timeShift/function_test.go
@@ -1,0 +1,67 @@
+package timeShift
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestAbsolute(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			parser.NewExpr("timeShift",
+				"metric1", parser.ArgValue("0s"),
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("timeShift(metric1,'0')",
+				[]float64{0, 1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			parser.NewExpr("timeShift",
+				"metric1", parser.ArgValue("1s"),
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -1, 0}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3, 4}, 1, now32-1)},
+			},
+			[]*types.MetricData{types.MakeMetricData("timeShift(metric1,'-1')",
+				[]float64{-1, 0, 1, 2, 3, 4}, 1, now32-1)},
+		},
+		{
+			parser.NewExpr("timeShift",
+				"metric1", parser.ArgValue("1h"),
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -60 * 60, -60*60 + 1}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3, 4}, 1, now32-60*60)},
+			},
+			[]*types.MetricData{types.MakeMetricData("timeShift(metric1,'-3600')",
+				[]float64{-1, 0, 1, 2, 3, 4}, 1, now32-60*60)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.E.Target() + "(" + tt.E.RawArgs() + ")"
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}


### PR DESCRIPTION
We noticed that `timeShift` had accidentally been changed to be the constant function that returns an empty set of metrics. These patches fix that.