### PR TITLE
Enhance convertGraphiteTargetToPromQL()

### DIFF
--- a/zipper/protocols/prometheus/prometheus_group.go
+++ b/zipper/protocols/prometheus/prometheus_group.go
@@ -217,7 +217,7 @@ func (c *PrometheusGroup) Fetch(ctx context.Context, request *protov3.MultiFetch
 				stepLocalStr, target = c.seriesByTagToPromQL(stepLocalStr, target)
 			} else {
 				reQuery := convertGraphiteTargetToPromQL(target)
-				target = "{__name__=~\"" + reQuery + "\"}"
+				target = fmt.Sprintf("{__name__=~%q}", reQuery)
 			}
 			if stepLocalStr[len(stepLocalStr)-1] >= '0' && stepLocalStr[len(stepLocalStr)-1] <= '9' {
 				stepLocalStr += "s"
@@ -334,8 +334,12 @@ func (c *PrometheusGroup) Find(ctx context.Context, request *protov3.MultiGlobRe
 	uniqueMetrics := make(map[string]bool)
 	for _, query := range request.Metrics {
 		// Convert query to Prometheus-compatible regex
+		if !strings.HasSuffix(query, "*") {
+			query = query + "*"
+		}
+
 		reQuery := convertGraphiteTargetToPromQL(query)
-		matchQuery := "{__name__=~\"" + reQuery + "\"}"
+		matchQuery := fmt.Sprintf("{__name__=~%q}", reQuery)
 		v := url.Values{
 			"match[]": []string{matchQuery},
 		}

--- a/zipper/protocols/prometheus/prometheus_helper.go
+++ b/zipper/protocols/prometheus/prometheus_helper.go
@@ -207,7 +207,7 @@ func convertGraphiteTargetToPromQL(query string) string {
 
 		switch ch {
 		case '*':
-			if len(query) == 0 {
+			if query == "" {
 				// needed to support find requests when asterisk is the last character and dots should be included
 				sb.WriteString(".*")
 				break

--- a/zipper/protocols/prometheus/prometheus_helper.go
+++ b/zipper/protocols/prometheus/prometheus_helper.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -191,32 +192,52 @@ func (c *PrometheusGroup) seriesByTagToPromQL(step, target string) (string, stri
 }
 
 func convertGraphiteTargetToPromQL(query string) string {
-	// Special case for query for "*", which is used to get top level metric parts
-	if query == "*" {
-		return ".*"
-	}
-	reQuery := strings.Builder{}
+	var sb strings.Builder
 
-	inGroup := 0
-	for _, c := range query {
-		switch c {
-		case '.':
-			reQuery.WriteString("\\\\.")
+	for {
+		n := strings.IndexAny(query, "*[{")
+		if n < 0 {
+			sb.WriteString(regexp.QuoteMeta(query))
+			return sb.String()
+		}
+
+		sb.WriteString(regexp.QuoteMeta(query[:n]))
+		ch := query[n]
+		query = query[n+1:]
+
+		switch ch {
 		case '*':
-			reQuery.WriteString("[^.][^.]*")
+			if len(query) == 0 {
+				// needed to support find requests when asterisk is the last character and dots should be included
+				sb.WriteString(".*")
+				break
+			}
+
+			sb.WriteString("[^.]*?")
+
+		case '[':
+			n = strings.Index(query, "]")
+			if n < 0 {
+				sb.WriteString(regexp.QuoteMeta("[" + query))
+				return sb.String()
+			}
+			sb.WriteString("[" + query[:n+1])
+			query = query[n+1:]
+
 		case '{':
-			reQuery.WriteString("(")
-			inGroup++
-		case ',':
-			reQuery.WriteString("|")
-		case '}':
-			reQuery.WriteString(")")
-		default:
-			reQuery.WriteRune(c)
+			n = strings.Index(query, "}")
+			if n < 0 {
+				sb.WriteString(regexp.QuoteMeta("{" + query))
+				return sb.String()
+			}
+			alts := strings.Split(query[:n], ",")
+			query = query[n+1:]
+			for i := range alts {
+				alts[i] = regexp.QuoteMeta(alts[i])
+			}
+			sb.WriteString("(" + strings.Join(alts, "|") + ")")
 		}
 	}
-
-	return reQuery.String()
 }
 
 // inserts math.NaN() in place of gaps in data from Prometheus


### PR DESCRIPTION
- In the previous version of the `convertGraphiteTargetToPromQL` function, an asterisk was matched to one or more symbols. Still, according to the [graphite documentation](https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards) it should match zero or more characters, so this is fixed in this PR.
- It did not escape all the possible regexp symbols that can be part of the query. This is fixed by `regexp.QuoteMeta()` now.
- For some reason, four backslashes were used to escape dots. We did not understand why so this new version adds two backslashes for each dot: one is added by `regexp.QuoteMeta()` and another by `%q` formatting instead of `%s`.

Thanks, @valyala for the `convertGraphiteTargetToPromQL` function.