### PR TITLE
Support negative indices in substr()

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -545,16 +545,6 @@ func TestEvalExpression(t *testing.T) {
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
 		{
-			parser.NewExpr("substr",
-				"metric1.foo.bar.baz", 1, 3,
-			),
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
-			},
-			[]*types.MetricData{types.MakeMetricData("foo.bar",
-				[]float64{1, 2, 3, 4, 5}, 1, now32)},
-		},
-		{
 			parser.NewExpr("mapSeries",
 				"servers.*.cpu.*", 1,
 			),

--- a/expr/functions/substr/function.go
+++ b/expr/functions/substr/function.go
@@ -68,7 +68,7 @@ func (f *substr) Do(e parser.Expr, from, until int64, values map[parser.MetricRe
 			if stopField < 0 {
 				realStopField = len(nodes) + stopField
 				if realStartField > 0 {
-					realStopField += 1
+					realStopField++
 				}
 			}
 			if realStopField < 0 || realStopField <= realStartField || realStopField-realStartField > len(nodes) {

--- a/expr/functions/substr/function.go
+++ b/expr/functions/substr/function.go
@@ -50,17 +50,31 @@ func (f *substr) Do(e parser.Expr, from, until int64, values map[parser.MetricRe
 	for _, a := range args {
 		metric := helper.ExtractMetric(a.Name)
 		nodes := strings.Split(metric, ".")
+		realStartField := startField
 		if startField != 0 {
-			if startField < 0 || startField > len(nodes)-1 {
+			if startField < 0 {
+				realStartField = len(nodes) + startField
+				if realStartField < 0 {
+					realStartField = 0
+				}
+			}
+			if realStartField > len(nodes)-1 {
 				return nil, errors.New("start out of range")
 			}
-			nodes = nodes[startField:]
+			nodes = nodes[realStartField:]
 		}
 		if stopField != 0 {
-			if stopField <= startField || stopField-startField > len(nodes) {
+			realStopField := stopField
+			if stopField < 0 {
+				realStopField = len(nodes) + stopField
+				if realStartField > 0 {
+					realStopField += 1
+				}
+			}
+			if realStopField < 0 || realStopField <= realStartField || realStopField-realStartField > len(nodes) {
 				return nil, errors.New("stop out of range")
 			}
-			nodes = nodes[:stopField-startField]
+			nodes = nodes[:realStopField-realStartField]
 		}
 
 		r := *a
@@ -69,7 +83,6 @@ func (f *substr) Do(e parser.Expr, from, until int64, values map[parser.MetricRe
 	}
 
 	return results, nil
-
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/substr/function_test.go
+++ b/expr/functions/substr/function_test.go
@@ -1,0 +1,101 @@
+package substr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+			th "github.com/go-graphite/carbonapi/tests"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	"github.com/go-graphite/carbonapi/expr/types"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestSubstr(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	/*
+	Python's behavior:
+	>>> a = ["metric1", "foo", "bar", "baz"]
+	>>> a[-3:-1]
+	['foo', 'bar']
+	>>> a[-4:-1]
+	['metric1', 'foo', 'bar']
+	>>> a[-65:]
+	['metric1', 'foo', 'bar', 'baz']
+	>>> a[-6:-1]
+	['metric1', 'foo', 'bar']
+	>>> a[0:-1]
+	['metric1', 'foo', 'bar']
+	 */
+	tests := []th.EvalTestItem{
+		{
+			parser.NewExpr("substr",
+				"metric1.foo.bar.baz", 1, 3,
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("foo.bar",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			parser.NewExpr("substr",
+				"metric1.foo.bar.baz", -3, -1,
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("foo.bar",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			parser.NewExpr("substr",
+				"metric1.foo.bar.baz", -3,
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("foo.bar.baz",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			parser.NewExpr("substr",
+				"metric1.foo.bar.baz", -6, -1,
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1.foo.bar",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			parser.NewExpr("substr",
+				"metric1.foo.bar.baz", 0, -1,
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1.foo.bar",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.E.Target() + "(" + tt.E.RawArgs() + ")"
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}


### PR DESCRIPTION
This should mimic graphite-web's behavior.

As it's using python, substr("metric1.foo.bar.baz", -3, -1)
should result in 'foo.bar', now it returns an error

Fixes #338