### PR TITLE
Add render panic HTTP answer

### DIFF
--- a/cmd/carbonapi/config/config.go
+++ b/cmd/carbonapi/config/config.go
@@ -78,6 +78,7 @@ type ConfigType struct {
 	Prefix                     string             `mapstructure:"prefix"`
 	Expvar                     ExpvarConfig       `mapstructure:"expvar"`
 	NotFoundStatusCode         int                `mapstructure:"notFoundStatusCode"`
+	HTTPResponseStackTrace     bool               `mapstructure:"httpResponseStackTrace"`
 
 	ResponseCache cache.BytesCache `mapstructure:"-" json:"-"`
 	BackendCache  cache.BytesCache `mapstructure:"-" json:"-"`
@@ -150,5 +151,6 @@ var Config = ConfigType{
 		Enabled:      true,
 		PProfEnabled: false,
 	},
-	NotFoundStatusCode: 200,
+	NotFoundStatusCode:     200,
+	HTTPResponseStackTrace: true,
 }

--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -231,6 +232,14 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 				zap.Any("reason", r),
 				zap.Stack("stack"),
 			)
+			logAsError = true
+			var answer string
+			if config.Config.HTTPResponseStackTrace {
+				answer = fmt.Sprintf("%v\nStack trace: %v", r, zap.Stack("").String)
+			} else {
+				answer = fmt.Sprint(r)
+			}
+			setError(w, accessLogDetails, answer, http.StatusInternalServerError)
 		}
 	}()
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -14,6 +14,7 @@ Table of Contents
     * [Example:](#example-4)
   * [notFoundStatusCode](#notfoundstatuscode)
     * [Example:](#example-5)
+  * [httpResponseStackTrace](#httpresponsestacktrace)
   * [unicodeRangeTables](#unicoderangetables)
     * [Example](#example-6)
   * [cache](#cache)
@@ -137,6 +138,13 @@ This is example to return HTTP code 200
 ```yaml
 notFoundStatusCode: 200
 ```
+
+***
+## httpResponseStackTrace
+
+This option controls if stack trace should be sent as http answer in case of a panic during `/render` proceeding.
+
+Default: true
 
 ***
 ## define


### PR DESCRIPTION
Currently, carbonapi answers with 200 without any signs of errors except a render log.

This PR adds 500 status code and sending stack trace (configurable, enabled by default).