### PR TITLE
ignore no metrics error

### DIFF
--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	utilctx "github.com/go-graphite/carbonapi/util/ctx"
+	ztypes "github.com/go-graphite/carbonapi/zipper/types"
 	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/lomik/zapwriter"
 	uuid "github.com/satori/go.uuid"
@@ -270,6 +271,9 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 		// Otherwise it should be 500
 		errMsgs := make([]string, 0)
 		for _, err := range errors {
+			if merry.Is(err, ztypes.ErrNoMetricsFetched) {
+				continue
+			}
 			errMsgs = append(errMsgs, err.Error())
 			if returnCode < 500 {
 				returnCode = merry.HTTPCode(err)

--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -224,6 +224,16 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 	results := make([]*types.MetricData, 0)
 	values := make(map[parser.MetricRequest][]*types.MetricData)
 
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("panic during eval:",
+				zap.String("cache_key", cacheKey),
+				zap.Any("reason", r),
+				zap.Stack("stack"),
+			)
+		}
+	}()
+
 	for _, target := range targets {
 		exp, e, err := parser.ParseExpr(target)
 		if err != nil || e != "" {

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -2,8 +2,8 @@ package expr
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/ansel1/merry"
 	"github.com/go-graphite/carbonapi/cmd/carbonapi/config"
 	_ "github.com/go-graphite/carbonapi/expr/functions"
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -130,7 +130,7 @@ func EvalExpr(e parser.Expr, from, until int64, values map[parser.MetricRequest]
 	if ok {
 		v, err := f.Do(e, from, until, values)
 		if err != nil {
-			err = fmt.Errorf("function=%s, err=%v", e.Target(), err)
+			err = merry.WithMessagef(err, "function=%s", e.Target())
 		}
 		return v, err
 	}

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -59,6 +59,10 @@ func (eval evaluator) FetchAndEvalExp(exp parser.Expr, from, until int64, values
 		}
 		for _, metric := range metrics {
 			metricRequest := metricRequestCache[metric.PathExpression]
+			if metric.RequestStartTime != 0 && metric.RequestStopTime != 0 {
+				metricRequest.From = metric.RequestStartTime
+				metricRequest.Until = metric.RequestStopTime
+			}
 			data, ok := values[metricRequest]
 			if !ok {
 				data = make([]*types.MetricData, 0, 1)


### PR DESCRIPTION
1. Fix the following case, which is caused by the rewrite function fetch.

query:
```
aliasByNode(highestAverage(applyByNode(host.dns[0-9]*.uptime.uptime.value,1, "scale(perSecond(%.interface-bond1.if_octets.tx), 0.000008)"), 5), 1, 2)
```
error:
```
Internal Server Error: error or no response: function=aliasByNode, err=function=highestAverage, err=no metrics in the Response
```

2. Another commit fixes same metric name cache

for example:
```
diffSeries(flink.1165.jobmanager.*.*.numberOfFailedCheckpoints, timeShift(flink.1165.jobmanager.*.*.numberOfFailedCheckpoints, '10min'))
```
