### PR TITLE
Logging zipper requests count

### DIFF
--- a/cmd/carbonapi/main_test.go
+++ b/cmd/carbonapi/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-graphite/carbonapi/expr/types"
+	zipperTypes "github.com/go-graphite/carbonapi/zipper/types"
 	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/lomik/zapwriter"
 	"github.com/stretchr/testify/assert"
@@ -20,25 +21,25 @@ func newMockCarbonZipper() *mockCarbonZipper {
 	return new(mockCarbonZipper)
 }
 
-func (z mockCarbonZipper) Find(ctx context.Context, metrics []string) (*pb.MultiGlobResponse, error) {
-	return getGlobResponse(), nil
+func (z mockCarbonZipper) Find(ctx context.Context, metrics []string) (*pb.MultiGlobResponse, *zipperTypes.Stats, error) {
+	return getGlobResponse(), nil, nil
 }
 
-func (z mockCarbonZipper) Info(ctx context.Context, metrics []string) (*pb.ZipperInfoResponse, error) {
+func (z mockCarbonZipper) Info(ctx context.Context, metrics []string) (*pb.ZipperInfoResponse, *zipperTypes.Stats, error) {
 	response := getMockInfoResponse()
 
-	return response, nil
+	return response, nil, nil
 }
 
-func (z mockCarbonZipper) Render(ctx context.Context, request pb.MultiFetchRequest) ([]*types.MetricData, error) {
+func (z mockCarbonZipper) Render(ctx context.Context, request pb.MultiFetchRequest) ([]*types.MetricData, *zipperTypes.Stats, error) {
 	return z.RenderCompat(ctx, []string{""}, 0, 0)
 }
 
-func (z mockCarbonZipper) RenderCompat(ctx context.Context, metrics []string, from, until int64) ([]*types.MetricData, error) {
+func (z mockCarbonZipper) RenderCompat(ctx context.Context, metrics []string, from, until int64) ([]*types.MetricData, *zipperTypes.Stats, error) {
 	var result []*types.MetricData
 	multiFetchResponse := getMultiFetchResponse()
 	result = append(result, &types.MetricData{FetchResponse: multiFetchResponse.Metrics[0]})
-	return result, nil
+	return result, nil, nil
 }
 
 func getGlobResponse() *pb.MultiGlobResponse {

--- a/zipper/broadcast/broadcast_group.go
+++ b/zipper/broadcast/broadcast_group.go
@@ -202,7 +202,7 @@ func (bg *BroadcastGroup) Fetch(ctx context.Context, request *protov3.MultiFetch
 		zipperRequests = 1
 	}
 	if len(requests) > 0 {
-		zipperRequests += ((len(requests) - 1) * bg.MaxMetricsPerRequest()) + len(requests[len(requests)-1].Metrics)
+		zipperRequests += len(requests) * len(clients)
 	}
 
 	result := types.NewServerFetchResponse()

--- a/zipper/types/stats.go
+++ b/zipper/types/stats.go
@@ -9,6 +9,7 @@ type Stats struct {
 	SearchRequests    int64
 	SearchCacheHits   int64
 	SearchCacheMisses int64
+	ZipperRequests    int64
 
 	MemoryUsage int64
 


### PR DESCRIPTION
In the merge of carbonapi and zipper, the zipper requests count was broken. This fix logs the zipper requests counts correctly, taking also splitting of requests into account for fetch/render requests.