### PR TITLE
Sort results before answer request

### DIFF
--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/go-graphite/carbonapi/date"
 	"github.com/go-graphite/carbonapi/expr"
 	"github.com/go-graphite/carbonapi/expr/functions/cairo/png"
+	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	utilctx "github.com/go-graphite/carbonapi/util/ctx"
@@ -259,6 +261,8 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				errors[target] = merry.Wrap(err)
 			}
+
+			sort.Sort(helper.ByNameNatural(result))
 
 			results = append(results, result...)
 		}


### PR DESCRIPTION
graphite-web always sort metric names in the response  
![screen_2020-07-07_10-36-01_window](https://user-images.githubusercontent.com/3025537/86769087-df9fdf00-c04e-11ea-88d5-f457ab951d4d.png)

But carbonapi didn't and results were inconsistent  
![screen_2020-07-07_10-34-48_window](https://user-images.githubusercontent.com/3025537/86769137-f5ad9f80-c04e-11ea-950f-4b7499fc195c.png)  
![screen_2020-07-07_10-35-30_window](https://user-images.githubusercontent.com/3025537/86769154-fcd4ad80-c04e-11ea-9841-e93315845dca.png)

This PR implements sorting of final results before an answer.
