### PR TITLE
Align total and first series in asPercent function

### DIFF
--- a/expr/functions/aggregateLine/function.go
+++ b/expr/functions/aggregateLine/function.go
@@ -93,6 +93,7 @@ func (f *aggregateLine) Do(ctx context.Context, e parser.Expr, from, until int64
 		} else {
 			r.FetchResponse.StepTime = a.FetchResponse.StopTime - a.FetchResponse.StartTime
 			r.FetchResponse.Values = []float64{val, val}
+			r.FetchResponse.StopTime = r.StartTime + int64(len(r.FetchResponse.Values))*r.FetchResponse.StepTime
 		}
 
 		results = append(results, &r)

--- a/expr/functions/aggregateLine/function_test.go
+++ b/expr/functions/aggregateLine/function_test.go
@@ -36,9 +36,9 @@ func TestConstantLine(t *testing.T) {
 				},
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("aggregateLine(metric1, 3)", []float64{3, 3, 3}, 1, now32),
-				types.MakeMetricData("aggregateLine(metric2, 4)", []float64{4, 4, 4}, 1, now32),
-				types.MakeMetricData("aggregateLine(metric3, 4.5)", []float64{4.5, 4.5, 4.5}, 1, now32),
+				types.MakeMetricData("aggregateLine(metric1, 3)", []float64{3, 3}, 6, now32),
+				types.MakeMetricData("aggregateLine(metric2, 4)", []float64{4, 4}, 6, now32),
+				types.MakeMetricData("aggregateLine(metric3, 4.5)", []float64{4.5, 4.5}, 6, now32),
 			},
 		},
 		{

--- a/expr/functions/cairo/cairo_test.go
+++ b/expr/functions/cairo/cairo_test.go
@@ -4,7 +4,6 @@ package cairo
 
 import (
 	"testing"
-	"time"
 
 	"github.com/go-graphite/carbonapi/expr/metadata"
 	"github.com/go-graphite/carbonapi/expr/types"
@@ -22,45 +21,43 @@ func init() {
 
 func TestEvalExpressionGraph(t *testing.T) {
 
-	now32 := int64(time.Now().Unix())
-
 	tests := []th.EvalTestItem{
 		{
 			"threshold(42.42)",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("42.42",
-				[]float64{42.42, 42.42}, 1, now32)},
+				[]float64{42.42, 42.42}, 1, 0)},
 		},
 		{
 			"threshold(42.42,\"fourty-two\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two",
-				[]float64{42.42, 42.42}, 1, now32)},
+				[]float64{42.42, 42.42}, 1, 0)},
 		},
 		{
 			"threshold(42.42,\"fourty-two\",\"blue\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two",
-				[]float64{42.42, 42.42}, 1, now32)},
+				[]float64{42.42, 42.42}, 1, 0)},
 		},
 		{
 			"threshold(42.42,label=\"fourty-two\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two",
-				[]float64{42.42, 42.42}, 1, now32)},
+				[]float64{42.42, 42.42}, 1, 0)},
 		},
 		{
 			"threshold(42.42,color=\"blue\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("42.42",
-				[]float64{42.42, 42.42}, 1, now32)},
+				[]float64{42.42, 42.42}, 1, 0)},
 		},
 		{
 			//TODO(nnuss): test blue is being set rather than just not causing expression to parse/fail
 			"threshold(42.42,label=\"fourty-two-blue\",color=\"blue\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two-blue",
-				[]float64{42.42, 42.42}, 1, now32)},
+				[]float64{42.42, 42.42}, 1, 0)},
 		},
 		{
 			// BUG(nnuss): This test actually fails with color = "" because of
@@ -70,7 +67,7 @@ func TestEvalExpressionGraph(t *testing.T) {
 			"threshold(42.42,gold,label=\"fourty-two-aurum\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two-aurum",
-				[]float64{42.42, 42.42}, 1, now32)},
+				[]float64{42.42, 42.42}, 1, 0)},
 		},
 	}
 

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -641,6 +641,7 @@ func Description() map[string]types.FunctionDescription {
 			Function:    "lineWidth(seriesList, width)",
 			Group:       "Graph",
 		},
