### PR TITLE
fix applyByNode

### DIFF
--- a/cmd/carbonapi/http/helper.go
+++ b/cmd/carbonapi/http/helper.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"fmt"
-	"github.com/go-graphite/carbonapi/pkg/parser"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/go-graphite/carbonapi/carbonapipb"
 	"github.com/go-graphite/carbonapi/cmd/carbonapi/config"
+	"github.com/go-graphite/carbonapi/pkg/parser"
 	"github.com/lomik/zapwriter"
 	"go.uber.org/zap"
 )
@@ -18,11 +18,6 @@ type responseFormat int
 
 // for testing
 var timeNow = time.Now
-
-type requestInterval struct {
-	from  int64
-	until int64
-}
 
 const (
 	jsonFormat responseFormat = iota

--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -229,7 +229,9 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 
 	var metrics []string
 	// Iterate over all targets, check if we need to fetch them
-	for _, target := range targets {
+	for i := 0; i < len(targets); i++ {
+		target := targets[i]
+
 		exp, e, err := parser.ParseExpr(target)
 
 		// if expression cannot be parsed return error

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -32,7 +32,7 @@ func (eval evaluator) FetchTargetExp(exp parser.Expr, from, until int64, values 
 
 	metrics, _, err := config.Config.ZipperInstance.Render(context.TODO(), req)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	for _, metric := range metrics {
 		mFetch := parser.MetricRequest{

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -1,9 +1,10 @@
 package expr
 
 import (
+	"context"
 	"fmt"
 
-	// Import all known functions
+	"github.com/go-graphite/carbonapi/cmd/carbonapi/config"
 	_ "github.com/go-graphite/carbonapi/expr/functions"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/metadata"
@@ -14,9 +15,64 @@ import (
 
 type evaluator struct{}
 
-// EvalExpr evalualtes expressions
-func (eval evaluator) EvalExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return EvalExpr(e, from, until, values)
+// FetchTargetExp evalualtes expressions
+func (eval evaluator) FetchTargetExp(exp parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	config.Config.Limiter.Enter()
+
+	var req pb.MultiFetchRequest
+
+	for _, m := range exp.Metrics() {
+		req.Metrics = append(req.Metrics, pb.FetchRequest{
+			Name:           m.Metric,
+			PathExpression: m.Metric,
+			StartTime:      m.From + from,
+			StopTime:       m.Until + until,
+		})
+	}
+
+	metrics, _, err := config.Config.ZipperInstance.Render(context.TODO(), req)
+	if err != nil {
+		return nil, nil
+	}
+	for _, metric := range metrics {
+		mFetch := parser.MetricRequest{
+			Metric: metric.PathExpression,
+			From:   from,
+			Until:  until,
+		}
+		data, ok := values[mFetch]
+		if !ok {
+			data = make([]*types.MetricData, 0, 1)
+		}
+		values[mFetch] = append(data, metric)
+	}
+
+	config.Config.Limiter.Leave()
+
+	return eval.Eval(exp, from, until, values)
+}
+
+// Eval evalualtes expressions
+func (eval evaluator) Eval(exp parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (results []*types.MetricData, err error) {
+	rewritten, targets, err := RewriteExpr(exp, from, until, values)
+	if err != nil {
+		return nil, err
+	}
+	if rewritten {
+		for _, target := range targets {
+			exp, _, err = parser.ParseExpr(target)
+			if err != nil {
+				return nil, err
+			}
+			result, err := eval.FetchTargetExp(exp, from, until, values)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, result...)
+		}
+		return results, nil
+	}
+	return EvalExpr(exp, from, until, values)
 }
 
 var _evaluator = evaluator{}
@@ -26,7 +82,11 @@ func init() {
 	metadata.SetEvaluator(_evaluator)
 }
 
-// EvalExpr is the main expression evaluator
+func FetchTargetExp(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	return _evaluator.FetchTargetExp(e, from, until, values)
+}
+
+// Eval is the main expression evaluator
 func EvalExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	if e.IsName() {
 		return values[parser.MetricRequest{Metric: e.Target(), From: from, Until: until}], nil

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -301,7 +301,7 @@ func TestRewriteExpr(t *testing.T) {
 			parser.NewExpr("applyByNode",
 
 				"metric*",
-				1,
+				0,
 				parser.ArgValue("%.count"),
 			),
 			map[parser.MetricRequest][]*types.MetricData{
@@ -320,7 +320,7 @@ func TestRewriteExpr(t *testing.T) {
 			parser.NewExpr("applyByNode",
 
 				"metric*",
-				1,
+				0,
 				parser.ArgValue("%.count"),
 				parser.ArgValue("% count"),
 			),
@@ -340,7 +340,7 @@ func TestRewriteExpr(t *testing.T) {
 			parser.NewExpr("applyByNode",
 
 				"foo.metric*",
-				2,
+				1,
 				parser.ArgValue("%.count"),
 			),
 			map[parser.MetricRequest][]*types.MetricData{

--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -130,7 +130,7 @@ func (f *asPercent) Do(e parser.Expr, from, until int64, values map[parser.Metri
 				seriesNameExprs[i] = parser.NewTargetExpr(seriesName)
 			}
 
-			result, err := f.Evaluator.EvalExpr(parser.NewExprTyped("sumSeries", seriesNameExprs), from, until, values)
+			result, err := f.Evaluator.Eval(parser.NewExprTyped("sumSeries", seriesNameExprs), from, until, values)
 
 			if err != nil {
 				return nil, err

--- a/expr/functions/groupByNode/function.go
+++ b/expr/functions/groupByNode/function.go
@@ -108,7 +108,7 @@ func (f *groupByNode) Do(e parser.Expr, from, until int64, values map[parser.Met
 			}
 		}
 
-		r, _ := f.Evaluator.EvalExpr(nexpr, from, until, nvalues)
+		r, _ := f.Evaluator.Eval(nexpr, from, until, nvalues)
 		if r != nil {
 			r[0].Name = k
 			results = append(results, r...)

--- a/expr/functions/groupByTags/function.go
+++ b/expr/functions/groupByTags/function.go
@@ -98,7 +98,7 @@ func (f *groupByTags) Do(e parser.Expr, from, until int64, values map[parser.Met
 			parser.MetricRequest{"stub", from, until}: v,
 		}
 
-		r, err := f.Evaluator.EvalExpr(nexpr, from, until, nvalues)
+		r, err := f.Evaluator.Eval(nexpr, from, until, nvalues)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/reduce/function.go
+++ b/expr/functions/reduce/function.go
@@ -95,7 +95,7 @@ AliasLoop:
 			reducedNodes[i] = parser.NewTargetExpr(matched.Name)
 		}
 
-		result, err := f.Evaluator.EvalExpr(parser.NewExprTyped("alias", []parser.Expr{
+		result, err := f.Evaluator.Eval(parser.NewExprTyped("alias", []parser.Expr{
 			parser.NewExprTyped(reduceFunction, reducedNodes),
 			parser.NewValueExpr(aliasName),
 		}), from, until, reducedValues)

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -36,7 +36,7 @@ func GetSeriesArg(arg parser.Expr, from, until int64, values map[parser.MetricRe
 		return nil, parser.ErrMissingTimeseries
 	}
 
-	a, err := evaluator.EvalExpr(arg, from, until, values)
+	a, err := evaluator.Eval(arg, from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/interfaces/inteface.go
+++ b/expr/interfaces/inteface.go
@@ -22,7 +22,7 @@ func (b *FunctionBase) GetEvaluator() Evaluator {
 
 // Evaluator is a interface for any existing expression parser
 type Evaluator interface {
-	EvalExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
+	Eval(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
 }
 
 type Order int

--- a/expr/rewrite/applyByNode/function.go
+++ b/expr/rewrite/applyByNode/function.go
@@ -54,7 +54,7 @@ func (f *applyByNode) Do(e parser.Expr, from, until int64, values map[parser.Met
 	for _, a := range args {
 		metric := helper.ExtractMetric(a.Name)
 		nodes := strings.Split(metric, ".")
-		node := strings.Join(nodes[0:field], ".")
+		node := strings.Join(nodes[0:field+1], ".")
 		newTarget := strings.Replace(callback, "%", node, -1)
 
 		if newName != "" {

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -18,7 +18,7 @@ type FuncEvaluator struct {
 	eval func(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
 }
 
-func (evaluator *FuncEvaluator) EvalExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+func (evaluator *FuncEvaluator) Eval(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	if e.IsName() {
 		return values[parser.MetricRequest{Metric: e.Target(), From: from, Until: until}], nil
 	} else if e.IsConst() {
@@ -293,7 +293,7 @@ func TestSummarizeEvalExpr(t *testing.T, tt *SummarizeEvalTestItem) {
 	t.Run(tt.Name, func(t *testing.T) {
 		originalMetrics := DeepClone(tt.M)
 		exp, _, _ := parser.ParseExpr(tt.Target)
-		g, err := evaluator.EvalExpr(exp, 0, 1, tt.M)
+		g, err := evaluator.Eval(exp, 0, 1, tt.M)
 		if err != nil {
 			t.Errorf("failed to eval %v: %+v", tt.Name, err)
 			return
@@ -330,7 +330,7 @@ func TestMultiReturnEvalExpr(t *testing.T, tt *MultiReturnEvalTestItem) {
 
 	originalMetrics := DeepClone(tt.M)
 	exp, _, err := parser.ParseExpr(tt.Target)
-	g, err := evaluator.EvalExpr(exp, 0, 1, tt.M)
+	g, err := evaluator.Eval(exp, 0, 1, tt.M)
 	if err != nil {
 		t.Errorf("failed to eval %v: %+v", tt.Name, err)
 		return
@@ -380,7 +380,7 @@ func TestEvalExpr(t *testing.T, tt *EvalTestItem) {
 	originalMetrics := DeepClone(tt.M)
 	testName := tt.Target
 	exp, _, err := parser.ParseExpr(tt.Target)
-	g, err := evaluator.EvalExpr(exp, 0, 1, tt.M)
+	g, err := evaluator.Eval(exp, 0, 1, tt.M)
 	if err != nil {
 		t.Errorf("failed to eval %s: %+v", testName, err)
 		return


### PR DESCRIPTION
When querying `aliasByNode(highestAverage(applyByNode(host.dns[0-9]*.uptime.uptime.value,1,"scale(perSecond(%.interface-bond1.if_octets.tx), 0.000008)"), 5), 1, 2)`, the `function = aliasByNode, err = function = highestAverage, err = unknown function in evalExpr: "applyByNode"` error still occurs.

Looks like the rewrite function cannot work with other functions, I try to implement applyByNode in other ways to avoid this error.