### PR TITLE
BUILD.md : fix golang version's requirement

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -13,7 +13,7 @@ PNG/SVG support is optional (but enabled by default if you are using Makefile) a
 Requirements
 ------------
 
- - golang 1.7 or newer.
+ - golang 1.11 or newer.
  - For PNG/SVG support only: cairo 1.12.0 or newer.
  - dep (https://github.com/golang/dep) for dependancy management
 


### PR DESCRIPTION
I tried to build carbonapi using golang 1.10 .   
The following error was output.
```
# make nocairo
GO111MODULE=on go build -mod=vendor -ldflags '-X main.BuildVersion=0.12.6' github.com/go-graphite/carbonapi/cmd/carbonapi
flag provided but not defined: -mod
usage: build [-o output] [-i] [build flags] [packages]
Run 'go help build' for details.
Makefile:20: recipe for target 'nocairo' failed
make: *** [nocairo] Error 2
```
  
All "go build" lines in MakeFile contain a "-mod" option.  
```
$ grep "build" Makefile
        PKG_CONFIG_PATH="$(EXTRA_PKG_CONFIG_PATH)" GO111MODULE=on $(GO) build -mod=vendor -v -tags cairo -ldflags '-X main.BuildVersion=$(VERSION)' $(PKG_CARBONAPI)
        PKG_CONFIG_PATH="$(EXTRA_PKG_CONFIG_PATH)" GO111MODULE=on $(GO) build -mod=vendor -v -tags cairo -ldflags '-X main.BuildVersion=$(VERSION)' -gcflags=all='-l -N' $(PKG_CARBONAPI)
        GO111MODULE=on $(GO) build -mod=vendor -ldflags '-X main.BuildVersion=$(VERSION)' $(PKG_CARBONAPI)
        GO111MODULE=on $(GO) build -mod=vendor --ldflags '-X main.BuildVersion=$(VERSION)' $(PKG_CARBONZIPPER)
```

I confirmed that the "-mod" option of go command exists on golang 1.11 or newer.
* https://github.com/golang/go/blob/release-branch.go1.10/src/cmd/go/alldocs.go
* https://github.com/golang/go/blob/release-branch.go1.11/src/cmd/go/alldocs.go

So I fixed golang version's requirement.  