### PR TITLE
fix response when no metrics found

### DIFF
--- a/cmd/carbonapi/http/find_handlers.go
+++ b/cmd/carbonapi/http/find_handlers.go
@@ -352,5 +352,5 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeResponse(w, b, format, jsonp)
+	writeResponse(w, http.StatusOK, b, format, jsonp)
 }

--- a/cmd/carbonapi/http/helper.go
+++ b/cmd/carbonapi/http/helper.go
@@ -151,37 +151,43 @@ func getFormat(r *http.Request, defaultFormat responseFormat) (responseFormat, b
 	return f, ok, format
 }
 
-func writeResponse(w http.ResponseWriter, b []byte, format responseFormat, jsonp string) {
-
+func writeResponse(w http.ResponseWriter, returnCode int, b []byte, format responseFormat, jsonp string) {
 	switch format {
 	case jsonFormat:
 		if jsonp != "" {
 			w.Header().Set("Content-Type", contentTypeJavaScript)
+			w.WriteHeader(returnCode)
 			w.Write([]byte(jsonp))
 			w.Write([]byte{'('})
 			w.Write(b)
 			w.Write([]byte{')'})
 		} else {
 			w.Header().Set("Content-Type", contentTypeJSON)
+			w.WriteHeader(returnCode)
 			w.Write(b)
 		}
 	case protoV2Format, protoV3Format:
 		w.Header().Set("Content-Type", contentTypeProtobuf)
+		w.WriteHeader(returnCode)
 		w.Write(b)
 	case rawFormat:
 		w.Header().Set("Content-Type", contentTypeRaw)
+		w.WriteHeader(returnCode)
 		w.Write(b)
 	case pickleFormat:
 		w.Header().Set("Content-Type", contentTypePickle)
+		w.WriteHeader(returnCode)
 		w.Write(b)
 	case csvFormat:
 		w.Header().Set("Content-Type", contentTypeCSV)
 		w.Write(b)
 	case pngFormat:
 		w.Header().Set("Content-Type", contentTypePNG)
+		w.WriteHeader(returnCode)
 		w.Write(b)
 	case svgFormat:
 		w.Header().Set("Content-Type", contentTypeSVG)
+		w.WriteHeader(returnCode)
 		w.Write(b)
 	}
 }

--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -210,7 +210,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 
 		if err == nil {
 			ApiMetrics.RequestCacheHits.Add(1)
-			writeResponse(w, response, format, jsonp)
+			writeResponse(w, http.StatusOK, response, format, jsonp)
 			accessLogDetails.FromCache = true
 			return
 		}
@@ -382,15 +382,11 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch format {
 	case jsonFormat:
-		if len(results) == 0 && returnCode == 404 {
-			body = []byte("[]")
-		} else {
-			if maxDataPoints, _ := strconv.Atoi(r.FormValue("maxDataPoints")); maxDataPoints != 0 {
-				types.ConsolidateJSON(maxDataPoints, results)
-			}
-
-			body = types.MarshalJSON(results, timestampMultiplier, noNullPoints)
+		if maxDataPoints, _ := strconv.Atoi(r.FormValue("maxDataPoints")); maxDataPoints != 0 {
+			types.ConsolidateJSON(maxDataPoints, results)
 		}
+
+		body = types.MarshalJSON(results, timestampMultiplier, noNullPoints)
 	case protoV2Format:
 		body, err = types.MarshalProtobufV2(results)
 		if err != nil {
@@ -417,8 +413,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 		body = png.MarshalSVGRequest(r, results, template)
 	}
 
-	w.WriteHeader(returnCode)
-	writeResponse(w, body, format, jsonp)
+	writeResponse(w, returnCode, body, format, jsonp)
 
 	if len(results) != 0 {
 		tc := time.Now()

--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -373,9 +373,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 		if returnCode == 404 {
 			returnCode = config.Config.NotFoundStatusCode
 		}
-		if returnCode < 500 {
-			results = append(results, &types.MetricData{})
-		} else {
+		if returnCode >= 500 {
 			setError(w, accessLogDetails, "empty or no response", returnCode)
 			logAsError = true
 			return

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -65,6 +65,9 @@ func MarshalCSV(results []*MetricData) []byte {
 
 // ConsolidateJSON consolidates values to maxDataPoints size
 func ConsolidateJSON(maxDataPoints int, results []*MetricData) {
+	if len(results) == 0 {
+		return
+	}
 	startTime := results[0].StartTime
 	endTime := results[0].StopTime
 	for _, r := range results {


### PR DESCRIPTION
Conflict with [this line](https://github.com/go-graphite/carbonapi/blob/36dd93313d84d1241207d3c143f0142eb2004672/cmd/carbonapi/http/render_handler.go#L388), `results` won't be empty.
Or when `results` is empty, no additional logic is needed to ensure that the response result is `[]`

It looks like adding an empty types.MetricData to results is not necessary. If you want to be forward compatible, we can modify it like this:
```go
if returnCode == 404 {
    returnCode = config.Config.NotFoundStatusCode
}
if returnCode != 400 {
    if returnCode < 500 {
        results = append(results, &types.MetricData{})
    } else {
        setError(w, accessLogDetails, "empty or no response", returnCode)
        logAsError = true
        return
    }
}
```
Or just check returnCode
```go
if returnCode == 404 {
    body = []byte("[]")
} else {
    if maxDataPoints, _ := strconv.Atoi(r.FormValue("maxDataPoints")); maxDataPoints != 0 {
        types.ConsolidateJSON(maxDataPoints, results)
    }
    body = types.MarshalJSON(results, timestampMultiplier, noNullPoints)
}
```

The response header must be added before write status code, otherwise it will not take effect.
![image](https://user-images.githubusercontent.com/3659110/76329154-2b53ad80-6327-11ea-826a-d75dc835bd68.png)
