### PR TITLE
Sort metrics after fetch but not after aggregation

### DIFF
--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -17,7 +16,6 @@ import (
 	"github.com/go-graphite/carbonapi/date"
 	"github.com/go-graphite/carbonapi/expr"
 	"github.com/go-graphite/carbonapi/expr/functions/cairo/png"
-	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	utilctx "github.com/go-graphite/carbonapi/util/ctx"
@@ -261,8 +259,6 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				errors[target] = merry.Wrap(err)
 			}
-
-			sort.Sort(helper.ByNameNatural(result))
 
 			results = append(results, result...)
 		}

--- a/cmd/carbonapi/zipper.go
+++ b/cmd/carbonapi/zipper.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"sort"
 
 	"github.com/ansel1/merry"
+	"github.com/go-graphite/carbonapi/expr/helper"
 	tags2 "github.com/go-graphite/carbonapi/expr/tags"
 	"github.com/go-graphite/carbonapi/expr/types"
 	util "github.com/go-graphite/carbonapi/util/ctx"
@@ -97,6 +99,8 @@ func (z zipper) Render(ctx context.Context, request pb.MultiFetchRequest) ([]*ty
 			})
 		}
 	}
+
+	sort.Sort(helper.ByNameNatural(result))
 
 	return result, stats, err
 }


### PR DESCRIPTION
Place `sort` into fetching part to respect custom functions ordering. E.g. `group(metric3, metric1, metric2)`