### PR TITLE
pkg/parser: fix type switch case order

### DIFF
--- a/pkg/parser/internal.go
+++ b/pkg/parser/internal.go
@@ -87,10 +87,10 @@ func sliceExpr(args []interface{}) ([]*expr, map[string]*expr) {
 			res = append(res, NewConstExpr(float64(v)).toExpr().(*expr))
 		case string:
 			res = append(res, NewTargetExpr(v).toExpr().(*expr))
-		case Expr:
-			res = append(res, v.toExpr().(*expr))
 		case *expr:
 			res = append(res, v)
+		case Expr:
+			res = append(res, v.toExpr().(*expr))
 		case NamedArgs:
 			nArgsNew := mapExpr(v)
 			nArgs = mergeNamedArgs(nArgs, nArgsNew)


### PR DESCRIPTION
Type switch executes its clauses sequentially until the first match.
The `*expr` type implements `Expr`, so if `Expr` goes
before `*expr` case, it will catch `*expr` values and will
never let `case *expr` to execute. The solution is simple, move
specific type case before the interface it implements.

Found using gocritic linter, `caseOrder` checker.