### PR TITLE
Fix error handling to return result even if a single node goes down

### DIFF
--- a/cmd/carbonapi/http_handlers.go
+++ b/cmd/carbonapi/http_handlers.go
@@ -301,7 +301,6 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				errors[target] = err.Error()
 				config.limiter.leave()
-				continue
 			}
 
 			config.limiter.leave()

--- a/cmd/carbonapi/http_handlers.go
+++ b/cmd/carbonapi/http_handlers.go
@@ -300,7 +300,6 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 			r, err := config.zipper.Render(ctx, req)
 			if err != nil {
 				errors[target] = err.Error()
-				config.limiter.leave()
 			}
 
 			config.limiter.leave()

--- a/zipper/broadcast/broadcast_group.go
+++ b/zipper/broadcast/broadcast_group.go
@@ -157,7 +157,9 @@ func (bg *BroadcastGroup) SplitRequest(ctx context.Context, request *protov3.Mul
 				zap.Any("errors", e.Errors),
 			)
 
-			continue
+			if f == nil {
+				continue
+			}
 		}
 
 		for _, m := range f.Metrics {

--- a/zipper/helper/requests.go
+++ b/zipper/helper/requests.go
@@ -162,6 +162,6 @@ func (c *HttpQuery) DoQuery(ctx context.Context, uri string, r types.Request) (*
 		return res, nil
 	}
 
-	e.AddFatal(types.ErrMaxTriesExceeded)
+	e.Add(types.ErrMaxTriesExceeded)
 	return nil, &e
 }

--- a/zipper/protocols/v3/protobuf_group.go
+++ b/zipper/protocols/v3/protobuf_group.go
@@ -126,6 +126,9 @@ func (c *ClientProtoV3Group) Fetch(ctx context.Context, request *protov3.MultiFe
 		return nil, stats, e
 	}
 
+	if res == nil {
+		return nil, stats, errors.FromErrNonFatal(types.ErrNoResponseFetched)
+	}
 	var metrics protov3.MultiFetchResponse
 	e.AddFatal(metrics.Unmarshal(res.Response))
 	if e == nil {
@@ -158,6 +161,9 @@ func (c *ClientProtoV3Group) Find(ctx context.Context, request *protov3.MultiGlo
 		return nil, stats, e
 	}
 
+	if res == nil {
+		return nil, stats, errors.FromErrNonFatal(types.ErrNotFound)
+	}
 	var globs protov3.MultiGlobResponse
 	err := globs.Unmarshal(res.Response)
 	if err != nil {
@@ -185,6 +191,9 @@ func (c *ClientProtoV3Group) Info(ctx context.Context, request *protov3.MultiMet
 		return nil, stats, e
 	}
 
+	if res == nil {
+		return nil, stats, errors.FromErrNonFatal(types.ErrNoResponseFetched)
+	}
 	var infos protov3.MultiMetricsInfoResponse
 	err := infos.Unmarshal(res.Response)
 	if err != nil {
@@ -224,6 +233,9 @@ func (c *ClientProtoV3Group) ProbeTLDs(ctx context.Context) ([]string, *errors.E
 		return nil, err
 	}
 
+	if res == nil {
+		return nil, err
+	}
 	var tlds []string
 	for _, m := range res.Metrics {
 		for _, v := range m.Matches {

--- a/zipper/types/response.go
+++ b/zipper/types/response.go
@@ -39,10 +39,6 @@ func (first *ServerInfoResponse) Merge(second *ServerInfoResponse) *errors.Error
 	}
 	first.Err.Merge(second.Err)
 
-	if first.Err.HaveFatalErrors {
-		return first.Err
-	}
-
 	if second.Response == nil {
 		return first.Err
 	}
@@ -78,10 +74,6 @@ func (first *ServerFindResponse) Merge(second *ServerFindResponse) *errors.Error
 		first.Err = new(errors.Errors)
 	}
 	first.Err.Merge(second.Err)
-
-	if first.Err.HaveFatalErrors {
-		return first.Err
-	}
 
 	if second.Response == nil {
 		return first.Err


### PR DESCRIPTION
Error handling is improved as current behaviour was a regression from older releases of zipper behaviour. In previous releases, if one of the
nodes failed for any reason, we would still return data (logging the errors), which
goes with graphite behavior. However, in the ensuing rewrite, this
behaviour changed. If one of the nodes went down for example, we
would treat it as a fatal error, and the entire request would not
return data.

This commit takes the behaviour to mirror older releases. However,
goig forward we can do some additional work to make it even
smarter, and checking if all metrics have some data from different
clusters, or so.