### PR TITLE
Allow / char in metric

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -505,7 +505,8 @@ func IsNameChar(r byte) bool {
 		r == '[' || r == ']' ||
 		r == '^' || r == '$' ||
 		r == '<' || r == '>' ||
-		r == '&' || r == '#'
+		r == '&' || r == '#' ||
+		r == '/'
 }
 
 func isDigit(r byte) bool {


### PR DESCRIPTION
This allows '/' to be in the metric name. This character is already valid in graphite as well.