### PR TITLE
Correct  #403 bad parsing of datapoints

### DIFF
--- a/expr/functions/graphiteWeb/function.go
+++ b/expr/functions/graphiteWeb/function.go
@@ -433,7 +433,7 @@ func (f *graphiteWeb) Do(e parser.Expr, from, until int64, values map[parser.Met
 			ConsolidationFunc: m.ConsolidationFunc,
 		}
 		for i, v := range m.Datapoints {
-			pbResp.Values[i] = v[1]
+			pbResp.Values[i] = v[0]
 		}
 		res = append(res, &types.MetricData{
 			FetchResponse: pbResp,


### PR DESCRIPTION
value is always in first element , date in the the second element  of datapoint json array deleiver by graphite web