+		// TODO: This function doesn't depend on cairo, should be moved out
 		"threshold": {
 			Name: "threshold",
 			Params: []types.FunctionParam{
@@ -821,6 +822,7 @@ func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricReq
 		return results, nil
 
 	case "threshold": // threshold(value, label=None, color=None)
+		// TODO: This function doesn't depend on cairo, should be moved out
 		// XXX does not match graphite's signature
 		// BUG(nnuss): the signature *does* match but there is an edge case because of named argument handling if you use it *just* wrong:
 		//			   threshold(value, "gold", label="Aurum")

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -847,13 +847,16 @@ func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricReq
 			return nil, err
 		}
 
+		newValues := []float64{value, value}
+		stepTime := until - from
+		stopTime := from + stepTime*int64(len(newValues))
 		p := types.MetricData{
 			FetchResponse: pb.FetchResponse{
 				Name:              name,
 				StartTime:         from,
-				StopTime:          until,
-				StepTime:          until - from,
-				Values:            []float64{value, value},
+				StopTime:          stopTime,
+				StepTime:          stepTime,
+				Values:            newValues,
 				ConsolidationFunc: "average",
 			},
 			GraphOptions: types.GraphOptions{Color: color},

--- a/expr/functions/constantLine/function.go
+++ b/expr/functions/constantLine/function.go
@@ -34,13 +34,16 @@ func (f *constantLine) Do(ctx context.Context, e parser.Expr, from, until int64,
 	if err != nil {
 		return nil, err
 	}
+	newValues := []float64{value, value}
+	stepTime := until - from
+	stopTime := from + stepTime*int64(len(newValues))
 	p := types.MetricData{
 		FetchResponse: pb.FetchResponse{
 			Name:              fmt.Sprintf("%g", value),
 			StartTime:         from,
-			StopTime:          until,
-			StepTime:          until - from,
-			Values:            []float64{value, value},
+			StopTime:          stopTime,
+			StepTime:          stepTime,
+			Values:            newValues,
 			ConsolidationFunc: "max",
 		},
 	}

--- a/expr/functions/constantLine/function_test.go
+++ b/expr/functions/constantLine/function_test.go
@@ -2,7 +2,6 @@ package constantLine
 
 import (
 	"testing"
-	"time"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/metadata"
@@ -22,16 +21,12 @@ func init() {
 }
 
 func TestConstantLine(t *testing.T) {
-	now32 := int64(time.Now().Unix())
-
 	tests := []th.EvalTestItem{
 		{
 			"constantLine(42.42)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"42.42", 0, 1}: {types.MakeMetricData("constantLine", []float64{12.3, 12.3}, 1, now32)},
-			},
+			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("42.42",
-				[]float64{42.42, 42.42}, 1, now32)},
+				[]float64{42.42, 42.42}, 1, 0)},
 		},
 	}
 

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -85,7 +85,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		r := *a
 		r.Name = fmt.Sprintf("%s(%s,%s)", e.Target(), a.Name, argstr)
 		r.StartTime = from
-		r.StopTime = until
+		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
 
 		if windowSize == 0 {
 			// Fix error on long time ranges (greater than 30 days), sampling to 10 min

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -31,28 +31,28 @@ func TestMoving(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingAverage(metric1,4)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1.25, 1.5, 1.75, 2.5, 3.5, 4, 5}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("movingAverage(metric1,4)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1.25, 1.5, 1.75, 2.5, 3.5, 4, 5}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingSum(metric1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, 6}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingSum(metric1,2)", []float64{math.NaN(), math.NaN(), 3, 5, 7, 9}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("movingSum(metric1,2)", []float64{math.NaN(), math.NaN(), 3, 5, 7, 9}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingMin(metric1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 2, 1, 0}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMin(metric1,2)", []float64{math.NaN(), math.NaN(), 1, 2, 2, 1}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("movingMin(metric1,2)", []float64{math.NaN(), math.NaN(), 1, 2, 2, 1}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingMax(metric1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 2, 1, 0}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMax(metric1,2)", []float64{math.NaN(), math.NaN(), 2, 3, 3, 2}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("movingMax(metric1,2)", []float64{math.NaN(), math.NaN(), 2, 3, 3, 2}, 1, 0)}, // StartTime = from
 		},
 	}
 

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -87,7 +87,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 		r.Name = fmt.Sprintf("movingMedian(%s,%s)", a.Name, argstr)
 		r.Values = make([]float64, len(a.Values)-offset)
 		r.StartTime = from
-		r.StopTime = until
+		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
 
 		data := movingmedian.NewMovingMedian(windowSize)
 

--- a/expr/functions/movingMedian/function_test.go
+++ b/expr/functions/movingMedian/function_test.go
@@ -31,28 +31,28 @@ func TestMovingMedian(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,4)", []float64{math.NaN(), math.NaN(), math.NaN(), 1, 1, 1.5, 2, 2, 3, 4, 5, 6}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,4)", []float64{math.NaN(), math.NaN(), math.NaN(), 1, 1, 1.5, 2, 2, 3, 4, 5, 6}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingMedian(metric1,5)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2, math.NaN()}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,5)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1, 2, 2, 2, 4, 4, 6, 6, 4, 2}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,5)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1, 2, 2, 2, 4, 4, 6, 6, 4, 2}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingMedian(metric1,\"1s\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -1, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2, 0}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,\"1s\")", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2, 0}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,\"1s\")", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2, 0}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingMedian(metric1,\"3s\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,\"3s\")", []float64{0, 1, 1, 1, 1, 2, 2, 2, 4, 4, 6, 6, 6, 2}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,\"3s\")", []float64{0, 1, 1, 1, 1, 2, 2, 2, 4, 4, 6, 6, 6, 2}, 1, 0)}, // StartTime = from
 		},
 	}
 

