### PR TITLE
Improve logging of payload data 

### DIFF
--- a/zipper/helper/requests.go
+++ b/zipper/helper/requests.go
@@ -64,7 +64,7 @@ func (c *HttpQuery) pickServer() string {
 	return srv
 }
 
-func (c *HttpQuery) doRequest(ctx context.Context, uri string, body []byte) (*ServerResponse, error) {
+func (c *HttpQuery) doRequest(ctx context.Context, uri string, r types.Request) (*ServerResponse, error) {
 	server := c.pickServer()
 	c.logger.Debug("picked server",
 		zap.String("server", server),
@@ -75,16 +75,26 @@ func (c *HttpQuery) doRequest(ctx context.Context, uri string, body []byte) (*Se
 		return nil, err
 	}
 
+	var requestString string
+	var reader io.Reader
+	var body []byte
+	if r != nil {
+		requestString = r.LogInfo()
+
+		body, err = r.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		if body != nil {
+			reader = bytes.NewReader(body)
+		}
+	}
 	logger := c.logger.With(
 		zap.String("server", server),
 		zap.String("name", c.groupName),
-		zap.String("uri", u.String()),
+		zap.String("uri", u.String()+requestString),
 	)
 
-	var reader io.Reader
-	if body != nil {
-		reader = bytes.NewReader(body)
-	}
 	req, err := http.NewRequest("GET", u.String(), reader)
 	req.Header.Set("Accept", c.encoding)
 	if err != nil {
@@ -129,7 +139,7 @@ func (c *HttpQuery) doRequest(ctx context.Context, uri string, body []byte) (*Se
 	return &ServerResponse{Server: server, Response: body}, nil
 }
 
-func (c *HttpQuery) DoQuery(ctx context.Context, uri string, body []byte) (*ServerResponse, *errors.Errors) {
+func (c *HttpQuery) DoQuery(ctx context.Context, uri string, r types.Request) (*ServerResponse, *errors.Errors) {
 	maxTries := c.maxTries
 	if len(c.servers) > maxTries {
 		maxTries = len(c.servers)
@@ -137,7 +147,7 @@ func (c *HttpQuery) DoQuery(ctx context.Context, uri string, body []byte) (*Serv
 
 	var e errors.Errors
 	for try := 0; try < maxTries; try++ {
-		res, err := c.doRequest(ctx, uri, body)
+		res, err := c.doRequest(ctx, uri, r)
 		if err != nil {
 			c.logger.Error("have errors",
 				zap.Error(err),

--- a/zipper/helper/requests.go
+++ b/zipper/helper/requests.go
@@ -75,12 +75,9 @@ func (c *HttpQuery) doRequest(ctx context.Context, uri string, r types.Request) 
 		return nil, err
 	}
 
-	var requestString string
 	var reader io.Reader
 	var body []byte
 	if r != nil {
-		requestString = r.LogInfo()
-
 		body, err = r.Marshal()
 		if err != nil {
 			return nil, err
@@ -92,7 +89,7 @@ func (c *HttpQuery) doRequest(ctx context.Context, uri string, r types.Request) 
 	logger := c.logger.With(
 		zap.String("server", server),
 		zap.String("name", c.groupName),
-		zap.String("uri", u.String()+requestString),
+		zap.String("uri", u.String()),
 	)
 
 	req, err := http.NewRequest("GET", u.String(), reader)
@@ -110,6 +107,7 @@ func (c *HttpQuery) doRequest(ctx context.Context, uri string, r types.Request) 
 		return nil, err
 	}
 	logger.Debug("got slot")
+	logger = logger.With(zap.Any("payloadData", r.LogInfo()))
 
 	resp, err := c.client.Do(req.WithContext(ctx))
 	c.limiter.Leave(ctx, server)

--- a/zipper/helper/requests.go
+++ b/zipper/helper/requests.go
@@ -107,8 +107,9 @@ func (c *HttpQuery) doRequest(ctx context.Context, uri string, r types.Request) 
 		return nil, err
 	}
 	logger.Debug("got slot")
-	logger = logger.With(zap.Any("payloadData", r.LogInfo()))
-
+	if r != nil {
+		logger = logger.With(zap.Any("payloadData", r.LogInfo()))
+	}
 	resp, err := c.client.Do(req.WithContext(ctx))
 	c.limiter.Leave(ctx, server)
 	if err != nil {

--- a/zipper/protocols/v3/protobuf_group.go
+++ b/zipper/protocols/v3/protobuf_group.go
@@ -117,7 +117,7 @@ func (c *ClientProtoV3Group) Fetch(ctx context.Context, request *protov3.MultiFe
 	}
 	rewrite.RawQuery = v.Encode()
 
-	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiFetchRequestV3{request})
+	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiFetchRequestV3{*request})
 	if e == nil {
 		e = &errors.Errors{}
 	}
@@ -149,7 +149,7 @@ func (c *ClientProtoV3Group) Find(ctx context.Context, request *protov3.MultiGlo
 	}
 	rewrite.RawQuery = v.Encode()
 
-	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiGlobRequestV3{request})
+	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiGlobRequestV3{*request})
 	if e == nil {
 		e = &errors.Errors{}
 	}
@@ -176,7 +176,7 @@ func (c *ClientProtoV3Group) Info(ctx context.Context, request *protov3.MultiMet
 	}
 	rewrite.RawQuery = v.Encode()
 
-	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiMetricsInfoV3{request})
+	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiMetricsInfoV3{*request})
 	if e == nil {
 		e = &errors.Errors{}
 	}

--- a/zipper/protocols/v3/protobuf_group.go
+++ b/zipper/protocols/v3/protobuf_group.go
@@ -117,12 +117,7 @@ func (c *ClientProtoV3Group) Fetch(ctx context.Context, request *protov3.MultiFe
 	}
 	rewrite.RawQuery = v.Encode()
 
-	data, err := request.Marshal()
-	if err != nil {
-		return nil, nil, errors.FromErrNonFatal(err)
-	}
-
-	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), data)
+	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiFetchRequestV3{request})
 	if e == nil {
 		e = &errors.Errors{}
 	}
@@ -154,12 +149,7 @@ func (c *ClientProtoV3Group) Find(ctx context.Context, request *protov3.MultiGlo
 	}
 	rewrite.RawQuery = v.Encode()
 
-	data, err := request.Marshal()
-	if err != nil {
-		return nil, nil, errors.FromErrNonFatal(err)
-	}
-
-	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), data)
+	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiGlobRequestV3{request})
 	if e == nil {
 		e = &errors.Errors{}
 	}
