### PR TITLE
handle evalExpr error in groupByTags

### DIFF
--- a/expr/functions/groupByTags/function.go
+++ b/expr/functions/groupByTags/function.go
@@ -91,7 +91,10 @@ func (f *groupByTags) Do(e parser.Expr, from, until int64, values map[parser.Met
 			parser.MetricRequest{"stub", from, until}: v,
 		}
 
-		r, _ := f.Evaluator.EvalExpr(nexpr, from, until, nvalues)
+		r, err := f.Evaluator.EvalExpr(nexpr, from, until, nvalues)
+		if err != nil {
+			return nil, err
+		}
 		if r != nil {
 			r[0].Name = names[k] + k
 			results = append(results, r...)


### PR DESCRIPTION
No check for EvalExpr result in groupByTags. With this patch in future possible push error to next level and return error code to client (after render Handler error checking refactoring).