### PR TITLE
fix getFetchRequestMetricStats index out of range

### DIFF
--- a/zipper/broadcast/broadcast_group.go
+++ b/zipper/broadcast/broadcast_group.go
@@ -258,12 +258,13 @@ GATHER:
 }
 
 func getFetchRequestMetricStats(requests []*protov3.MultiFetchRequest, bg *BroadcastGroup, clients []types.ServerClient) (int, int) {
-	totalMetricsCount := (len(requests)-1)*bg.MaxMetricsPerRequest() + len(requests[len(requests)-1].Metrics)
+	var totalMetricsCount int
 	var zipperRequests int
 	if bg.MaxMetricsPerRequest() > 0 {
 		zipperRequests = 1
 	}
 	if len(requests) > 0 {
+		totalMetricsCount = (len(requests)-1)*bg.MaxMetricsPerRequest() + len(requests[len(requests)-1].Metrics)
 		zipperRequests += len(requests) * len(clients)
 	}
 	return zipperRequests, totalMetricsCount


### PR DESCRIPTION
Sometimes len(requests) == 0 and carbonapi serving panic

2018/10/01 08:32:46 http: panic serving 127.0.0.1:55376: runtime error: index out of range
goroutine 446 [running]:
net/http.(*conn).serve.func1(0xc420085220)
        /usr/local/go/src/net/http/server.go:1697 +0xd0
panic(0xcbfde0, 0x12b1a20)
        /usr/local/go/src/runtime/panic.go:491 +0x283
github.com/go-graphite/carbonapi/zipper/broadcast.getFetchRequestMetricStats(...)
        /go/src/github.com/go-graphite/carbonapi/zipper/broadcast/broadcast_group.go:261
github.com/go-graphite/carbonapi/zipper/broadcast.(*BroadcastGroup).Fetch(0xc4201f3180, 0x1278740, 0xc420216a20, 0xc420228040, 0x0, 0x0, 0x0)
        /go/src/github.com/go-graphite/carbonapi/zipper/broadcast/broadcast_group.go:200 +0x1674
github.com/go-graphite/carbonapi/zipper.Zipper.FetchProtoV3(0xc420167000, 0xc420168300, 0xc420168360, 0x9184e72a000, 0x1dcd6500, 0x6fc23ac00, 0x0, 0x0, 0x0, 0x0, ...)
        /go/src/github.com/go-graphite/carbonapi/zipper/zipper.go:379 +0xf7f
main.zipper.Render(0xc4201f3280, 0xc4202359e0, 0xdee278, 0xc4204ae100, 0x1278740, 0xc420216a20, 0xc4202ea720, 0x1, 0x1, 0xc400000000, ...)
        /go/src/github.com/go-graphite/carbonapi/cmd/carbonapi/zipper.go:105 +0x108
main.(*zipper).Render(0xc4202da000, 0x1278740, 0xc420216a20, 0xc4202ea720, 0x1, 0x1, 0x0, 0x1, 0x0, 0x0, ...)
        <autogenerated>:1 +0xbf
