### PR TITLE
Add a new cache for caching backend responses before rendering.

### DIFF
--- a/carbonapipb/carbonapi.pb.go
+++ b/carbonapipb/carbonapi.pb.go
@@ -23,11 +23,13 @@ type AccessLogDetails struct {
 	SendGlobs                     bool              `json:"send_globs,omitempty"`
 	From                          int64             `json:"from,omitempty"`
 	Until                         int64             `json:"until,omitempty"`
+	MaxDataPoints                 int64             `json:"max_data_points,omitempty"`
 	Tz                            string            `json:"tz,omitempty"`
 	FromRaw                       string            `json:"from_raw,omitempty"`
 	UntilRaw                      string            `json:"until_raw,omitempty"`
 	URI                           string            `json:"uri,omitempty"`
 	FromCache                     bool              `json:"from_cache"`
+	UsedBackendCache              bool              `json:"used_backend_cache"`
 	ZipperRequests                int64             `json:"zipper_requests,omitempty"`
 	TotalMetricsCount             int64             `json:"total_metrics_count,omitempty"`
 	RequestHeaders                map[string]string `json:"request_headers"`

--- a/cmd/carbonapi/config/config.go
+++ b/cmd/carbonapi/config/config.go
@@ -53,7 +53,8 @@ type ConfigType struct {
 	Listen                     string             `mapstructure:"listen"`
 	Buckets                    int                `mapstructure:"buckets"`
 	Concurency                 int                `mapstructure:"concurency"`
-	Cache                      CacheConfig        `mapstructure:"cache"`
+	ResponseCacheConfig        CacheConfig        `mapstructure:"cache"`
+	BackendCacheConfig         CacheConfig        `mapstructure:"backendCache"`
 	Cpus                       int                `mapstructure:"cpus"`
 	TimezoneString             string             `mapstructure:"tz"`
 	UnicodeRangeTables         []string           `mapstructure:"unicodeRangeTables"`
@@ -78,8 +79,8 @@ type ConfigType struct {
 	Expvar                     ExpvarConfig       `mapstructure:"expvar"`
 	NotFoundStatusCode         int                `mapstructure:"notFoundStatusCode"`
 
-	QueryCache cache.BytesCache `mapstructure:"-" json:"-"`
-	FindCache  cache.BytesCache `mapstructure:"-" json:"-"`
+	ResponseCache cache.BytesCache `mapstructure:"-" json:"-"`
+	BackendCache  cache.BytesCache `mapstructure:"-" json:"-"`
 
 	DefaultTimeZone *time.Location `mapstructure:"-" json:"-"`
 
@@ -106,9 +107,13 @@ var Config = ConfigType{
 	Buckets:               10,
 	Concurency:            1000,
 	MaxBatchSize:          100,
-	Cache: CacheConfig{
+	ResponseCacheConfig: CacheConfig{
 		Type:              "mem",
 		DefaultTimeoutSec: 60,
+	},
+	BackendCacheConfig: CacheConfig{
+		Type:              "null",
+		DefaultTimeoutSec: 0,
 	},
 	TimezoneString: "",
 	Graphite: GraphiteConfig{
@@ -121,8 +126,8 @@ var Config = ConfigType{
 	IdleConnections: 10,
 	PidFile:         "",
 
-	QueryCache: cache.NullCache{},
-	FindCache:  cache.NullCache{},
+	ResponseCache: cache.NullCache{},
+	BackendCache:  cache.NullCache{},
 
 	DefaultTimeZone: time.Local,
 	Logger:          []zapwriter.Config{DefaultLoggerConfig},

--- a/cmd/carbonapi/graphite_metrics.go
+++ b/cmd/carbonapi/graphite_metrics.go
@@ -48,16 +48,14 @@ func setupGraphiteMetrics(logger *zap.Logger) {
 		graphite.Register(fmt.Sprintf("%s.request_cache_hits", pattern), http.ApiMetrics.RequestCacheHits)
 		graphite.Register(fmt.Sprintf("%s.request_cache_misses", pattern), http.ApiMetrics.RequestCacheMisses)
 		graphite.Register(fmt.Sprintf("%s.request_cache_overhead_ns", pattern), http.ApiMetrics.RenderCacheOverheadNS)
+		graphite.Register(fmt.Sprintf("%s.backend_cache_hits", pattern), http.ApiMetrics.BackendCacheHits)
+		graphite.Register(fmt.Sprintf("%s.backend_cache_misses", pattern), http.ApiMetrics.BackendCacheMisses)
 
 		for i := 0; i <= config.Config.Buckets; i++ {
 			graphite.Register(fmt.Sprintf("%s.requests_in_%dms_to_%dms", pattern, i*100, (i+1)*100), http.BucketEntry(i))
 		}
 
 		graphite.Register(fmt.Sprintf("%s.find_requests", pattern), http.ApiMetrics.FindRequests)
-		graphite.Register(fmt.Sprintf("%s.find_cache_hits", pattern), http.ApiMetrics.FindCacheHits)
-		graphite.Register(fmt.Sprintf("%s.find_cache_misses", pattern), http.ApiMetrics.FindCacheMisses)
-		graphite.Register(fmt.Sprintf("%s.find_cache_overhead_ns", pattern), http.ApiMetrics.FindCacheOverheadNS)
-
 		graphite.Register(fmt.Sprintf("%s.render_requests", pattern), http.ApiMetrics.RenderRequests)
 
 		if http.ApiMetrics.MemcacheTimeouts != nil {

--- a/cmd/carbonapi/http/metrics.go
+++ b/cmd/carbonapi/http/metrics.go
@@ -16,13 +16,12 @@ var ApiMetrics = struct {
 	RenderRequests        *expvar.Int
 	RequestCacheHits      *expvar.Int
 	RequestCacheMisses    *expvar.Int
+	BackendCacheHits      *expvar.Int
+	BackendCacheMisses    *expvar.Int
 	RenderCacheOverheadNS *expvar.Int
 	RequestBuckets        expvar.Func
 
-	FindRequests        *expvar.Int
-	FindCacheHits       *expvar.Int
-	FindCacheMisses     *expvar.Int
-	FindCacheOverheadNS *expvar.Int
+	FindRequests *expvar.Int
 
 	MemcacheTimeouts expvar.Func
 
@@ -34,13 +33,11 @@ var ApiMetrics = struct {
 	RenderRequests:        expvar.NewInt("render_requests"),
 	RequestCacheHits:      expvar.NewInt("request_cache_hits"),
 	RequestCacheMisses:    expvar.NewInt("request_cache_misses"),
+	BackendCacheHits:      expvar.NewInt("backend_cache_hits"),
+	BackendCacheMisses:    expvar.NewInt("backend_cache_misses"),
 	RenderCacheOverheadNS: expvar.NewInt("render_cache_overhead_ns"),
 
 	FindRequests: expvar.NewInt("find_requests"),
-
-	FindCacheHits:       expvar.NewInt("find_cache_hits"),
-	FindCacheMisses:     expvar.NewInt("find_cache_misses"),
-	FindCacheOverheadNS: expvar.NewInt("find_cache_overhead_ns"),
 }
 
 var ZipperMetrics = struct {
@@ -117,9 +114,9 @@ func RenderTimeBuckets() interface{} {
 }
 
 func SetupMetrics(logger *zap.Logger) {
-	switch config.Config.Cache.Type {
+	switch config.Config.ResponseCacheConfig.Type {
 	case "memcache":
-		mcache := config.Config.QueryCache.(*cache.MemcachedCache)
+		mcache := config.Config.ResponseCache.(*cache.MemcachedCache)
 
 		ApiMetrics.MemcacheTimeouts = expvar.Func(func() interface{} {
 			return mcache.Timeouts()
@@ -127,7 +124,7 @@ func SetupMetrics(logger *zap.Logger) {
 		expvar.Publish("memcache_timeouts", ApiMetrics.MemcacheTimeouts)
 
 	case "mem":
-		qcache := config.Config.QueryCache.(*cache.ExpireCache)
+		qcache := config.Config.ResponseCache.(*cache.ExpireCache)
 
 		ApiMetrics.CacheSize = expvar.Func(func() interface{} {
 			return qcache.Size()

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -202,7 +202,13 @@ unicodeRangeTables:
 
 ***
 ## cache
-Specify what storage to use for metric cache and path cache.
+Specify what storage to use for response cache. This cache stores the final
+carbonapi response right before sending it to the client. A cache hit to this
+cache avoids almost all computations, including rendering images etc. On the
+other hand, a request will cause a cache hit only if a previous request with
+exactly the same response format and with same maxDataPoints param populated the
+cache. Grafana sets maxDataPoints depending on client screen width, reducing the
+hit ratio for this cache.
 
 Supported cache types:
  - `mem` - will use integrated in-memory cache. Not distributed. Fast.
@@ -212,7 +218,6 @@ Supported cache types:
 Extra options:
  - `size_mb` - specify max size of cache, in MiB
  - `defaultTimeoutSec` - specify default cache duration. Identical to `DEFAULT_CACHE_DURATION` in graphite-web
-
 ### Example
 ```yaml
 cache:
@@ -223,7 +228,24 @@ cache:
        - "127.0.0.1:1234"
        - "127.0.0.2:1235"
 ```
+## backendCache
+Specify what storage to use for backend cache. This cache stores the responses
+from the backends. It should have more cache hits than the response cache since
+the response format and the maxDataPoints paramter are not part of the cache
+key, but results from cache still need to be postprocessed (e.g. serialized to
+desired response format).
 
+Supports same options as the response cache.
+### Example
+```yaml
+backendCache:
+   type: "memcache"
+   size_mb: 0
+   defaultTimeoutSec: 60
+   memcachedServers:
+       - "127.0.0.1:1234"
+       - "127.0.0.2:1235"
+```
 ***
 ## cpus
 

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -59,7 +59,7 @@ func MarshalCSV(results []*MetricData) []byte {
 }
 
 // ConsolidateJSON consolidates values to maxDataPoints size
-func ConsolidateJSON(maxDataPoints int, results []*MetricData) {
+func ConsolidateJSON(maxDataPoints int64, results []*MetricData) {
 	if len(results) == 0 {
 		return
 	}


### PR DESCRIPTION
The new cache has a much better hit ratio when using CarbonAPI with Grafana. Grafana varies the value of maxDataPoints sent in requests depending on the screen width of the client, which often prevents reusing the results in the existing cache, which stores the response already after trimming the results to maxDataPoints. See also https://github.com/go-graphite/carbonapi/issues/18

The new cache is free from this problem and for us it results in around 25-30% less queries to Clickhouse and 25%-30% less load on Clickhouse servers, which we use for storing the metrics, in comparison to a setup with just the existing  cache.

I tried to be fairly conservative in implementing this:
- the preexisting response cache is still there
- the backend cache is configured separately and is disabled by default
- noCache param disables both caches (and cacheTimeout param overwrites the timeout for both caches)
- if there are errors when fetching the metrics from backends, nothing is stored in the cache 