--- a/expr/functions/pearson/function.go
+++ b/expr/functions/pearson/function.go
@@ -61,7 +61,7 @@ func (f *pearson) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 	r.Name = fmt.Sprintf("pearson(%s,%s,%d)", a1.Name, a2.Name, windowSize)
 	r.Values = make([]float64, len(a1.Values))
 	r.StartTime = from
-	r.StopTime = until
+	r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
 
 	for i, v1 := range a1.Values {
 		v2 := a2.Values[i]

--- a/expr/functions/pearson/function_test.go
+++ b/expr/functions/pearson/function_test.go
@@ -32,7 +32,7 @@ func TestFunction(t *testing.T) {
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{43, 21, 25, 42, 57, 59}, 1, now32)},
 				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{99, 65, 79, 75, 87, 81}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("pearson(metric1,metric2,6)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0.5298089018901744}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("pearson(metric1,metric2,6)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0.5298089018901744}, 1, 0)}, // StartTime = from
 		},
 	}
 

--- a/expr/functions/pow/function_test.go
+++ b/expr/functions/pow/function_test.go
@@ -31,7 +31,7 @@ func TestFunction(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{5, 1, math.NaN(), 0, 12, 125, 10.4, 1.1}, 60, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("pow(metric1,3)", []float64{125, 1, math.NaN(), 0, 1728, 1953125, 1124.864, 1.331}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("pow(metric1,3)", []float64{125, 1, math.NaN(), 0, 1728, 1953125, 1124.864, 1.331}, 60, now32)},
 		},
 	}
 

--- a/expr/functions/scaleToSeconds/function_test.go
+++ b/expr/functions/scaleToSeconds/function_test.go
@@ -31,7 +31,7 @@ func TestFunction(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{60, 120, math.NaN(), 120, 120}, 60, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("scaleToSeconds(metric1,5)", []float64{5, 10, math.NaN(), 10, 10}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("scaleToSeconds(metric1,5)", []float64{5, 10, math.NaN(), 10, 10}, 60, now32)},
 		},
 	}
 

--- a/expr/functions/timeShift/function_test.go
+++ b/expr/functions/timeShift/function_test.go
@@ -39,7 +39,7 @@ func TestAbsolute(t *testing.T) {
 				{"metric1", -1, 0}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3, 4}, 1, now32-1)},
 			},
 			[]*types.MetricData{types.MakeMetricData("timeShift(metric1,'-1')",
-				[]float64{-1, 0, 1, 2, 3, 4}, 1, now32-1)},
+				[]float64{-1, 0, 1, 2, 3, 4}, 1, now32)},
 		},
 		{
 			`timeShift(metric1, "1h")`,
@@ -47,7 +47,7 @@ func TestAbsolute(t *testing.T) {
 				{"metric1", -60 * 60, -60*60 + 1}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3, 4}, 1, now32-60*60)},
 			},
 			[]*types.MetricData{types.MakeMetricData("timeShift(metric1,'-3600')",
-				[]float64{-1, 0, 1, 2, 3, 4}, 1, now32-60*60)},
+				[]float64{-1, 0, 1, 2, 3, 4}, 1, now32)},
 		},
 	}
 

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -450,9 +450,8 @@ type EvalTestItem struct {
 	Want   []*types.MetricData
 }
 
