### PR TITLE
Prometheus: Adjust step for queries

### DIFF
--- a/cmd/carbonapi/carbonapi.example.prometheus.yaml
+++ b/cmd/carbonapi/carbonapi.example.prometheus.yaml
@@ -48,6 +48,7 @@ upstreams:
             backendOptions:
                 step: "60"
                 start: "-5m"
+                max_points_per_query: 5000
             timeouts:
                 find: "2s"
                 render: "50s"

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -456,6 +456,7 @@ Supported options:
         supports either unix timestamp or delta from now(). For delta you should specify it in duration format.
 
         For example `-5m` will mean "5 minutes ago", time will be resolved every time you do find query.
+      - `max_points_per_query` - define maximum datapoints per query. It will be used to adjust step for queries over big range. Default limit for Prometheus is 11000.
   - `concurrencyLimitPerServer` - limit of max connections per server. Likely should be >= maxIdleConnsPerHost. Default: 0 - unlimited
   - `maxIdleConnsPerHost` - as we use KeepAlive to keep connections opened, this limits amount of connections that will be left opened. Tune with care as some backends might have issues handling larger number of connections.
   - `keepAliveInterval` - KeepAlive interval

--- a/zipper/protocols/prometheus/prometheus_helper.go
+++ b/zipper/protocols/prometheus/prometheus_helper.go
@@ -261,3 +261,50 @@ func alignValues(startTime, stopTime, step int64, promValues []prometheusValue) 
 
 	return resValues
 }
+
+// adjustStep adjusts step keeping in mind default/configurable limit of maximum points per query
+// Steps sequence is aligned with Grafana. Step progresses in the following order:
+// minimal configured step if not default => 20 => 30 => 60 => 120 => 300 => 600 => 900 => 1200 => 1800 => 3600 => 7200 => 10800 => 21600 => 43200 => 86400
+func adjustStep(start, stop, maxPointsPerQuery, minStep int64) int64 {
+	safeStep := int64(math.Ceil(float64(stop-start) / float64(maxPointsPerQuery)))
+
+	step := minStep
+	if safeStep > minStep {
+		step = safeStep
+	}
+
+	switch {
+	case step <= minStep:
+		return minStep // minimal configured step
+	case step <= 20:
+		return 20 // 20s
+	case step <= 30:
+		return 30 // 30s
+	case step <= 60:
+		return 60 // 1m
+	case step <= 120:
+		return 120 // 2m
+	case step <= 300:
+		return 300 // 5m
+	case step <= 600:
+		return 600 // 10m
+	case step <= 900:
+		return 900 // 15m
+	case step <= 1200:
+		return 1200 // 20m
+	case step <= 1800:
+		return 1800 // 30m
+	case step <= 3600:
+		return 3600 // 1h
+	case step <= 7200:
+		return 7200 // 2h
+	case step <= 10800:
+		return 10800 // 3h
+	case step <= 21600:
+		return 21600 // 6h
+	case step <= 43200:
+		return 43200 // 12h
+	default:
+		return 86400 // 24h
+	}
+}


### PR DESCRIPTION
Previously, step in queries to Prometheus was static and this resulted in `exceeded maximum resolution of 11,000 points per timeseries` errors on a wider time ranges. 

This PR adds adjusting step to respect the provided constraints. It also rounds the step to match the steps scale in use by Grafana. The constraint is defaulted to the Prometheus 11k and is configurable via **`max_points_per_query`** `backendOptions` option