### PR TITLE
Initial implementation of feature flag pkg

### DIFF
--- a/cmd/carbonapi/carbonapi.example.toml
+++ b/cmd/carbonapi/carbonapi.example.toml
@@ -40,6 +40,11 @@ file = "carbonapi.log"
 level = "info"
 logger = ""
 
+# features allows to specify feature flags on a startup time
+#   format: flag-name = value
+[featureFlags]
+applyByNode-count-nodes-from-1 = true
+
 # Uncomment this to get the behavior of graphite-web as proposed in https://github.com/graphite-project/graphite-web/pull/2239
 # Beware this will make darkbackground graphs less readable
 #[defaultColors]

--- a/cmd/carbonapi/carbonapi.example.yaml
+++ b/cmd/carbonapi/carbonapi.example.yaml
@@ -163,6 +163,10 @@ upstreams:
 # Default: 600 (10 minutes)
 graphTemplates: graphTemplates.example.yaml
 expireDelaySec: 10
+# features allows to specify feature flags on a startup time
+#   format: flag-name: value
+featureFlags:
+  applyByNode-count-nodes-from-1: true
 # Uncomment this to get the behavior of graphite-web as proposed in https://github.com/graphite-project/graphite-web/pull/2239
 # Beware this will make darkbackground graphs less readable
 #defaultColors:

--- a/cmd/carbonapi/config/config.go
+++ b/cmd/carbonapi/config/config.go
@@ -60,6 +60,7 @@ type ConfigType struct {
 	DefaultColors              map[string]string  `mapstructure:"defaultColors"`
 	GraphTemplates             string             `mapstructure:"graphTemplates"`
 	FunctionsConfigs           map[string]string  `mapstructure:"functionsConfig"`
+	FeatureFlags               map[string]bool    `mapstructure:"featureFlags"`
 
 	QueryCache cache.BytesCache `mapstructure:"-" json:"-"`
 	FindCache  cache.BytesCache `mapstructure:"-" json:"-"`

--- a/cmd/carbonapi/config/init.go
+++ b/cmd/carbonapi/config/init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/rewrite"
 	"github.com/go-graphite/carbonapi/limiter"
+	"github.com/go-graphite/carbonapi/pkg/features"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	zipperTypes "github.com/go-graphite/carbonapi/zipper/types"
 	"github.com/lomik/zapwriter"
@@ -52,6 +53,18 @@ func SetUpConfig(logger *zap.Logger, BuildVersion string) {
 			zap.Any("configuration", Config.Logger),
 			zap.Error(err),
 		)
+	}
+
+	flags := features.GetFeaturesInstance()
+	for flag, value := range Config.FeatureFlags {
+		err := flags.SetFlagByNameForced(flag, value)
+		if err != nil {
+			logger.Warn("failed to set feature flag",
+				zap.String("flag", flag),
+				zap.Bool("value", value),
+				zap.Error(err),
+			)
+		}
 	}
 
 	if Config.GraphTemplates != "" {

--- a/cmd/carbonapi/http/init.go
+++ b/cmd/carbonapi/http/init.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/dgryski/httputil"
+	"github.com/go-graphite/carbonapi/pkg/features"
 	"github.com/go-graphite/carbonapi/util/ctx"
 )
 
