### PR TITLE
Fix concurrency limit bug

### DIFF
--- a/zipper/zipper.go
+++ b/zipper/zipper.go
@@ -148,7 +148,7 @@ func createBackendsV2(logger *zap.Logger, backends types.BackendsV2, expireDelay
 				backends = append(backends, client)
 			}
 
-			client, ePtr = broadcast.NewBroadcastGroup(logger, backend.GroupName, backends, expireDelaySec, concurencyLimit, timeouts)
+			client, ePtr = broadcast.NewBroadcastGroup(logger, backend.GroupName, backends, expireDelaySec, *backend.ConcurrencyLimit, timeouts)
 			e.Merge(ePtr)
 			if e.HaveFatalErrors {
 				return nil, &e


### PR DESCRIPTION
Fix concurrency limit bug, where the concurrency limit for a backend group was being set to the concurrency limit for the
backends, the default value specified in backendsv2 config.