### PR TITLE
Gmagnusson/bugfix monitor warn

### DIFF
--- a/cmd/carbonapi/carbonapi.example.yaml
+++ b/cmd/carbonapi/carbonapi.example.yaml
@@ -47,8 +47,11 @@ pidFile: ""
 upstreams:
     # Number of 100ms buckets to track request distribution in. Used to build
     # 'carbon.zipper.hostname.requests_in_0ms_to_100ms' metric and friends.
-    # Requests beyond the last bucket are logged as slow
-    # (default of 10 implies "slow" is >1 second).
+    # Requests beyond the last bucket are logged as slow (default of 10 implies
+    # "slow" is >1 second).
+    # The last bucket is _not_ called 'requests_in_Xms_to_inf' on purpose, so
+    # we can change our minds about how many buckets we want to have and have
+    # their names remain consistent.
     buckets: 10
 
     timeouts:

--- a/cmd/carbonapi/http_handlers.go
+++ b/cmd/carbonapi/http_handlers.go
@@ -9,21 +9,21 @@ import (
 	"strings"
 	"time"
 
-	pickle "github.com/lomik/og-rek"
-	"github.com/satori/go.uuid"
-
 	"github.com/go-graphite/carbonapi/carbonapipb"
 	"github.com/go-graphite/carbonapi/date"
 	"github.com/go-graphite/carbonapi/expr"
 	"github.com/go-graphite/carbonapi/expr/functions/cairo/png"
+	"github.com/go-graphite/carbonapi/expr/metadata"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/intervalset"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	util "github.com/go-graphite/carbonapi/util/ctx"
-	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 
-	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/dgryski/httputil"
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+	pickle "github.com/lomik/og-rek"
 	"github.com/lomik/zapwriter"
+	"github.com/satori/go.uuid"
 	"go.uber.org/zap"
 )
 
@@ -46,14 +46,14 @@ const (
 
 func initHandlers() *http.ServeMux {
 	r := http.DefaultServeMux
-	r.HandleFunc("/render/", renderHandler)
-	r.HandleFunc("/render", renderHandler)
+	r.HandleFunc("/render/", httputil.TrackConnections(httputil.TimeHandler(util.ParseCtx(renderHandler, util.HeaderUUIDAPI), bucketRequestTimes)))
+	r.HandleFunc("/render", httputil.TrackConnections(httputil.TimeHandler(util.ParseCtx(renderHandler, util.HeaderUUIDAPI), bucketRequestTimes)))
 
-	r.HandleFunc("/metrics/find/", findHandler)
-	r.HandleFunc("/metrics/find", findHandler)
+	r.HandleFunc("/metrics/find/", httputil.TrackConnections(httputil.TimeHandler(util.ParseCtx(findHandler, util.HeaderUUIDAPI), bucketRequestTimes)))
+	r.HandleFunc("/metrics/find", httputil.TrackConnections(httputil.TimeHandler(util.ParseCtx(findHandler, util.HeaderUUIDAPI), bucketRequestTimes)))
 
-	r.HandleFunc("/info/", infoHandler)
-	r.HandleFunc("/info", infoHandler)
+	r.HandleFunc("/info/", httputil.TrackConnections(httputil.TimeHandler(util.ParseCtx(infoHandler, util.HeaderUUIDAPI), bucketRequestTimes)))
+	r.HandleFunc("/info", httputil.TrackConnections(httputil.TimeHandler(util.ParseCtx(infoHandler, util.HeaderUUIDAPI), bucketRequestTimes)))
 
 	r.HandleFunc("/lb_check", lbcheckHandler)
 


### PR DESCRIPTION
These are three unrelated patches that:

- Log a new warning when Find requests in Fetch fail
- Expose the carbonzipper request duration buckets in carbonapi for monitoring
- Fix an infinite loop bug in Fetch requests that happens when we filter out some clients