### PR TITLE
Add logging for metric count

### DIFF
--- a/carbonapipb/carbonapi.pb.go
+++ b/carbonapipb/carbonapi.pb.go
@@ -29,4 +29,5 @@ type AccessLogDetails struct {
 	URI                           string   `json:"uri,omitempty"`
 	FromCache                     bool     `json:"from_cache"`
 	ZipperRequests                int64    `json:"zipper_requests,omitempty"`
+	TotalMetricsCount             int64    `json:"total_metrics_count,omitempty"`
 }

--- a/cmd/carbonapi/http_handlers.go
+++ b/cmd/carbonapi/http_handlers.go
@@ -299,6 +299,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 			r, stats, err := config.zipper.Render(ctx, req)
 			if stats != nil {
 				accessLogDetails.ZipperRequests += stats.ZipperRequests
+				accessLogDetails.TotalMetricsCount += stats.TotalMetricsCount
 			}
 			if err != nil {
 				errors[target] = err.Error()
@@ -613,6 +614,7 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 	multiGlobs, stats, err := config.zipper.Find(ctx, query)
 	if stats != nil {
 		accessLogDetails.ZipperRequests = stats.ZipperRequests
+		accessLogDetails.TotalMetricsCount += stats.TotalMetricsCount
 	}
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -725,6 +727,7 @@ func infoHandler(w http.ResponseWriter, r *http.Request) {
 	data, stats, err := config.zipper.Info(ctx, query)
 	if stats != nil {
 		accessLogDetails.ZipperRequests = stats.ZipperRequests
+		accessLogDetails.TotalMetricsCount += stats.TotalMetricsCount
 	}
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/zipper/types/response.go
+++ b/zipper/types/response.go
@@ -23,7 +23,7 @@ type ServerInfoResponse struct {
 
 func NewServerInfoResponse() *ServerInfoResponse {
 	return &ServerInfoResponse{
-		Response: new(protov3.ZipperInfoResponse),
+		Response: &protov3.ZipperInfoResponse{Info: make(map[string]protov3.MultiMetricsInfoResponse)},
 		Stats:    new(Stats),
 		Err:      new(errors.Errors),
 	}

--- a/zipper/types/stats.go
+++ b/zipper/types/stats.go
@@ -10,6 +10,7 @@ type Stats struct {
 	SearchCacheHits   int64
 	SearchCacheMisses int64
 	ZipperRequests    int64
+	TotalMetricsCount int64
 
 	MemoryUsage int64
 


### PR DESCRIPTION
This is especially important for fetch/render requests. Logging the metric counts after requests
are globbed/expanded in render requests.
Also, fixed a bug with info requests due to nil map in
ServerInfoResponse Info field.