### PR TITLE
Get some request statistics

### DIFF
--- a/cmd/carbonapi/main.go
+++ b/cmd/carbonapi/main.go
@@ -79,8 +79,6 @@ var zipperMetrics = struct {
 
 	InfoRequests *expvar.Int
 	InfoErrors   *expvar.Int
-
-	Timeouts *expvar.Int
 }{
 	FindRequests: expvar.NewInt("zipper_find_requests"),
 	FindErrors:   expvar.NewInt("zipper_find_errors"),
@@ -90,8 +88,6 @@ var zipperMetrics = struct {
 
 	InfoRequests: expvar.NewInt("zipper_info_requests"),
 	InfoErrors:   expvar.NewInt("zipper_info_errors"),
-
-	Timeouts: expvar.NewInt("zipper_timeouts"),
 }
 
 // BuildVersion is provided to be overridden at build time. Eg. go build -ldflags -X 'main.BuildVersion=...'
@@ -240,7 +236,6 @@ func zipperStats(stats *zipperTypes.Stats) {
 	if stats == nil {
 		return
 	}
-	zipperMetrics.Timeouts.Add(stats.Timeouts)
 	zipperMetrics.FindErrors.Add(stats.FindErrors)
 	zipperMetrics.RenderErrors.Add(stats.RenderErrors)
 	zipperMetrics.InfoErrors.Add(stats.InfoErrors)
@@ -517,8 +512,6 @@ func setUpConfig(logger *zap.Logger) {
 
 		graphite.Register(fmt.Sprintf("%s.zipper.info_requests", pattern), zipperMetrics.InfoRequests)
 		graphite.Register(fmt.Sprintf("%s.zipper.info_errors", pattern), zipperMetrics.InfoErrors)
-
-		graphite.Register(fmt.Sprintf("%s.zipper.timeouts", pattern), zipperMetrics.Timeouts)
 
 		go mstats.Start(config.Graphite.Interval)
 

--- a/cmd/carbonapi/main.go
+++ b/cmd/carbonapi/main.go
@@ -81,11 +81,6 @@ var zipperMetrics = struct {
 	InfoErrors   *expvar.Int
 
 	Timeouts *expvar.Int
-
-	CacheSize   expvar.Func
-	CacheItems  expvar.Func
-	CacheMisses *expvar.Int
-	CacheHits   *expvar.Int
 }{
 	FindRequests: expvar.NewInt("zipper_find_requests"),
 	FindErrors:   expvar.NewInt("zipper_find_errors"),
@@ -97,9 +92,6 @@ var zipperMetrics = struct {
 	InfoErrors:   expvar.NewInt("zipper_info_errors"),
 
 	Timeouts: expvar.NewInt("zipper_timeouts"),
-
-	CacheHits:   expvar.NewInt("zipper_cache_hits"),
-	CacheMisses: expvar.NewInt("zipper_cache_misses"),
 }
 
 // BuildVersion is provided to be overridden at build time. Eg. go build -ldflags -X 'main.BuildVersion=...'
@@ -252,8 +244,6 @@ func zipperStats(stats *zipperTypes.Stats) {
 	zipperMetrics.FindErrors.Add(stats.FindErrors)
 	zipperMetrics.RenderErrors.Add(stats.RenderErrors)
 	zipperMetrics.InfoErrors.Add(stats.InfoErrors)
-	zipperMetrics.CacheMisses.Add(stats.CacheMisses)
-	zipperMetrics.CacheHits.Add(stats.CacheHits)
 }
 
 var graphTemplates map[string]png.PictureParams
@@ -529,9 +519,6 @@ func setUpConfig(logger *zap.Logger) {
 		graphite.Register(fmt.Sprintf("%s.zipper.info_errors", pattern), zipperMetrics.InfoErrors)
 
 		graphite.Register(fmt.Sprintf("%s.zipper.timeouts", pattern), zipperMetrics.Timeouts)
-
-		graphite.Register(fmt.Sprintf("%s.zipper.cache_hits", pattern), zipperMetrics.CacheHits)
-		graphite.Register(fmt.Sprintf("%s.zipper.cache_misses", pattern), zipperMetrics.CacheMisses)
 
 		go mstats.Start(config.Graphite.Interval)
 

--- a/cmd/carbonapi/main.go
+++ b/cmd/carbonapi/main.go
@@ -39,7 +39,9 @@ import (
 )
 
 var apiMetrics = struct {
-	Requests              *expvar.Int
+	Requests *expvar.Int
+	Errors   *expvar.Int
+
 	RenderRequests        *expvar.Int
 	RequestCacheHits      *expvar.Int
 	RequestCacheMisses    *expvar.Int
@@ -57,6 +59,8 @@ var apiMetrics = struct {
 	CacheItems expvar.Func
 }{
 	Requests: expvar.NewInt("requests"),
+	Errors:   expvar.NewInt("errors"),
+
 	// TODO: request_cache -> render_cache
 	RenderRequests:        expvar.NewInt("render_requests"),
 	RequestCacheHits:      expvar.NewInt("request_cache_hits"),
@@ -483,8 +487,10 @@ func setUpConfig(logger *zap.Logger) {
 		pattern = strings.Replace(pattern, "{fqdn}", hostname, -1)
 
 		graphite.Register(fmt.Sprintf("%s.requests", pattern), apiMetrics.Requests)
+		graphite.Register(fmt.Sprintf("%s.errors", pattern), apiMetrics.Errors)
 		graphite.Register(fmt.Sprintf("%s.request_cache_hits", pattern), apiMetrics.RequestCacheHits)
 		graphite.Register(fmt.Sprintf("%s.request_cache_misses", pattern), apiMetrics.RequestCacheMisses)
+
 		graphite.Register(fmt.Sprintf("%s.request_cache_overhead_ns", pattern), apiMetrics.RenderCacheOverheadNS)
 
 		for i := 0; i <= config.Buckets; i++ {

--- a/cmd/carbonapi/main.go
+++ b/cmd/carbonapi/main.go
@@ -74,8 +74,6 @@ var zipperMetrics = struct {
 	FindRequests *expvar.Int
 	FindErrors   *expvar.Int
 
-	SearchRequests *expvar.Int
-
 	RenderRequests *expvar.Int
 	RenderErrors   *expvar.Int
 
@@ -91,8 +89,6 @@ var zipperMetrics = struct {
 }{
 	FindRequests: expvar.NewInt("zipper_find_requests"),
 	FindErrors:   expvar.NewInt("zipper_find_errors"),
-
-	SearchRequests: expvar.NewInt("zipper_search_requests"),
 
 	RenderRequests: expvar.NewInt("zipper_render_requests"),
 	RenderErrors:   expvar.NewInt("zipper_render_errors"),
@@ -256,7 +252,6 @@ func zipperStats(stats *zipperTypes.Stats) {
 	zipperMetrics.FindErrors.Add(stats.FindErrors)
 	zipperMetrics.RenderErrors.Add(stats.RenderErrors)
 	zipperMetrics.InfoErrors.Add(stats.InfoErrors)
-	zipperMetrics.SearchRequests.Add(stats.SearchRequests)
 	zipperMetrics.CacheMisses.Add(stats.CacheMisses)
 	zipperMetrics.CacheHits.Add(stats.CacheHits)
 }

--- a/cmd/carbonapi/main.go
+++ b/cmd/carbonapi/main.go
@@ -236,8 +236,11 @@ func zipperStats(stats *zipperTypes.Stats) {
 	if stats == nil {
 		return
 	}
+	zipperMetrics.FindRequests.Add(stats.FindRequests)
 	zipperMetrics.FindErrors.Add(stats.FindErrors)
+	zipperMetrics.RenderRequests.Add(stats.RenderRequests)
 	zipperMetrics.RenderErrors.Add(stats.RenderErrors)
+	zipperMetrics.InfoRequests.Add(stats.InfoRequests)
 	zipperMetrics.InfoErrors.Add(stats.InfoErrors)
 }
 

--- a/cmd/carbonzipper/main.go
+++ b/cmd/carbonzipper/main.go
@@ -119,14 +119,10 @@ var Metrics = struct {
 
 	Timeouts *expvar.Int
 
-	CacheSize         expvar.Func
-	CacheItems        expvar.Func
-	CacheMisses       *expvar.Int
-	CacheHits         *expvar.Int
-	SearchCacheSize   expvar.Func
-	SearchCacheItems  expvar.Func
-	SearchCacheMisses *expvar.Int
-	SearchCacheHits   *expvar.Int
+	CacheSize   expvar.Func
+	CacheItems  expvar.Func
+	CacheMisses *expvar.Int
+	CacheHits   *expvar.Int
 }{
 	FindRequests: expvar.NewInt("find_requests"),
 	FindErrors:   expvar.NewInt("find_errors"),
@@ -141,10 +137,8 @@ var Metrics = struct {
 
 	Timeouts: expvar.NewInt("timeouts"),
 
-	CacheHits:         expvar.NewInt("cache_hits"),
-	CacheMisses:       expvar.NewInt("cache_misses"),
-	SearchCacheHits:   expvar.NewInt("search_cache_hits"),
-	SearchCacheMisses: expvar.NewInt("search_cache_misses"),
+	CacheHits:   expvar.NewInt("cache_hits"),
+	CacheMisses: expvar.NewInt("cache_misses"),
 }
 
 // BuildVersion is defined at build and reported at startup and as expvar
@@ -771,16 +765,10 @@ func main() {
 		/* TODO(civil): Find a way to return that data
 		graphite.Register(fmt.Sprintf("%s.cache_size", pattern), Metrics.CacheSize)
 		graphite.Register(fmt.Sprintf("%s.cache_items", pattern), Metrics.CacheItems)
-
-		graphite.Register(fmt.Sprintf("%s.search_cache_size", pattern), Metrics.SearchCacheSize)
-		graphite.Register(fmt.Sprintf("%s.search_cache_items", pattern), Metrics.SearchCacheItems)
 		*/
 
 		graphite.Register(fmt.Sprintf("%s.cache_hits", pattern), Metrics.CacheHits)
 		graphite.Register(fmt.Sprintf("%s.cache_misses", pattern), Metrics.CacheMisses)
-
-		graphite.Register(fmt.Sprintf("%s.search_cache_hits", pattern), Metrics.SearchCacheHits)
-		graphite.Register(fmt.Sprintf("%s.search_cache_misses", pattern), Metrics.SearchCacheMisses)
 
 		go mstats.Start(config.Graphite.Interval)
 
@@ -859,9 +847,6 @@ func sendStats(stats *types.Stats) {
 	Metrics.FindErrors.Add(stats.FindErrors)
 	Metrics.RenderErrors.Add(stats.RenderErrors)
 	Metrics.InfoErrors.Add(stats.InfoErrors)
-	Metrics.SearchRequests.Add(stats.SearchRequests)
-	Metrics.SearchCacheHits.Add(stats.SearchCacheHits)
-	Metrics.SearchCacheMisses.Add(stats.SearchCacheMisses)
 	Metrics.CacheMisses.Add(stats.CacheMisses)
 	Metrics.CacheHits.Add(stats.CacheHits)
 }

--- a/cmd/carbonzipper/main.go
+++ b/cmd/carbonzipper/main.go
@@ -812,7 +812,6 @@ func sendStats(stats *types.Stats) {
 	if stats == nil {
 		return
 	}
-	Metrics.Timeouts.Add(stats.Timeouts)
 	Metrics.FindErrors.Add(stats.FindErrors)
 	Metrics.RenderErrors.Add(stats.RenderErrors)
 	Metrics.InfoErrors.Add(stats.InfoErrors)

--- a/zipper/protocols/graphite/graphite_group.go
+++ b/zipper/protocols/graphite/graphite_group.go
@@ -196,7 +196,6 @@ func (c *GraphiteGroup) Find(ctx context.Context, request *protov3.MultiGlobRequ
 			continue
 		}
 
-		stats.Servers = append(stats.Servers, res.Server)
 		matches := make([]protov3.GlobMatch, 0, len(globs))
 		for _, m := range globs {
 			matches = append(matches, protov3.GlobMatch{
@@ -254,7 +253,6 @@ func (c *GraphiteGroup) Info(ctx context.Context, request *protov3.MultiMetricsI
 			e.Add(err)
 			continue
 		}
-		stats.Servers = append(stats.Servers, res.Server)
 
 		if info.AggregationMethod == "" {
 			info.AggregationMethod = "average"

--- a/zipper/protocols/graphite/graphite_group.go
+++ b/zipper/protocols/graphite/graphite_group.go
@@ -129,11 +129,14 @@ func (c *GraphiteGroup) Fetch(ctx context.Context, request *protov3.MultiFetchRe
 			"until":  []string{strconv.Itoa(int(request.Metrics[0].StopTime))},
 		}
 		rewrite.RawQuery = v.Encode()
+		stats.RenderRequests++
 		res, err := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), nil)
 		if err == nil {
 			err = &errors.Errors{}
 		}
+
 		if err.HaveFatalErrors {
+			stats.RenderErrors++
 			err.HaveFatalErrors = false
 			return nil, stats, err
 		}
@@ -142,6 +145,7 @@ func (c *GraphiteGroup) Fetch(ctx context.Context, request *protov3.MultiFetchRe
 		_, e := metrics.UnmarshalMsg(res.Response)
 		err.AddFatal(e)
 		if err.HaveFatalErrors {
+			stats.RenderErrors++
 			return nil, stats, err
 		}
 
@@ -184,14 +188,17 @@ func (c *GraphiteGroup) Find(ctx context.Context, request *protov3.MultiGlobRequ
 			"format": []string{c.protocol},
 		}
 		rewrite.RawQuery = v.Encode()
+		stats.FindRequests++
 		res, err := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), nil)
 		if err != nil {
+			stats.FindErrors++
 			e.Merge(err)
 			continue
 		}
 		var globs msgpack.MultiGraphiteGlobResponse
 		_, marshalErr := globs.UnmarshalMsg(res.Response)
 		if marshalErr != nil {
+			stats.FindErrors++
 			e.Add(marshalErr)
 			continue
 		}
@@ -241,8 +248,10 @@ func (c *GraphiteGroup) Info(ctx context.Context, request *protov3.MultiMetricsI
 			"format": []string{c.protocol},
 		}
 		rewrite.RawQuery = v.Encode()
+		stats.InfoRequests++
 		res, e2 := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), nil)
 		if e2 != nil {
+			stats.InfoErrors++
 			e.Merge(e2)
 			continue
 		}
@@ -250,6 +259,7 @@ func (c *GraphiteGroup) Info(ctx context.Context, request *protov3.MultiMetricsI
 		var info protov2.InfoResponse
 		err := info.Unmarshal(res.Response)
 		if err != nil {
+			stats.InfoErrors++
 			e.Add(err)
 			continue
 		}

--- a/zipper/protocols/grpc/grpc_group.go
+++ b/zipper/protocols/grpc/grpc_group.go
@@ -118,7 +118,6 @@ func (c *ClientGRPCGroup) Fetch(ctx context.Context, request *protov3.MultiFetch
 	if err != nil {
 		stats.RenderErrors++
 	}
-	stats.MemoryUsage = int64(res.Size())
 
 	return res, stats, errors.FromErrNonFatal(err)
 }
@@ -132,7 +131,6 @@ func (c *ClientGRPCGroup) Find(ctx context.Context, request *protov3.MultiGlobRe
 	if err != nil {
 		stats.RenderErrors++
 	}
-	stats.MemoryUsage = int64(res.Size())
 
 	return res, stats, errors.FromErrNonFatal(err)
 }
@@ -145,7 +143,6 @@ func (c *ClientGRPCGroup) Info(ctx context.Context, request *protov3.MultiMetric
 	if err != nil {
 		stats.RenderErrors++
 	}
-	stats.MemoryUsage = int64(res.Size())
 
 	r := &protov3.ZipperInfoResponse{
 		Info: map[string]protov3.MultiMetricsInfoResponse{
@@ -165,7 +162,6 @@ func (c *ClientGRPCGroup) List(ctx context.Context) (*protov3.ListMetricsRespons
 	if err != nil {
 		stats.RenderErrors++
 	}
-	stats.MemoryUsage = int64(res.Size())
 
 	return res, stats, errors.FromErrNonFatal(err)
 }
@@ -178,7 +174,6 @@ func (c *ClientGRPCGroup) Stats(ctx context.Context) (*protov3.MetricDetailsResp
 	if err != nil {
 		stats.RenderErrors++
 	}
-	stats.MemoryUsage = int64(res.Size())
 
 	return res, stats, errors.FromErrNonFatal(err)
 }

--- a/zipper/protocols/grpc/grpc_group.go
+++ b/zipper/protocols/grpc/grpc_group.go
@@ -110,17 +110,13 @@ func (c ClientGRPCGroup) Backends() []string {
 }
 
 func (c *ClientGRPCGroup) Fetch(ctx context.Context, request *protov3.MultiFetchRequest) (*protov3.MultiFetchResponse, *types.Stats, *errors.Errors) {
-	stats := &types.Stats{
-		Servers: []string{c.Name()},
-	}
+	stats := &types.Stats{}
 	ctx, cancel := context.WithTimeout(ctx, c.timeout.Render)
 	defer cancel()
 
 	res, err := c.client.FetchMetrics(ctx, request)
 	if err != nil {
 		stats.RenderErrors++
-		stats.FailedServers = stats.Servers
-		stats.Servers = []string{}
 	}
 	stats.MemoryUsage = int64(res.Size())
 
@@ -128,34 +124,26 @@ func (c *ClientGRPCGroup) Fetch(ctx context.Context, request *protov3.MultiFetch
 }
 
 func (c *ClientGRPCGroup) Find(ctx context.Context, request *protov3.MultiGlobRequest) (*protov3.MultiGlobResponse, *types.Stats, *errors.Errors) {
-	stats := &types.Stats{
-		Servers: []string{c.Name()},
-	}
+	stats := &types.Stats{}
 	ctx, cancel := context.WithTimeout(ctx, c.timeout.Find)
 	defer cancel()
 
 	res, err := c.client.FindMetrics(ctx, request)
 	if err != nil {
 		stats.RenderErrors++
-		stats.FailedServers = stats.Servers
-		stats.Servers = []string{}
 	}
 	stats.MemoryUsage = int64(res.Size())
 
 	return res, stats, errors.FromErrNonFatal(err)
 }
 func (c *ClientGRPCGroup) Info(ctx context.Context, request *protov3.MultiMetricsInfoRequest) (*protov3.ZipperInfoResponse, *types.Stats, *errors.Errors) {
-	stats := &types.Stats{
-		Servers: []string{c.Name()},
-	}
+	stats := &types.Stats{}
 	ctx, cancel := context.WithTimeout(ctx, c.timeout.Render)
 	defer cancel()
 
 	res, err := c.client.MetricsInfo(ctx, request)
 	if err != nil {
 		stats.RenderErrors++
-		stats.FailedServers = stats.Servers
-		stats.Servers = []string{}
 	}
 	stats.MemoryUsage = int64(res.Size())
 
@@ -169,34 +157,26 @@ func (c *ClientGRPCGroup) Info(ctx context.Context, request *protov3.MultiMetric
 }
 
 func (c *ClientGRPCGroup) List(ctx context.Context) (*protov3.ListMetricsResponse, *types.Stats, *errors.Errors) {
-	stats := &types.Stats{
-		Servers: []string{c.Name()},
-	}
+	stats := &types.Stats{}
 	ctx, cancel := context.WithTimeout(ctx, c.timeout.Render)
 	defer cancel()
 
 	res, err := c.client.ListMetrics(ctx, types.EmptyMsg)
 	if err != nil {
 		stats.RenderErrors++
-		stats.FailedServers = stats.Servers
-		stats.Servers = []string{}
 	}
 	stats.MemoryUsage = int64(res.Size())
 
 	return res, stats, errors.FromErrNonFatal(err)
 }
 func (c *ClientGRPCGroup) Stats(ctx context.Context) (*protov3.MetricDetailsResponse, *types.Stats, *errors.Errors) {
-	stats := &types.Stats{
-		Servers: []string{c.Name()},
-	}
+	stats := &types.Stats{}
 	ctx, cancel := context.WithTimeout(ctx, c.timeout.Render)
 	defer cancel()
 
 	res, err := c.client.Stats(ctx, types.EmptyMsg)
 	if err != nil {
 		stats.RenderErrors++
-		stats.FailedServers = stats.Servers
-		stats.Servers = []string{}
 	}
 	stats.MemoryUsage = int64(res.Size())
 

--- a/zipper/protocols/grpc/grpc_group.go
+++ b/zipper/protocols/grpc/grpc_group.go
@@ -114,6 +114,7 @@ func (c *ClientGRPCGroup) Fetch(ctx context.Context, request *protov3.MultiFetch
 	ctx, cancel := context.WithTimeout(ctx, c.timeout.Render)
 	defer cancel()
 
+	stats.RenderRequests++
 	res, err := c.client.FetchMetrics(ctx, request)
 	if err != nil {
 		stats.RenderErrors++
@@ -127,9 +128,10 @@ func (c *ClientGRPCGroup) Find(ctx context.Context, request *protov3.MultiGlobRe
 	ctx, cancel := context.WithTimeout(ctx, c.timeout.Find)
 	defer cancel()
 
+	stats.FindRequests++
 	res, err := c.client.FindMetrics(ctx, request)
 	if err != nil {
-		stats.RenderErrors++
+		stats.FindErrors++
 	}
 
 	return res, stats, errors.FromErrNonFatal(err)
@@ -139,6 +141,7 @@ func (c *ClientGRPCGroup) Info(ctx context.Context, request *protov3.MultiMetric
 	ctx, cancel := context.WithTimeout(ctx, c.timeout.Render)
 	defer cancel()
 
+	stats.InfoRequests++
 	res, err := c.client.MetricsInfo(ctx, request)
 	if err != nil {
 		stats.RenderErrors++

--- a/zipper/protocols/v2/protobuf_group.go
+++ b/zipper/protocols/v2/protobuf_group.go
@@ -205,7 +205,6 @@ func (c *ClientProtoV2Group) Find(ctx context.Context, request *protov3.MultiGlo
 			e.Add(marshalErr)
 			continue
 		}
-		stats.Servers = append(stats.Servers, res.Server)
 		matches := make([]protov3.GlobMatch, 0, len(globs.Matches))
 		for _, m := range globs.Matches {
 			matches = append(matches, protov3.GlobMatch{
@@ -263,7 +262,6 @@ func (c *ClientProtoV2Group) Info(ctx context.Context, request *protov3.MultiMet
 			e.Add(err)
 			continue
 		}
-		stats.Servers = append(stats.Servers, res.Server)
 
 		if info.AggregationMethod == "" {
 			info.AggregationMethod = "average"

--- a/zipper/protocols/v3/protobuf_group.go
+++ b/zipper/protocols/v3/protobuf_group.go
@@ -117,16 +117,19 @@ func (c *ClientProtoV3Group) Fetch(ctx context.Context, request *protov3.MultiFe
 	}
 	rewrite.RawQuery = v.Encode()
 
+	stats.RenderRequests++
 	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiFetchRequestV3{*request})
 	if e == nil {
 		e = &errors.Errors{}
 	}
 
 	if e.HaveFatalErrors {
+		stats.RenderErrors++
 		return nil, stats, e
 	}
 
 	if res == nil {
+		stats.RenderErrors++
 		return nil, stats, errors.FromErrNonFatal(types.ErrNoResponseFetched)
 	}
 	var metrics protov3.MultiFetchResponse
@@ -136,6 +139,7 @@ func (c *ClientProtoV3Group) Fetch(ctx context.Context, request *protov3.MultiFe
 	}
 
 	if e.HaveFatalErrors {
+		stats.RenderErrors++
 		e.HaveFatalErrors = false
 		return nil, stats, e
 	}
@@ -152,16 +156,19 @@ func (c *ClientProtoV3Group) Find(ctx context.Context, request *protov3.MultiGlo
 	}
 	rewrite.RawQuery = v.Encode()
 
+	stats.FindRequests++
 	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiGlobRequestV3{*request})
 	if e == nil {
 		e = &errors.Errors{}
 	}
 
 	if e.HaveFatalErrors {
+		stats.FindErrors++
 		return nil, stats, e
 	}
 
 	if res == nil {
+		stats.FindErrors++
 		return nil, stats, errors.FromErrNonFatal(types.ErrNotFound)
 	}
 	var globs protov3.MultiGlobResponse
@@ -182,16 +189,19 @@ func (c *ClientProtoV3Group) Info(ctx context.Context, request *protov3.MultiMet
 	}
 	rewrite.RawQuery = v.Encode()
 
+	stats.InfoRequests++
 	res, e := c.httpQuery.DoQuery(ctx, rewrite.RequestURI(), types.MultiMetricsInfoV3{*request})
 	if e == nil {
 		e = &errors.Errors{}
 	}
 
 	if e.HaveFatalErrors {
+		stats.InfoErrors++
 		return nil, stats, e
 	}
 
 	if res == nil {
+		stats.InfoErrors++
 		return nil, stats, errors.FromErrNonFatal(types.ErrNoResponseFetched)
 	}
 	var infos protov3.MultiMetricsInfoResponse

--- a/zipper/protocols/v3/protobuf_group.go
+++ b/zipper/protocols/v3/protobuf_group.go
@@ -200,8 +200,6 @@ func (c *ClientProtoV3Group) Info(ctx context.Context, request *protov3.MultiMet
 		return nil, nil, errors.FromErrNonFatal(err)
 	}
 
-	stats.MemoryUsage = int64(infos.Size())
-
 	r := &protov3.ZipperInfoResponse{
 		Info: map[string]protov3.MultiMetricsInfoResponse{
 			c.Name(): infos,

--- a/zipper/types/stats.go
+++ b/zipper/types/stats.go
@@ -9,9 +9,6 @@ type Stats struct {
 	ZipperRequests int64
 
 	MemoryUsage int64
-
-	CacheMisses int64
-	CacheHits   int64
 }
 
 func (s *Stats) Merge(stats *Stats) {
@@ -20,6 +17,4 @@ func (s *Stats) Merge(stats *Stats) {
 	s.RenderErrors += stats.RenderErrors
 	s.InfoErrors += stats.InfoErrors
 	s.MemoryUsage += stats.MemoryUsage
-	s.CacheMisses += stats.CacheMisses
-	s.CacheHits += stats.CacheHits
 }

--- a/zipper/types/stats.go
+++ b/zipper/types/stats.go
@@ -15,9 +15,6 @@ type Stats struct {
 
 	CacheMisses int64
 	CacheHits   int64
-
-	Servers       []string
-	FailedServers []string
 }
 
 func (s *Stats) Merge(stats *Stats) {
@@ -31,6 +28,4 @@ func (s *Stats) Merge(stats *Stats) {
 	s.MemoryUsage += stats.MemoryUsage
 	s.CacheMisses += stats.CacheMisses
 	s.CacheHits += stats.CacheHits
-	s.Servers = append(s.Servers, stats.Servers...)
-	s.FailedServers = append(s.FailedServers, stats.FailedServers...)
 }

--- a/zipper/types/stats.go
+++ b/zipper/types/stats.go
@@ -7,12 +7,10 @@ type Stats struct {
 	InfoErrors     int64
 	ZipperRequests int64
 
-	MemoryUsage int64
 }
 
 func (s *Stats) Merge(stats *Stats) {
 	s.FindErrors += stats.FindErrors
 	s.RenderErrors += stats.RenderErrors
 	s.InfoErrors += stats.InfoErrors
-	s.MemoryUsage += stats.MemoryUsage
 }

--- a/zipper/types/stats.go
+++ b/zipper/types/stats.go
@@ -2,7 +2,6 @@ package types
 
 // Stats provides zipper-related statistics
 type Stats struct {
-	Timeouts       int64
 	FindErrors     int64
 	RenderErrors   int64
 	InfoErrors     int64
@@ -12,7 +11,6 @@ type Stats struct {
 }
 
 func (s *Stats) Merge(stats *Stats) {
-	s.Timeouts += stats.Timeouts
 	s.FindErrors += stats.FindErrors
 	s.RenderErrors += stats.RenderErrors
 	s.InfoErrors += stats.InfoErrors

--- a/zipper/types/stats.go
+++ b/zipper/types/stats.go
@@ -2,15 +2,25 @@ package types
 
 // Stats provides zipper-related statistics
 type Stats struct {
-	FindErrors     int64
-	RenderErrors   int64
-	InfoErrors     int64
-	ZipperRequests int64
+	FindRequests int64
+	FindErrors   int64
 
+	RenderRequests int64
+	RenderErrors   int64
+
+	InfoRequests int64
+	InfoErrors   int64
+
+	ZipperRequests int64
 }
 
 func (s *Stats) Merge(stats *Stats) {
+	s.FindRequests += stats.FindRequests
 	s.FindErrors += stats.FindErrors
+
+	s.RenderRequests += stats.RenderRequests
 	s.RenderErrors += stats.RenderErrors
+
+	s.InfoRequests += stats.InfoRequests
 	s.InfoErrors += stats.InfoErrors
 }

--- a/zipper/types/stats.go
+++ b/zipper/types/stats.go
@@ -2,14 +2,11 @@ package types
 
 // Stats provides zipper-related statistics
 type Stats struct {
-	Timeouts          int64
-	FindErrors        int64
-	RenderErrors      int64
-	InfoErrors        int64
-	SearchRequests    int64
-	SearchCacheHits   int64
-	SearchCacheMisses int64
-	ZipperRequests    int64
+	Timeouts       int64
+	FindErrors     int64
+	RenderErrors   int64
+	InfoErrors     int64
+	ZipperRequests int64
 
 	MemoryUsage int64
 
@@ -22,9 +19,6 @@ func (s *Stats) Merge(stats *Stats) {
 	s.FindErrors += stats.FindErrors
 	s.RenderErrors += stats.RenderErrors
 	s.InfoErrors += stats.InfoErrors
-	s.SearchRequests += stats.SearchRequests
-	s.SearchCacheHits += stats.SearchCacheHits
-	s.SearchCacheMisses += stats.SearchCacheMisses
 	s.MemoryUsage += stats.MemoryUsage
 	s.CacheMisses += stats.CacheMisses
 	s.CacheHits += stats.CacheHits


### PR DESCRIPTION
This series of commits is aimed at the metrics we write to Graphite. We delete some dead code, populate the zipper.Stats we pass around in the various requests, and count carbonapi total requests and errors.