### PR TITLE
fix average in averageSeries

### DIFF
--- a/expr/functions/averageSeries/function.go
+++ b/expr/functions/averageSeries/function.go
@@ -19,7 +19,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	f := &averageSeries{}
 	res := make([]interfaces.FunctionMetadata, 0)
-	for _, n := range []string{"avg", "averageSeries"} {
+	for _, n := range []string{"avg", "average", "averageSeries"} {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
 	return res


### PR DESCRIPTION
As I wrote today, aggregations in groupByTags is not complete as graphite-web.
This patch add average to averageSeries aliases.