### PR TITLE
smartSummarize should expand wildcards in metric names

### DIFF
--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -1,6 +1,7 @@
 package smartSummarize
 
 import (
+	"fmt"
 	"github.com/go-graphite/carbonapi/expr/consolidations"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
@@ -66,7 +67,12 @@ func (f *smartSummarize) Do(e parser.Expr, from, until int64, values map[parser.
 	results := make([]*types.MetricData, 0, len(args))
 	for _, arg := range args {
 
-		name := e.ToString()
+		name := fmt.Sprintf("smartSummarize(%s,'%s','%s'", arg.Name, e.Args()[1].StringValue(), summarizeFunction)
+		if alignToInterval != "" {
+			name += fmt.Sprintf(",'%s')", alignToInterval)
+		} else {
+			name += ")";
+		}
 
 		r := types.MetricData{FetchResponse: pb.FetchResponse{
 			Name:              name,

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -85,6 +85,32 @@ func TestEvalSummarize(t *testing.T) {
 	}
 }
 
+func TestFunctionUseNameWithWildcards(t *testing.T) {
+	tests := []th.MultiReturnEvalTestItem{
+		{
+			"smartSummarize(metric1.*,'1minute','last')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.*", 0, 1}: {
+					types.MakeMetricData("metric1.foo", generateValues(0, 240, 1), 1, 0),
+					types.MakeMetricData("metric1.bar", generateValues(0, 240, 1), 1, 0),
+				},
+			},
+			"smartSummarize",
+			map[string][]*types.MetricData{
+				"smartSummarize(metric1.foo,'1minute','last')": {types.MakeMetricData("smartSummarize(metric1.foo,'1minute','last')", []float64{59, 119, 179, 239}, 60, 0)},
+				"smartSummarize(metric1.bar,'1minute','last')": {types.MakeMetricData("smartSummarize(metric1.bar,'1minute','last')", []float64{59, 119, 179, 239}, 60, 0)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestMultiReturnEvalExpr(t, &tt)
+		})
+	}
+}
+
 func generateValues(start, stop, step int64) (values []float64) {
 	for i := start; i < stop; i += step {
 		values = append(values, float64(i))


### PR DESCRIPTION
fixes go-graphite/carbonapi#468