### PR TITLE
sortBy implementation

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -127,8 +127,6 @@ _When `format=png`_ (default if not specified)
 | setXFilesFactor |
 | sin |
 | sinFunction |
-| smartSummarize |
-| sortBy |
 | timeSlice |
 | unique |
 | verticalLine |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -245,6 +245,8 @@ _When `format=png`_ (default if not specified)
 | scaleToSeconds(seriesList, seconds) | no |
 | secondYAxis(seriesList) | no |
 | seriesByTag(*tagExpressions) | no |
+| smartSummarize(seriesList, intervalString, func='sum', alignTo=None) | no |
+| sortBy(seriesList, func='average', reverse=False) | no |
 | sortByMaxima(seriesList) | no |
 | sortByMinima(seriesList) | no |
 | sortByName(seriesList, natural=False, reverse=False) | no |

--- a/expr/functions/sortBy/function.go
+++ b/expr/functions/sortBy/function.go
@@ -43,6 +43,9 @@ func (f *sortBy) Do(e parser.Expr, from, until int64, values map[parser.MetricRe
 	ascending := !reverse
 
 	sortByFunc, err := e.GetStringArgDefault(1, "average")
+	if err != nil {
+		return nil, err
+	}
 
 	aggFuncMap := map[string]struct {
 		name      string

--- a/expr/functions/sortBy/function.go
+++ b/expr/functions/sortBy/function.go
@@ -1,6 +1,7 @@
 package sortBy
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/go-graphite/carbonapi/expr/consolidations"
@@ -21,7 +22,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &sortBy{}
-	functions := []string{"sortByMaxima", "sortByMinima", "sortByTotal"}
+	functions := []string{"sortByMaxima", "sortByMinima", "sortByTotal", "sortBy"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
@@ -35,24 +36,54 @@ func (f *sortBy) Do(e parser.Expr, from, until int64, values map[parser.MetricRe
 		return nil, err
 	}
 
+	reverse, err := e.GetBoolArgDefault(2, false)
+	if err != nil {
+		return nil, err
+	}
+	ascending := !reverse
+
+	sortByFunc, err := e.GetStringArgDefault(1, "average")
+
+	aggFuncMap := map[string]struct {
+		name      string
+		ascending bool
+	}{
+		"sortByTotal":  {"sum", false},
+		"sortByMaxima": {"max", false},
+		"sortByMinima": {"min", true},
+		"sortBy":       {sortByFunc, true},
+	}
+
+	target := e.Target()
+	aggFunc, exists := aggFuncMap[target]
+	if !exists {
+		return nil, fmt.Errorf("invalid function called: %s", target)
+	}
+
+	// some function by default are not ascending so we need to reverse behaviour
+	if !aggFunc.ascending {
+		ascending = !ascending
+	}
+
+	return doSort(aggFunc.name, ascending, original), nil
+}
+
+func doSort(aggFuncName string, ascending bool, original []*types.MetricData) []*types.MetricData {
 	arg := make([]*types.MetricData, len(original))
 	copy(arg, original)
 	vals := make([]float64, len(arg))
 
 	for i, a := range arg {
-		switch e.Target() {
-		case "sortByTotal":
-			vals[i] = consolidations.SummarizeValues("sum", a.Values)
-		case "sortByMaxima":
-			vals[i] = consolidations.SummarizeValues("max", a.Values)
-		case "sortByMinima":
-			vals[i] = 1 / consolidations.SummarizeValues("min", a.Values)
-		}
+		vals[i] = consolidations.SummarizeValues(aggFuncName, a.Values)
 	}
 
-	sort.Sort(helper.ByVals{Vals: vals, Series: arg})
+	if ascending {
+		sort.Sort(helper.ByVals{Vals: vals, Series: arg})
+	} else {
+		sort.Sort(sort.Reverse(helper.ByVals{Vals: vals, Series: arg}))
+	}
 
-	return arg, nil
+	return arg
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
@@ -97,6 +128,30 @@ func (f *sortBy) Description() map[string]types.FunctionDescription {
 					Name:     "seriesList",
 					Required: true,
 					Type:     types.SeriesList,
+				},
+			},
+		},
+		"sortBy": {
+			Description: "Takes one metric or a wildcard seriesList followed by an aggregation function and an optional reverse parameter.\nReturns the metrics sorted according to the specified function.",
+			Function:    "sortBy(seriesList, func='average', reverse=False)",
+			Group:       "Sorting",
+			Module:      "graphite.render.functions",
+			Name:        "sortBy",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "func",
+					Required: false,
+					Type:     types.AggFunc,
+				},
+				{
+					Name:     "reverse",
+					Required: false,
+					Type:     types.Boolean,
 				},
 			},
 		},

--- a/expr/functions/sortBy/function_test.go
+++ b/expr/functions/sortBy/function_test.go
@@ -70,6 +70,52 @@ func TestFunction(t *testing.T) {
 				types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 			},
 		},
+		{
+			"sortBy(metric*)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+					types.MakeMetricData("metricC", []float64{1, 2, 3, 4, 5, 6}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+				types.MakeMetricData("metricC", []float64{1, 2, 3, 4, 5, 6}, 1, now32),
+				types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+			},
+		},
+		{
+			"sortBy(metric*, 'median')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					types.MakeMetricData("metricB", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					types.MakeMetricData("metricC", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+				types.MakeMetricData("metricB", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+				types.MakeMetricData("metricC", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+			},
+		},
+
+		{
+			"sortBy(metric*, 'max', true)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+				types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+				types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/helper/sort.go
+++ b/expr/helper/sort.go
@@ -27,8 +27,7 @@ func (s ByVals) Swap(i, j int) {
 
 // Less compares two elements with specified IDs, required to be sortable
 func (s ByVals) Less(i, j int) bool {
-	// actually "greater than"
-	return s.Vals[i] > s.Vals[j]
+	return s.Vals[i] < s.Vals[j]
 }
 
 // ByName sorts metrics by name


### PR DESCRIPTION
Implementing `sortBy/3` to match graphite's ones. I will try to compare results from Graphite and my changes (this and https://github.com/go-graphite/carbonapi/pull/437) and if there are differences I'll try to fix them in following PRs.

No tests changes for existing `sortBy*` functions, so no breaking changes for this field.

I'm open for some optimizations proposals. I wasn't trying to make it as fast as possible here by complicating code, but there is place for speeding up this code if needed.