### PR TITLE
Accept 1 and 0 as bool arguments for true and false

### DIFF
--- a/pkg/parser/internal.go
+++ b/pkg/parser/internal.go
@@ -39,14 +39,14 @@ func (e *expr) doGetStringArg() (string, error) {
 }
 
 func (e *expr) doGetBoolArg() (bool, error) {
-	if e.etype != EtString && e.etype != EtBool {
+	if e.etype != EtString && e.etype != EtBool && e.etype != EtConst {
 		return false, ErrBadType
 	}
 
 	switch e.valStr {
-	case "False", "false":
+	case "False", "false", "0":
 		return false, nil
-	case "True", "true":
+	case "True", "true", "1":
 		return true, nil
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -371,3 +371,52 @@ func TestParseExpr(t *testing.T) {
 		})
 	}
 }
+
+func TestDoGetBoolVar(t *testing.T) {
+	tests := []struct {
+		s string
+		e *expr
+		r bool
+	}{
+		{
+			"1 is true",
+			&expr{val: 1, etype: EtConst, valStr: "1"},
+			true,
+		},
+		{
+			"true is true",
+			&expr{etype: EtString, valStr: "true"},
+			true,
+		},
+		{
+			"True is true",
+			&expr{etype: EtString, valStr: "True"},
+			true,
+		},
+		{
+			"0 is false",
+			&expr{val: 0, etype: EtConst, valStr: "0"},
+			false,
+		},
+		{
+			"False is false",
+			&expr{etype: EtString, valStr: "False"},
+			false,
+		},
+		{
+			"false is false",
+			&expr{etype: EtString, valStr: "false"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r, err := tt.e.doGetBoolArg()
+			if assert.NoError(err) {
+				assert.Equal(tt.r, r, tt.s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Without this fix drop-in replacement for functions like `summarize(metric,'1h','max',1)` are impossible. Tests are included as well