### PR TITLE
ignore series not exist error

### DIFF
--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -271,7 +271,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 		// Otherwise it should be 500
 		errMsgs := make([]string, 0)
 		for _, err := range errors {
-			if merry.Is(err, ztypes.ErrNoMetricsFetched) {
+			if merry.Is(err, ztypes.ErrNoMetricsFetched) || merry.Is(err, parser.ErrSeriesDoesNotExist) {
 				continue
 			}
 			errMsgs = append(errMsgs, err.Error())


### PR DESCRIPTION
Similar to https://github.com/go-graphite/carbonapi/pull/459, which appears in this case

```
divideSeries(summarize(sumSeries(order.commit.*.*.response.*.*.error.*), '1min', 'sum', false),summarize(sumSeries(order.commit.*.*.response.*.*.*.*), '1min', 'sum', false))
```

![image](https://user-images.githubusercontent.com/3659110/79824685-6be42380-83c9-11ea-92c7-8eb2299f64e4.png)