@@ -28,6 +29,11 @@ func InitHandlers() *http.ServeMux {
 
 	r.HandleFunc("/tags", tagHandler)
 	r.HandleFunc("/tags/", tagHandler)
+
+	features := features.GetFeaturesInstance()
+	r.HandleFunc("/_internal/flags", features.FlagListHandler)
+	r.HandleFunc("/_internal/flags/id", features.FlagPatchByIDHandler)
+	r.HandleFunc("/_internal/flags/name", features.FlagPatchByNameHandler)
 
 	r.HandleFunc("/", usageHandler)
 	return r

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -19,9 +19,20 @@ func (eval evaluator) EvalExpr(e parser.Expr, from, until int64, values map[pars
 
 var _evaluator = evaluator{}
 
+type rewriter struct{}
+
+// EvalExpr evalualtes expressions
+func (eval rewriter) RewriteExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error) {
+	return RewriteExpr(e, from, until, values)
+}
+
+var _rewriter = rewriter{}
+
 func init() {
 	helper.SetEvaluator(_evaluator)
+	helper.SetRewriter(_rewriter)
 	metadata.SetEvaluator(_evaluator)
+	metadata.SetRewriter(_rewriter)
 }
 
 // EvalExpr is the main expression evaluator

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -1443,68 +1443,6 @@ func TestRewriteExpr(t *testing.T) {
 			false,
 			[]string{},
 		},
-		{
-			"applyByNode",
-			parser.NewExpr("applyByNode",
-
-				"metric*",
-				1,
-				parser.ArgValue("%.count"),
-			),
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
-					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
-				},
-				{"metric1", 0, 1}: {
-					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
-				},
-			},
-			true,
-			[]string{"metric1.count"},
-		},
-		{
-			"applyByNode",
-			parser.NewExpr("applyByNode",
-
-				"metric*",
-				1,
-				parser.ArgValue("%.count"),
-				parser.ArgValue("% count"),
-			),
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
-					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
-				},
-				{"metric1", 0, 1}: {
-					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
-				},
-			},
-			true,
-			[]string{"alias(metric1.count,\"metric1 count\")"},
-		},
-		{
-			"applyByNode",
-			parser.NewExpr("applyByNode",
-
-				"foo.metric*",
-				2,
-				parser.ArgValue("%.count"),
-			),
-			map[parser.MetricRequest][]*types.MetricData{
-				{"foo.metric*", 0, 1}: {
-					types.MakeMetricData("foo.metric1", []float64{1, 2, 3}, 1, now32),
-					types.MakeMetricData("foo.metric2", []float64{1, 2, 3}, 1, now32),
-				},
-				{"foo.metric1", 0, 1}: {
-					types.MakeMetricData("foo.metric1", []float64{1, 2, 3}, 1, now32),
-				},
-				{"foo.metric2", 0, 1}: {
-					types.MakeMetricData("foo.metric2", []float64{1, 2, 3}, 1, now32),
-				},
-			},
-			true,
-			[]string{"foo.metric1.count", "foo.metric2.count"},
-		},
 	}
 
 	for _, tt := range tests {

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -18,6 +18,7 @@ import (
 )
 
 var evaluator interfaces.Evaluator
+var rewriter interfaces.Rewriter
 
 // Backref is a pre-compiled expression for backref
 var Backref = regexp.MustCompile(`\\(\d+)`)
@@ -32,6 +33,11 @@ func (e ErrUnknownFunction) Error() string {
 // SetEvaluator sets evaluator for all helper functions
 func SetEvaluator(e interfaces.Evaluator) {
 	evaluator = e
+}
+
+// SetRewriter sets rewriter for all helper functions
+func SetRewriter(e interfaces.Rewriter) {
+	rewriter = e
 }
 
 // GetSeriesArg returns argument from series.

--- a/expr/interfaces/inteface.go
+++ b/expr/interfaces/inteface.go
@@ -20,11 +20,12 @@ func (b *FunctionBase) GetEvaluator() Evaluator {
 	return b.Evaluator
 }
 
-// Evaluator is a interface for any existing expression parser
+// Evaluator is an interface for any existing expression parser
 type Evaluator interface {
 	EvalExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
 }
 
+// Rewriter is an interface for any existing rewriters (main one and the one used in tests)
 type Rewriter interface {
 	RewriteExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error)
 }

--- a/expr/interfaces/inteface.go
+++ b/expr/interfaces/inteface.go
@@ -25,6 +25,10 @@ type Evaluator interface {
 	EvalExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
 }
 
+type Rewriter interface {
+	RewriteExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error)
+}
+
 type Order int
 
 const (

--- a/expr/metadata/metadata.go
+++ b/expr/metadata/metadata.go
@@ -79,6 +79,23 @@ func GetEvaluator() interfaces.Evaluator {
 	return FunctionMD.evaluator
 }
 
+// SetRewriter sets new rewriter function to be default for everything that needs it
+func SetRewriter(rewriter interfaces.Rewriter) {
+	FunctionMD.Lock()
+	defer FunctionMD.Unlock()
+
+	FunctionMD.rewriter = rewriter
+	// For now no rewrite function needs custom rewriter later.
+}
+
+// GetEvaluator returns evaluator
+func GetRewriter() interfaces.Rewriter {
+	FunctionMD.RLock()
+	defer FunctionMD.RUnlock()
+
+	return FunctionMD.rewriter
+}
+
 // Metadata is a type to store global function metadata
 type Metadata struct {
 	sync.RWMutex
@@ -90,6 +107,7 @@ type Metadata struct {
 	FunctionConfigFiles map[string]string
 
 	evaluator interfaces.Evaluator
+	rewriter  interfaces.Rewriter
 }
 
 // FunctionMD is actual global variable that stores metadata

--- a/expr/metadata/metadata.go
+++ b/expr/metadata/metadata.go
@@ -88,7 +88,7 @@ func SetRewriter(rewriter interfaces.Rewriter) {
 	// For now no rewrite function needs custom rewriter later.
 }
 
-// GetEvaluator returns evaluator
+// GetRewriter returns current rewriter
 func GetRewriter() interfaces.Rewriter {
 	FunctionMD.RLock()
 	defer FunctionMD.RUnlock()

--- a/expr/rewrite/applyByNode/function_test.go
+++ b/expr/rewrite/applyByNode/function_test.go
@@ -1,0 +1,131 @@
+package applyByNode
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := &th.FuncEvaluator{}
+	rewriter := th.RewriterFromFunc(md[0].F)
+	metadata.SetRewriter(rewriter)
+	metadata.SetEvaluator(evaluator)
+	helper.SetRewriter(rewriter)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterRewriteFunction(m.Name, m.F)
+	}
+}
+
+func TestRewriteExpr(t *testing.T) {
+	now32 := time.Now().Unix()
+
+	tests := []struct {
+		name       string
+		e          parser.Expr
+		m          map[parser.MetricRequest][]*types.MetricData
+		rewritten  bool
+		newTargets []string
+	}{
+		{
+			"applyByNode",
+			parser.NewExpr("applyByNode",
+
+				"metric*",
+				1,
+				parser.ArgValue("%.count"),
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
+				},
+				{"metric1", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
+				},
+			},
+			true,
+			[]string{"metric1.count"},
+		},
+		{
+			"applyByNode",
+			parser.NewExpr("applyByNode",
+
+				"metric*",
+				1,
+				parser.ArgValue("%.count"),
+				parser.ArgValue("% count"),
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
+				},
+				{"metric1", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
+				},
+			},
+			true,
+			[]string{"alias(metric1.count,\"metric1 count\")"},
+		},
+		{
+			"applyByNode",
+			parser.NewExpr("applyByNode",
+
+				"foo.metric*",
+				2,
+				parser.ArgValue("%.count"),
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"foo.metric*", 0, 1}: {
+					types.MakeMetricData("foo.metric1", []float64{1, 2, 3}, 1, now32),
+					types.MakeMetricData("foo.metric2", []float64{1, 2, 3}, 1, now32),
+				},
+				{"foo.metric1", 0, 1}: {
+					types.MakeMetricData("foo.metric1", []float64{1, 2, 3}, 1, now32),
+				},
+				{"foo.metric2", 0, 1}: {
+					types.MakeMetricData("foo.metric2", []float64{1, 2, 3}, 1, now32),
+				},
+			},
+			true,
+			[]string{"foo.metric1.count", "foo.metric2.count"},
+		},
+	}
+
+	rewriter := metadata.GetRewriter()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rewritten, newTargets, err := rewriter.RewriteExpr(tt.e, 0, 1, tt.m)
+
+			if err != nil {
+				t.Errorf("failed to rewrite %v: %+v", tt.name, err)
+				return
+			}
+
+			if rewritten != tt.rewritten {
+				t.Errorf("failed to rewrite %v: expected rewritten=%v but was %v", tt.name, tt.rewritten, rewritten)
+				return
+			}
+
+			var targetsMatch = true
+			if len(tt.newTargets) != len(newTargets) {
+				targetsMatch = false
+			} else {
+				for i := range tt.newTargets {
+					targetsMatch = targetsMatch && tt.newTargets[i] == newTargets[i]
+				}
+			}
+
+			if !targetsMatch {
+				t.Errorf("failed to rewrite %v: expected newTargets=%v but was %v", tt.name, tt.newTargets, newTargets)
+				return
+			}
+		})
+	}
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,108 @@
+package features
+
+import (
+	"sync"
+)
+
+type featuresImpl struct {
+	sync.RWMutex
+	nameToID      map[string]int64
+	state         map[int64]bool
+	cursorRuntime int64
+	cursorConfig  int64
+}
+
+// RegisterRuntime registers feature that can be set in runtime
+// You must provide feature name and you'll get FeatureID in the end
+// All runtime IDs are >=0
+func (f *featuresImpl) RegisterRuntime(name string, def bool) (int64, error) {
+	f.Lock()
+	defer f.Unlock()
+	if id, ok := f.nameToID[name]; ok {
+		return id, ErrAlreadyExists
+	}
+
+	nextID := f.cursorRuntime
+	f.nameToID[name] = nextID
+	f.state[nextID] = def
+	f.cursorRuntime++
+
+	return nextID, nil
+}
+
+// RegisterConfig registers feature that can be set only in config
+// You must provide feature name and you'll get FeatureID in the end
+// All config-time IDs are negative
+func (f *featuresImpl) RegisterConfig(name string, def bool) (int64, error) {
+	f.Lock()
+	defer f.Unlock()
+	if id, ok := f.nameToID[name]; ok {
+		return id, ErrAlreadyExists
+	}
+
+	nextID := f.cursorConfig
+	f.nameToID[name] = nextID
+	f.state[nextID] = def
+	f.cursorConfig--
+
+	return nextID, nil
+}
+
+// IsEnabledID allows to check if this feature was enabled by it's ID
+func (f *featuresImpl) IsEnabledID(id int64) bool {
+	f.RLock()
+	defer f.RUnlock()
+	if enabled, ok := f.state[id]; ok {
+		return enabled
+	}
+	return false
+}
+
+// IsEnabledName allows to check if this feature was enabled by it's name
+func (f *featuresImpl) IsEnabledName(name string) bool {
+	f.RLock()
+	defer f.RUnlock()
+	if id, ok := f.nameToID[name]; ok {
+		if enabled, ok := f.state[id]; ok {
+			return enabled
+		}
+	}
+	return false
+}
+
+// SetFlagByID updates flag status by flag id
+func (f *featuresImpl) SetFlagByID(id int64, enabled bool) bool {
+	if id < 0 {
+		return false
+	}
+	f.Lock()
+	defer f.Unlock()
+	if _, ok := f.state[id]; ok {
+		f.state[id] = enabled
+		return true
+	}
+	return false
+}
+
+// SetFlagByName updates flag status by name
+func (f *featuresImpl) SetFlagByName(name string, enabled bool) bool {
+	f.Lock()
+	defer f.Unlock()
+	if id, ok := f.nameToID[name]; ok {
+		if id < 0 {
+			return false
+		}
+		f.state[id] = enabled
+		return true
+	}
+	return false
+}
+
+// NewFeatures creates a new instance of feature flag controller
+func NewFeatures() Features {
+	return &featuresImpl{
+		nameToID:     make(map[string]int64),
+		state:        make(map[int64]bool),
+		cursorConfig: -1,
+	}
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -70,6 +70,18 @@ func (f *featuresImpl) IsEnabledName(name string) bool {
 	return false
 }
 
+// GetIDByName gets id of feature if exists by it's name
+// Useful to do conditional tests, when you don't know what
+// ID feature flag got
+func (f *featuresImpl) GetIDByName(name string) (int64, error) {
+	f.RLock()
+	defer f.RUnlock()
+	if id, ok := f.nameToID[name]; ok {
+		return id, nil
+	}
+	return 0, ErrFeatureNotRegistered
+}
+
 // SetFlagByID updates flag status by flag id
 func (f *featuresImpl) SetFlagByID(id int64, enabled bool) bool {
 	if id < 0 {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -110,6 +110,17 @@ func (f *featuresImpl) SetFlagByName(name string, enabled bool) bool {
 	return false
 }
 
+// SetFlagByNameForced is a function that should be during initialization
+// It's not thread-safe (on purpose) and allows to change even config-time flags
+// returns error if there is no such flag
+func (f *featuresImpl) SetFlagByNameForced(name string, enabled bool) error {
+	if id, ok := f.nameToID[name]; ok {
+		f.state[id] = enabled
+		return nil
+	}
+	return ErrFeatureNotRegistered
+}
+
 type featuresSingleton struct {
 	features Features
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -98,8 +98,25 @@ func (f *featuresImpl) SetFlagByName(name string, enabled bool) bool {
 	return false
 }
 
+type featuresSingleton struct {
+	features Features
+}
+
+var featuresInstance *featuresSingleton
+var once sync.Once
+
+// GetFeaturesInstance returns or initialize feature instance
+func GetFeaturesInstance() Features {
+	once.Do(func() {
+		featuresInstance = &featuresSingleton{
+			features: newFeatures(),
+		}
+	})
+	return featuresInstance.features
+}
+
 // NewFeatures creates a new instance of feature flag controller
-func NewFeatures() Features {
+func newFeatures() Features {
 	return &featuresImpl{
 		nameToID:     make(map[string]int64),
 		state:        make(map[int64]bool),

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -1,0 +1,454 @@
+package features
+
+import (
+	"sync"
+	"testing"
+)
+
+type feature struct {
+	name        string
+	value       bool
+	assignedID  int64
+	expectedID  int64
+	expectedErr error
+}
+
+type query struct {
+	byName         string
+	byID           int64
+	expectedResult bool
+}
+
+type featuresBaseTestCase struct {
+	name                  string
+	runtimeFeatures       []feature
+	configFeatures        []feature
+	expectedCursorConfig  int64
+	expectedCursorRuntime int64
+
+	extraQueries []query
+}
+
+func TestFeaturesSingleRoutine(t *testing.T) {
+	tests := []featuresBaseTestCase{
+		{
+			name:            "empty set",
+			runtimeFeatures: []feature{},
+			configFeatures:  []feature{},
+			extraQueries:    []query{},
+		},
+		{
+			name: "some features",
+			runtimeFeatures: []feature{
+				{
+					name:        "test1",
+					value:       false,
+					expectedErr: nil,
+				},
+				{
+					name:        "test1",
+					value:       false,
+					expectedErr: ErrAlreadyExists,
+				},
+				{
+					name:        "test2",
+					value:       true,
+					expectedErr: nil,
+				},
+			},
+			configFeatures: []feature{
+				{
+					name:        "test3",
+					value:       false,
+					expectedErr: nil,
+				},
+				{
+					name:        "test1",
+					value:       false,
+					expectedErr: ErrAlreadyExists,
+				},
+				{
+					name:        "test4",
+					value:       false,
+					expectedErr: nil,
+				},
+			},
+			extraQueries: []query{
+				{
+					byName:         "blah",
+					byID:           100500,
+					expectedResult: false,
+				},
+				{
+					byName:         "test1",
+					byID:           0,
+					expectedResult: false,
+				},
+				{
+					byName:         "test2",
+					byID:           1,
+					expectedResult: true,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := NewFeatures()
+			realF := f.(*featuresImpl)
+
+			insertedRuntimeFeatures := 0
+			for i := range test.runtimeFeatures {
+				feature := &test.runtimeFeatures[i]
+				id, err := f.RegisterRuntime(feature.name, feature.value)
+				if err != feature.expectedErr {
+					t.Errorf("unexpected error value, got %v, expected %v", err, feature.expectedErr)
+				}
+				if err == nil {
+					if id < 0 {
+						t.Errorf("got negative id for runtime flag, but it's reserved for config flags")
+					}
+					insertedRuntimeFeatures++
+					feature.assignedID = id
+				}
+			}
+
+			insertedConfigFeatures := 0
+			for i := range test.configFeatures {
+				feature := &test.configFeatures[i]
+				id, err := f.RegisterConfig(feature.name, feature.value)
+				if err != feature.expectedErr {
+					t.Errorf("unexpected error value, got %v, expected %v", err, feature.expectedErr)
+				}
+				if err == nil {
+					if id >= 0 {
+						t.Errorf("got non-negative id for config flag, but it's reserved for runtime flags")
+					}
+					insertedConfigFeatures++
+					feature.assignedID = id
+				}
+				feature.assignedID = id
+			}
+
+			insertedFeatures := insertedConfigFeatures + insertedRuntimeFeatures
+			if len(realF.state) != insertedFeatures {
+				t.Errorf("len(state) mismatch, got %v, expected %v", len(realF.state), insertedFeatures)
+			}
+
+			if len(realF.nameToID) != insertedFeatures {
+				t.Errorf("len(nameToID) mismatch, got %v, expected 0", len(realF.nameToID))
+			}
+
+			if realF.cursorConfig != -1-int64(insertedConfigFeatures) {
+				t.Errorf("cursorConfig mismatch, got %v, expected %v", realF.cursorConfig, -1-int64(insertedConfigFeatures))
+			}
+
+			if realF.cursorRuntime != int64(insertedRuntimeFeatures) {
+				t.Errorf("cursorRuntime mismatch, got %v, expected %v", realF.cursorRuntime, insertedRuntimeFeatures)
+			}
+
+			for _, feature := range test.runtimeFeatures {
+				if feature.expectedErr != nil {
+					continue
+				}
+				ok := f.SetFlagByName(feature.name, feature.value)
+				if !ok {
+					t.Errorf("failed to update existing runtime feature flag '%v' by name", feature.name)
+				}
+
+				ok = f.SetFlagByID(feature.assignedID, feature.value)
+				if !ok {
+					t.Errorf("failed to update existing runtime feature flag '%v' by id", feature.name)
+				}
+			}
+
+			for _, feature := range test.configFeatures {
+				if feature.expectedErr != nil {
+					continue
+				}
+				ok := f.SetFlagByName(feature.name, feature.value)
+				if ok {
+					t.Errorf("successfully updated config feature flag '%v' by name, when we shouldn't", feature.name)
+				}
+
+				ok = f.SetFlagByID(feature.assignedID, feature.value)
+				if ok {
+					t.Errorf("successfully updated config feature flag '%v' by id '%v', when we shouldn't", feature.name, feature.assignedID)
+				}
+			}
+		})
+	}
+}
+
+func TestFeaturesMultipleRoutinesReadOnly(t *testing.T) {
+	goRoutines := 1000
+	test := featuresBaseTestCase{
+		name: "some features",
+		runtimeFeatures: []feature{
+			{
+				name:        "test1",
+				value:       false,
+				expectedErr: nil,
+			},
+			{
+				name:        "test2",
+				value:       true,
+				expectedErr: nil,
+			},
+		},
+	}
+
+	f := NewFeatures()
+
+	insertedRuntimeFeatures := 0
+	for i := range test.runtimeFeatures {
+		feature := &test.runtimeFeatures[i]
+		id, err := f.RegisterRuntime(feature.name, feature.value)
+		if err != feature.expectedErr {
+			t.Errorf("unexpected error value, got %v, expected %v", err, feature.expectedErr)
+		}
+		if err == nil {
+			if id < 0 {
+				t.Errorf("got negative id for runtime flag, but it's reserved for config flags")
+			}
+			insertedRuntimeFeatures++
+			feature.assignedID = id
+		}
+	}
+
+	insertedConfigFeatures := 0
+	for i := range test.configFeatures {
+		feature := &test.configFeatures[i]
+		id, err := f.RegisterConfig(feature.name, feature.value)
+		if err != feature.expectedErr {
+			t.Errorf("unexpected error value, got %v, expected %v", err, feature.expectedErr)
+		}
+		if err == nil {
+			if id >= 0 {
+				t.Errorf("got non-negative id for config flag, but it's reserved for runtime flags")
+			}
+			insertedConfigFeatures++
+			feature.assignedID = id
+		}
+		feature.assignedID = id
+	}
+
+	startChan := make(chan struct{})
+	wg := sync.WaitGroup{}
+	routine := 0
+	for j := 0; j < len(test.runtimeFeatures); j++ {
+		go func(feature feature) {
+			<-startChan
+
+			ok := f.IsEnabledID(feature.assignedID)
+			if ok != feature.value {
+				t.Errorf("unexpected value, got %v, expected %v", ok, feature.value)
+			}
+		}(test.runtimeFeatures[j])
+
+		routine++
+		if routine == goRoutines {
+			break
+		}
+	}
+	close(startChan)
+	wg.Wait()
+}
+
+func TestFeaturesMultipleRoutinesReadUpdate(t *testing.T) {
+	goRoutines := 200
+	test := featuresBaseTestCase{
+		name: "some features",
+		runtimeFeatures: []feature{
+			{
+				name:        "test1",
+				value:       false,
+				expectedErr: nil,
+			},
+			{
+				name:        "test2",
+				value:       true,
+				expectedErr: nil,
+			},
+		},
+		configFeatures: []feature{
+			{
+				name:        "test3",
+				value:       false,
+				expectedErr: nil,
+			},
+			{
+				name:        "test4",
+				value:       true,
+				expectedErr: nil,
+			},
+		},
+	}
+
+	f := NewFeatures()
+
+	insertedRuntimeFeatures := 0
+	for i := range test.runtimeFeatures {
+		feature := &test.runtimeFeatures[i]
+		id, err := f.RegisterRuntime(feature.name, feature.value)
+		if err != feature.expectedErr {
+			t.Errorf("unexpected error value, got %v, expected %v", err, feature.expectedErr)
+		}
+		if err == nil {
+			if id < 0 {
+				t.Errorf("got negative id for runtime flag, but it's reserved for config flags")
+			}
+			insertedRuntimeFeatures++
+			feature.assignedID = id
+		}
+	}
+
+	insertedConfigFeatures := 0
+	for i := range test.configFeatures {
+		feature := &test.configFeatures[i]
+		id, err := f.RegisterConfig(feature.name, feature.value)
+		if err != feature.expectedErr {
+			t.Errorf("unexpected error value, got %v, expected %v", err, feature.expectedErr)
+		}
+		if err == nil {
+			if id >= 0 {
+				t.Errorf("got non-negative id for config flag, but it's reserved for runtime flags")
+			}
+			insertedConfigFeatures++
+			feature.assignedID = id
+		}
+		feature.assignedID = id
+	}
+
+	startChan := make(chan struct{})
+	wg := sync.WaitGroup{}
+	routine := 0
+	for j := 0; j < len(test.runtimeFeatures); j++ {
+		go func(feature feature) {
+			<-startChan
+
+			ok := f.IsEnabledID(feature.assignedID)
+			if ok != feature.value {
+				t.Errorf("unexpected value, got %v, expected %v", ok, feature.value)
+			}
+		}(test.runtimeFeatures[j])
+
+		routine++
+		if routine == goRoutines {
+			break
+		}
+	}
+
+	routine = 0
+	for j := 0; j < len(test.configFeatures); j++ {
+		go func(feature feature) {
+			<-startChan
+
+			ok := f.IsEnabledID(feature.assignedID)
+			if ok != feature.value {
+				t.Errorf("unexpected value, got %v, expected %v", ok, feature.value)
+			}
+		}(test.configFeatures[j])
+
+		routine++
+		if routine == goRoutines {
+			break
+		}
+	}
+
+	routine = 0
+	for j := 0; j < len(test.runtimeFeatures); j++ {
+		go func(feature feature) {
+			<-startChan
+
+			ok := f.SetFlagByName(feature.name, feature.value)
+			if !ok {
+				t.Errorf("failed to update runtime feature")
+			}
+		}(test.runtimeFeatures[j])
+
+		routine++
+		if routine == goRoutines {
+			break
+		}
+	}
+
+	routine = 0
+	for j := 0; j < len(test.configFeatures); j++ {
+		go func(feature feature) {
+			<-startChan
+
+			ok := f.SetFlagByName(feature.name, feature.value)
+			if ok {
+				t.Errorf("updated config feature, but shouldn't")
+			}
+		}(test.configFeatures[j])
+
+		routine++
+		if routine == goRoutines {
+			break
+		}
+	}
+	close(startChan)
+	wg.Wait()
+}
+
+func BenchmarkFeaturesSingleThreadOverheadByID(b *testing.B) {
+	test := featuresBaseTestCase{
+		name: "some features",
+		runtimeFeatures: []feature{
+			{
+				name:        "test1",
+				value:       false,
+				expectedErr: nil,
+			},
+			{
+				name:        "test2",
+				value:       true,
+				expectedErr: nil,
+			},
+		},
+	}
+
+	f := NewFeatures()
+
+	insertedRuntimeFeatures := 0
+	for i := range test.runtimeFeatures {
+		feature := &test.runtimeFeatures[i]
+		id, err := f.RegisterRuntime(feature.name, feature.value)
+		if err != feature.expectedErr {
+			b.Fatalf("unexpected error value, got %v, expected %v", err, feature.expectedErr)
+		}
+		if err == nil {
+			if id < 0 {
+				b.Fatalf("got negative id for runtime flag, but it's reserved for config flags")
+			}
+			insertedRuntimeFeatures++
+			feature.assignedID = id
+		}
+	}
+
+	insertedConfigFeatures := 0
+	for i := range test.configFeatures {
+		feature := &test.configFeatures[i]
+		id, err := f.RegisterConfig(feature.name, feature.value)
+		if err != feature.expectedErr {
+			b.Fatalf("unexpected error value, got %v, expected %v", err, feature.expectedErr)
+		}
+		if err == nil {
+			if id >= 0 {
+				b.Fatalf("got non-negative id for config flag, but it's reserved for runtime flags")
+			}
+			insertedConfigFeatures++
+			feature.assignedID = id
+		}
+		feature.assignedID = id
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		id := int64(i % len(test.runtimeFeatures))
+		_ = f.IsEnabledID(id)
+	}
+}

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -95,7 +95,7 @@ func TestFeaturesSingleRoutine(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			f := NewFeatures()
+			f := newFeatures()
 			realF := f.(*featuresImpl)
 
 			insertedRuntimeFeatures := 0
@@ -199,7 +199,7 @@ func TestFeaturesMultipleRoutinesReadOnly(t *testing.T) {
 		},
 	}
 
-	f := NewFeatures()
+	f := newFeatures()
 
 	insertedRuntimeFeatures := 0
 	for i := range test.runtimeFeatures {
@@ -286,7 +286,7 @@ func TestFeaturesMultipleRoutinesReadUpdate(t *testing.T) {
 		},
 	}
 
-	f := NewFeatures()
+	f := newFeatures()
 
 	insertedRuntimeFeatures := 0
 	for i := range test.runtimeFeatures {
@@ -411,7 +411,7 @@ func BenchmarkFeaturesSingleThreadOverheadByID(b *testing.B) {
 		},
 	}
 
-	f := NewFeatures()
+	f := newFeatures()
 
 	insertedRuntimeFeatures := 0
 	for i := range test.runtimeFeatures {

--- a/pkg/features/http_handler.go
+++ b/pkg/features/http_handler.go
@@ -1,0 +1,122 @@
+package features
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type flagType struct {
+	Name      string
+	ID        int64
+	State     bool
+	Immutable bool
+}
+
+type patchResponse struct {
+	Applied bool
+	Errors  []error
+}
+
+func (f *featuresImpl) FlagPatchByIDHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var res []byte
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		res, _ = json.Marshal(err)
+		w.Write(res)
+		return
+	}
+
+	var input []ChangeRequestByID
+	err = json.Unmarshal(body, &input)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		res, _ = json.Marshal(err)
+		w.Write(res)
+		return
+	}
+
+	var resp patchResponse
+	for _, request := range input {
+		if request.ID < 0 {
+			resp.Errors = append(resp.Errors, fmt.Errorf("flag with id=%v is immutable (id < 0)", request.ID))
+			continue
+		}
+		f.SetFlagByID(request.ID, request.Value)
+	}
+	if len(resp.Errors) < len(input) {
+		resp.Applied = true
+	} else {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	res, _ = json.Marshal(resp)
+	w.Write(res)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (f *featuresImpl) FlagPatchByNameHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var res []byte
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		res, _ = json.Marshal(err)
+		w.Write(res)
+		return
+	}
+
+	var input []ChangeRequestByName
+	err = json.Unmarshal(body, &input)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		res, _ = json.Marshal(err)
+		w.Write(res)
+		return
+	}
+
+	var resp patchResponse
+	for _, request := range input {
+		ok := f.SetFlagByName(request.Name, request.Value)
+		if !ok {
+			resp.Errors = append(resp.Errors, fmt.Errorf("flag with name=%v is immutable", request.Name))
+			continue
+		}
+	}
+	if len(resp.Errors) < len(input) {
+		resp.Applied = true
+	} else {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	res, _ = json.Marshal(resp)
+	w.Write(res)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (f *featuresImpl) FlagListHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	res := make([]flagType, 0)
+	f.RLock()
+	for flag, id := range f.nameToID {
+		res = append(res, flagType{
+			Name:      flag,
+			ID:        id,
+			State:     f.state[id],
+			Immutable: id < 0,
+		})
+	}
+	f.RUnlock()
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		data, _ = json.Marshal(err)
+		w.Write(data)
+		return
+	}
+	w.Write(data)
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/features/interface.go
+++ b/pkg/features/interface.go
@@ -1,0 +1,77 @@
+package features
+
+import (
+	"fmt"
+	"net/http"
+)
+
+var (
+	// ErrAlreadyExists is an error when you are trying to register feature that already registered
+	ErrAlreadyExists = fmt.Errorf("feature already registered")
+)
+
+// ChangeRequestByID is a type that's used by FlagPatchByIDHandler
+type ChangeRequestByID struct {
+	ID    int64
+	Value bool
+}
+
+// ChangeRequestByName is a type that's used by FlagPatchByNameHandler
+type ChangeRequestByName struct {
+	Name  string
+	Value bool
+}
+
+// Features - interface to provide a simple feature flag framework
+// For now default state is always "false" - disabled. This is subject to discuss in future
+// Package should declare new feature flags in it's init function.
+type Features interface {
+	// RegisterRuntime registers feature that can be set in runtime
+	// You must provide feature name and you'll get FeatureID in the end
+	RegisterRuntime(name string, def bool) (int64, error)
+
+	// RegisterConfig registers feature that can be set only in config
+	// You must provide feature name and you'll get FeatureID in the end
+	RegisterConfig(name string, def bool) (int64, error)
+
+	// IsEnabledID allows to check if this feature was enabled by it's ID
+	// if flag not found returns false
+	IsEnabledID(id int64) bool
+
+	// IsEnabledName allows to check if this feature was enabled by it's name
+	// if flag not found returns false
+	IsEnabledName(name string) bool
+
+	// SetFlagByID updates flag status by flag id
+	// returns true on success and false if flag not found
+	SetFlagByID(id int64, enabled bool) bool
+
+	// SetFlagByName updates flag status by name
+	// returns true on success and false if flag not found
+	SetFlagByName(name string, enabled bool) bool
+
+	// FlagListHandler is an HTTP Handler that provides current flag state
+	//
+	FlagListHandler(w http.ResponseWriter, r *http.Request)
+
+	// FlagPatchByIDHandler is an HTTP Handler controls current flag configuration
+	// Handler supports PATCH requests only. Accepts []ChangeRequestByID
+	//
+	//   If user tries to change flag that can't be change in a runtime
+	//   HTTP 400 error will be produced and no changes will be applied
+	FlagPatchByIDHandler(w http.ResponseWriter, r *http.Request)
+
+	// FlagPatchByIDHandler is an HTTP Handler controls current flag configuration
+	// Handler supports PATCH requests only. Accepts []ChangeRequestByName
+	//
+	//   If user tries to change flag that can't be change in a runtime
+	//   HTTP 400 error will be produced and no changes will be applied
+	FlagPatchByNameHandler(w http.ResponseWriter, r *http.Request)
+}
+
+/*
+TODO:
+ 1. Think of a way to sync flags
+ 2. Find a way to improve performance for check-mostly cases. E.x. treat whole config as immutable and migrate to atomics
+ 3. Implement a way to do A/B tests, e.x. by user name.
+*/

--- a/pkg/features/interface.go
+++ b/pkg/features/interface.go
@@ -7,7 +7,8 @@ import (
 
 var (
 	// ErrAlreadyExists is an error when you are trying to register feature that already registered
-	ErrAlreadyExists = fmt.Errorf("feature already registered")
+	ErrAlreadyExists        = fmt.Errorf("feature flag already registered")
+	ErrFeatureNotRegistered = fmt.Errorf("feature flag not registered")
 )
 
 // ChangeRequestByID is a type that's used by FlagPatchByIDHandler
@@ -23,7 +24,6 @@ type ChangeRequestByName struct {
 }
 
 // Features - interface to provide a simple feature flag framework
-// For now default state is always "false" - disabled. This is subject to discuss in future
 // Package should declare new feature flags in it's init function.
 type Features interface {
 	// RegisterRuntime registers feature that can be set in runtime
@@ -49,6 +49,11 @@ type Features interface {
 	// SetFlagByName updates flag status by name
 	// returns true on success and false if flag not found
 	SetFlagByName(name string, enabled bool) bool
+
+	// GetIDByName gets id of feature if exists by it's name
+	// Useful to do conditional tests, when you don't know what
+	// ID feature flag got
+	GetIDByName(name string) (int64, error)
 
 	// FlagListHandler is an HTTP Handler that provides current flag state
 	//

--- a/pkg/features/interface.go
+++ b/pkg/features/interface.go
@@ -8,6 +8,7 @@ import (
 var (
 	// ErrAlreadyExists is an error when you are trying to register feature that already registered
 	ErrAlreadyExists        = fmt.Errorf("feature flag already registered")
+	// ErrFeatureNotRegistered is an error that's returned when there is no flag registered with specified name
 	ErrFeatureNotRegistered = fmt.Errorf("feature flag not registered")
 )
 

--- a/pkg/features/interface.go
+++ b/pkg/features/interface.go
@@ -5,9 +5,16 @@ import (
 	"net/http"
 )
 
+/*
+ * There are two types of flags:
+ *   1. Runtime (mutable) - flags that are safe to change during runtime (via API)
+ *   2. Config (immutable) - flags that shouldn't be changed during runtime, they must be set via config.
+        In code they must be set with SetFlagByNameForced function when config is parsed.
+*/
+
 var (
 	// ErrAlreadyExists is an error when you are trying to register feature that already registered
-	ErrAlreadyExists        = fmt.Errorf("feature flag already registered")
+	ErrAlreadyExists = fmt.Errorf("feature flag already registered")
 	// ErrFeatureNotRegistered is an error that's returned when there is no flag registered with specified name
 	ErrFeatureNotRegistered = fmt.Errorf("feature flag not registered")
 )
@@ -73,6 +80,11 @@ type Features interface {
 	//   If user tries to change flag that can't be change in a runtime
 	//   HTTP 400 error will be produced and no changes will be applied
 	FlagPatchByNameHandler(w http.ResponseWriter, r *http.Request)
+
+	// SetFlagByNameForced is a function that should be during initialization
+	// It's not thread-safe (on purpose) and allows to change even config-time flags
+	// returns error if there is no such flag
+	SetFlagByNameForced(name string, enabled bool) error
 }
 
 /*

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -55,6 +55,22 @@ func EvaluatorFromFuncWithMetadata(metadata map[string]interfaces.Function) inte
 	return e
 }
 
+type FuncRewriter struct {
+	eval func(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error)
+}
+
+func (evaluator *FuncRewriter) RewriteExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error) {
+	return evaluator.eval(e, from, until, values)
+}
+
+func RewriterFromFunc(function interfaces.RewriteFunction) interfaces.Rewriter {
+	e := &FuncRewriter{
+		eval: function.Do,
+	}
+
+	return e
+}
+
 func DeepClone(original map[parser.MetricRequest][]*types.MetricData) map[parser.MetricRequest][]*types.MetricData {
 	clone := map[parser.MetricRequest][]*types.MetricData{}
 	for key, originalMetrics := range original {

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -55,14 +55,18 @@ func EvaluatorFromFuncWithMetadata(metadata map[string]interfaces.Function) inte
 	return e
 }
 
+// FuncRewriter is a struct that can evaluate rewrite func
+// It's useful for tests for rewrite functions. See how to initialize it below
 type FuncRewriter struct {
 	eval func(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error)
 }
 
+// RewriteExpr rewrites expressions (see expr/expr.go RewriteExpr for more details
 func (evaluator *FuncRewriter) RewriteExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error) {
 	return evaluator.eval(e, from, until, values)
 }
 
+// RewriterFromFunc creates a struct that interface.Rewriter compatible and only executes specified function
 func RewriterFromFunc(function interfaces.RewriteFunction) interfaces.Rewriter {
 	e := &FuncRewriter{
 		eval: function.Do,


### PR DESCRIPTION
There are more and more experimental changes. This pkg implements
a unified way to control what feature flags (experiment flags) enabled
and provides a way to change some of them in runtime (PATCH request).

From now on all code that considered to be experimental or not desirable by
everyone (e.x. incompatible with graphite-web) should be under a feature flag

Overhead of the implementation is low for single thread - 50ns per request,
Though it's better to replace whole function if the code path is too hot.