-func TestEvalExpr(t *testing.T, tt *EvalTestItem) {
+func TestEvalExprModifiedOrigin(t *testing.T, tt *EvalTestItem) {
 	evaluator := metadata.GetEvaluator()
-	originalMetrics := DeepClone(tt.M)
 	testName := tt.Target
 	exp, _, err := parser.ParseExpr(tt.Target)
 	if err != nil {
@@ -467,9 +466,7 @@ func TestEvalExpr(t *testing.T, tt *EvalTestItem) {
 	if len(g) != len(tt.Want) {
 		t.Errorf("%s returned a different number of metrics, actual %v, Want %v", testName, len(g), len(tt.Want))
 		return
-
 	}
-	DeepEqual(t, testName, originalMetrics, tt.M)
 
 	for i, want := range tt.Want {
 		actual := g[i]
@@ -488,4 +485,10 @@ func TestEvalExpr(t *testing.T, tt *EvalTestItem) {
 			return
 		}
 	}
+}
+
+func TestEvalExpr(t *testing.T, tt *EvalTestItem) {
+	originalMetrics := DeepClone(tt.M)
+	TestEvalExprModifiedOrigin(t, tt)
+	DeepEqual(t, tt.Target, originalMetrics, tt.M)
 }

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -484,6 +484,9 @@ func TestEvalExprModifiedOrigin(t *testing.T, tt *EvalTestItem) {
 			t.Errorf("different values for %s metric %s: got %v, Want %v", testName, actual.Name, actual.Values, want.Values)
 			return
 		}
+		if actual.StepTime != want.StepTime {
+			t.Errorf("different StepTime for %s metric %s: got %v, Want %v", testName, actual.Name, actual.StepTime, want.StepTime)
+		}
 	}
 }
 

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -487,6 +487,9 @@ func TestEvalExprModifiedOrigin(t *testing.T, tt *EvalTestItem) {
 		if actual.StepTime != want.StepTime {
 			t.Errorf("different StepTime for %s metric %s: got %v, Want %v", testName, actual.Name, actual.StepTime, want.StepTime)
 		}
+		if actual.StartTime != want.StartTime {
+			t.Errorf("different StartTime for %s metric %s: got %v, Want %v", testName, actual.Name, actual.StartTime, want.StartTime)
+		}
 	}
 }
 

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -490,6 +490,9 @@ func TestEvalExprModifiedOrigin(t *testing.T, tt *EvalTestItem) {
 		if actual.StartTime != want.StartTime {
 			t.Errorf("different StartTime for %s metric %s: got %v, Want %v", testName, actual.Name, actual.StartTime, want.StartTime)
 		}
+		if actual.StopTime != want.StopTime {
+			t.Errorf("different StopTime for %s metric %s: got %v, Want %v", testName, actual.Name, actual.StopTime, want.StopTime)
+		}
 	}
 }
 


### PR DESCRIPTION
Currently, the issues like `runtime error: index out of range [288] with length 288` are possible. The stack-trace is

```
 0  0x000000000043aa64 in runtime.goPanicIndex
    at /usr/lib/go/src/runtime/panic.go:88
 1  0x0000000000f320c6 in github.com/go-graphite/carbonapi/expr/functions/asPercent.(*asPercent).Do.func5
    at ./expr/functions/asPercent/function.go:90
 2  0x0000000000f2ef17 in github.com/go-graphite/carbonapi/expr/functions/asPercent.(*asPercent).Do
    at ./expr/functions/asPercent/function.go:284
 3  0x0000000001004e05 in github.com/go-graphite/carbonapi/expr.EvalExpr
```

Here is a list of changes:

- Align total and first series in asPercent function
- Add tests helper for case of modified initial metrics
- Add a check for StepTime and adjust tests
- Add a check for StartTime and adjust tests
- Add a check for StopTime, adjust tests and fix functions