### PR TITLE
fix Windowed.Push on empty arg

### DIFF
--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -23,6 +23,10 @@ type Windowed struct {
 
 // Push pushes data
 func (w *Windowed) Push(n float64) {
+	if len(w.Data) == 0 {
+		return
+	}
+
 	old := w.Data[w.head]
 
 	w.length++


### PR DESCRIPTION
runtime error: index out of range
github.com/go-graphite/carbonapi/expr/types.(*Windowed).Push
        /go/src/github.com/go-graphite/carbonapi/expr/types/windowed.go:26