### PR TITLE
Prometheus: align timestamps to correctly work with gaps in data

### DIFF
--- a/zipper/protocols/prometheus/prometheus_group.go
+++ b/zipper/protocols/prometheus/prometheus_group.go
@@ -296,11 +296,8 @@ func (c *PrometheusGroup) Fetch(ctx context.Context, request *protov3.MultiFetch
 			}
 
 			for _, m := range response.Data.Result {
-				vals := make([]float64, len(m.Values))
-				// TODO: Verify timestamps
-				for i, v := range m.Values {
-					vals[i] = v.Value
-				}
+				alignedValues := alignValues(request.Metrics[0].StartTime, request.Metrics[0].StopTime, stepLocal, m.Values)
+
 				r.Metrics = append(r.Metrics, protov3.FetchResponse{
 					Name:              c.promMetricToGraphite(m.Metric),
 					PathExpression:    pathExpr,
@@ -308,7 +305,7 @@ func (c *PrometheusGroup) Fetch(ctx context.Context, request *protov3.MultiFetch
 					StartTime:         request.Metrics[0].StartTime,
 					StopTime:          request.Metrics[0].StopTime,
 					StepTime:          stepLocal,
-					Values:            vals,
+					Values:            alignedValues,
 					XFilesFactor:      0.0,
 				})
 			}

--- a/zipper/protocols/prometheus/prometheus_helper.go
+++ b/zipper/protocols/prometheus/prometheus_helper.go
@@ -218,3 +218,25 @@ func convertGraphiteTargetToPromQL(query string) string {
 
 	return reQuery.String()
 }
+
+// inserts math.NaN() in place of gaps in data from Prometheus
+func alignValues(startTime, stopTime, step int64, promValues []prometheusValue) []float64 {
+	var (
+		promValuesCtr = 0
+		resValues     = make([]float64, (stopTime-startTime)/step)
+	)
+
+	for i := range resValues {
+		nextTimestamp := float64(startTime + int64(i)*step)
+
+		if promValuesCtr < len(promValues) && promValues[promValuesCtr].Timestamp == nextTimestamp {
+			resValues[i] = promValues[promValuesCtr].Value
+			promValuesCtr++
+			continue
+		}
+
+		resValues[i] = math.NaN()
+	}
+
+	return resValues
+}


### PR DESCRIPTION
Previously, points were added to CarbonAPI response regardless of actual timestamps returned from Prometheus. It led to incorrect responses whenever any gaps were present in data from Prometheus.

This PR aligns timestamps from Prometheus and puts `math.NaN()` in place of gaps.