### PR TITLE
fix build without cairo

### DIFF
--- a/expr/functions/cairo/png/pixel_ratio.go
+++ b/expr/functions/cairo/png/pixel_ratio.go
@@ -1,3 +1,5 @@
+// +build cairo
+
 package png
 
 import "github.com/evmar/gocairo/cairo"


### PR DESCRIPTION
currently it's impossible to build carbonapi without cairo (regression is introduced by c66ce1e0049415aad6ad3497c6535526e2d259c8)