### PR TITLE
changing default golang we use for packaging to 1.10.x instead of beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ git:
 
 matrix:
   include:
-    - go: 1.x
-      env:
+    - go: "1.x"
+    - go: "1.9.x"
+    - go: "1.10.x"
+       env:
         - BUILD_PACKAGES=true
-    - go: 1.9.x
-    - go: 1.10.x
-    - go: master
+   - go: "master"


### PR DESCRIPTION
Periodically travis fails to build packages with errors like:
# github.com/go-graphite/carbonapi/vendor/go.uber.org/zap
vendor/go.uber.org/zap/field.go:33: syntax error: unexpected = in type declaration

one of the reasons I can imagine for that is this:
go version go1.11beta2 linux/amd64

additionally according to https://docs.travis-ci.com/user/languages/go/
changing go version declaration to string instead of float.