### PR TITLE
add ignoreHTTPError option

### DIFF
--- a/cmd/carbonapi/config/config.go
+++ b/cmd/carbonapi/config/config.go
@@ -76,7 +76,7 @@ type ConfigType struct {
 	Define                     []Define           `mapstructure:"define"`
 	Prefix                     string             `mapstructure:"prefix"`
 	Expvar                     ExpvarConfig       `mapstructure:"expvar"`
-	NotFoundStatusCode         int                `mapstructure:"notFoundStatusCode"`
+	IgnoreHTTPError            bool               `mapstructure:"ignoreHTTPError"`
 
 	QueryCache cache.BytesCache `mapstructure:"-" json:"-"`
 	FindCache  cache.BytesCache `mapstructure:"-" json:"-"`
@@ -146,5 +146,5 @@ var Config = ConfigType{
 		Enabled:      true,
 		PProfEnabled: false,
 	},
-	NotFoundStatusCode: 404,
+	IgnoreHTTPError: true,
 }


### PR DESCRIPTION
In graphite-web, all rendering errors will only return empty results, no errors will be returned. For example, divide by an empty series.

It may not be reasonable, but I want them to be consistent, we have some systems that expect the graphite api to never return an error.