### PR TITLE
Sync metrics/find api behavior with graphite-web

### DIFF
--- a/http_handlers.go
+++ b/http_handlers.go
@@ -579,7 +579,7 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if format == "completer" {
-		for i, _ := range query {
+		for i := range query {
 			if query[i] == "" || query[i] == "/" || query[i] == "." {
 				query[i] = "*"
 			}

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -578,6 +578,14 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 		deferredAccessLogging(accessLogger, &accessLogDetails, t0, logAsError)
 	}()
 
+	if format == "completer" {
+		for i, _ := range query {
+			if query[i] == "" || query[i] == "/" || query[i] == "." {
+				query[i] = "*"
+			}
+		}
+	}
+
 	if len(query) == 0 {
 		http.Error(w, "missing parameter `query`", http.StatusBadRequest)
 		accessLogDetails.HttpCode = http.StatusBadRequest


### PR DESCRIPTION
Metrics find api wasn't behaving same as graphite web(python) stack in case of completer format. This fixes issues with that, and when trying to complete the top level metric, it will list all metrics in top level for '', '.', '/' query parameters as well now by rewriting query parameter to *.