@@ -169,7 +159,7 @@ func (c *ClientProtoV3Group) Find(ctx context.Context, request *protov3.MultiGlo
 	}
 
 	var globs protov3.MultiGlobResponse
-	err = globs.Unmarshal(res.Response)
+	err := globs.Unmarshal(res.Response)
 	if err != nil {
 		return nil, nil, errors.FromErrNonFatal(err)
 	}
@@ -186,12 +176,7 @@ func (c *ClientProtoV3Group) Info(ctx context.Context, request *protov3.MultiMet
 	}
 	rewrite.RawQuery = v.Encode()
 
-	data, err := request.Marshal()
-	if err != nil {
-		return nil, nil, errors.FromErrNonFatal(err)
-	}
-
-	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), data)
+	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiMetricsInfoV3{request})
 	if e == nil {
 		e = &errors.Errors{}
 	}
@@ -201,7 +186,7 @@ func (c *ClientProtoV3Group) Info(ctx context.Context, request *protov3.MultiMet
 	}
 
 	var infos protov3.MultiMetricsInfoResponse
-	err = infos.Unmarshal(res.Response)
+	err := infos.Unmarshal(res.Response)
 	if err != nil {
 		return nil, nil, errors.FromErrNonFatal(err)
 	}

--- a/zipper/types/interface.go
+++ b/zipper/types/interface.go
@@ -7,6 +7,11 @@ import (
 	protov3 "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )
 
+type Request interface {
+	Marshal() ([]byte, error)
+	LogInfo() string
+}
+
 type ServerClient interface {
 	Name() string
 	Backends() []string

--- a/zipper/types/interface.go
+++ b/zipper/types/interface.go
@@ -9,7 +9,7 @@ import (
 
 type Request interface {
 	Marshal() ([]byte, error)
-	LogInfo() string
+	LogInfo() interface{}
 }
 
 type ServerClient interface {

--- a/zipper/types/requests.go
+++ b/zipper/types/requests.go
@@ -1,37 +1,39 @@
 package types
 
-import protov3 "github.com/go-graphite/protocol/carbonapi_v3_pb"
+import (
+	protov3 "github.com/go-graphite/protocol/carbonapi_v3_pb"
+)
 
 type MultiFetchRequestV3 struct {
-	*protov3.MultiFetchRequest
+	protov3.MultiFetchRequest
 }
 
 type MultiGlobRequestV3 struct {
-	*protov3.MultiGlobRequest
+	protov3.MultiGlobRequest
 }
 
 type MultiMetricsInfoV3 struct {
-	*protov3.MultiMetricsInfoRequest
+	protov3.MultiMetricsInfoRequest
 }
 
 type CapabilityRequestV3 struct {
-	*protov3.CapabilityRequest
+	protov3.CapabilityRequest
 }
 
 func (request MultiGlobRequestV3) Marshal() ([]byte, error) {
 	return request.MultiGlobRequest.Marshal()
 }
 
-func (request MultiGlobRequestV3) LogInfo() string {
-	return request.MultiGlobRequest.GoString()
+func (request MultiGlobRequestV3) LogInfo() interface{} {
+	return request.MultiGlobRequest
 }
 
 func (request MultiFetchRequestV3) Marshal() ([]byte, error) {
 	return request.MultiFetchRequest.Marshal()
 }
 
-func (request MultiFetchRequestV3) LogInfo() string {
-	return request.MultiFetchRequest.GoString()
+func (request MultiFetchRequestV3) LogInfo() interface{} {
+	return request.MultiFetchRequest
 
 }
 
@@ -39,14 +41,14 @@ func (request MultiMetricsInfoV3) Marshal() ([]byte, error) {
 	return request.MultiMetricsInfoRequest.Marshal()
 }
 
-func (request MultiMetricsInfoV3) LogInfo() string {
-	return request.MultiMetricsInfoRequest.GoString()
+func (request MultiMetricsInfoV3) LogInfo() interface{} {
+	return request.MultiMetricsInfoRequest
 }
 
 func (request CapabilityRequestV3) Marshal() ([]byte, error) {
 	return request.CapabilityRequest.Marshal()
 }
 
-func (request CapabilityRequestV3) LogInfo() string {
-	return request.CapabilityRequest.GoString()
+func (request CapabilityRequestV3) LogInfo() interface{} {
+	return request.CapabilityRequest
 }

--- a/zipper/types/requests.go
+++ b/zipper/types/requests.go
@@ -1,0 +1,52 @@
+package types
+
+import protov3 "github.com/go-graphite/protocol/carbonapi_v3_pb"
+
+type MultiFetchRequestV3 struct {
+	*protov3.MultiFetchRequest
+}
+
+type MultiGlobRequestV3 struct {
+	*protov3.MultiGlobRequest
+}
+
+type MultiMetricsInfoV3 struct {
+	*protov3.MultiMetricsInfoRequest
+}
+
+type CapabilityRequestV3 struct {
+	*protov3.CapabilityRequest
+}
+
+func (request MultiGlobRequestV3) Marshal() ([]byte, error) {
+	return request.MultiGlobRequest.Marshal()
+}
+
+func (request MultiGlobRequestV3) LogInfo() string {
+	return request.MultiGlobRequest.GoString()
+}
+
+func (request MultiFetchRequestV3) Marshal() ([]byte, error) {
+	return request.MultiFetchRequest.Marshal()
+}
+
+func (request MultiFetchRequestV3) LogInfo() string {
+	return request.MultiFetchRequest.GoString()
+
+}
+
+func (request MultiMetricsInfoV3) Marshal() ([]byte, error) {
+	return request.MultiMetricsInfoRequest.Marshal()
+}
+
+func (request MultiMetricsInfoV3) LogInfo() string {
+	return request.MultiMetricsInfoRequest.GoString()
+}
+
+func (request CapabilityRequestV3) Marshal() ([]byte, error) {
+	return request.CapabilityRequest.Marshal()
+}
+
+func (request CapabilityRequestV3) LogInfo() string {
+	return request.CapabilityRequest.GoString()
+}


### PR DESCRIPTION
Logging the payload data while making requests to backend stores in case of errors. Previously, we were missing this for protobuf requests.