### PR TITLE
Move precision alignment from per-target zipper to per-request FetchAndEvalExp

### DIFF
--- a/cmd/carbonapi/http/main_test.go
+++ b/cmd/carbonapi/http/main_test.go
@@ -52,6 +52,10 @@ func (z mockCarbonZipper) TagValues(ctx context.Context, query string, limit int
 	return []string{}, nil
 }
 
+func (z mockCarbonZipper) ScaleToCommonStep() bool {
+	return true
+}
+
 func getGlobResponse() *pb.MultiGlobResponse {
 	globMtach := pb.GlobMatch{Path: "foo.bar", IsLeaf: true}
 	var matches []pb.GlobMatch

--- a/cmd/carbonapi/interfaces/zipper.go
+++ b/cmd/carbonapi/interfaces/zipper.go
@@ -19,4 +19,5 @@ type CarbonZipper interface {
 	Render(ctx context.Context, request pb.MultiFetchRequest) ([]*types.MetricData, *zipperTypes.Stats, merry.Error)
 	TagNames(ctx context.Context, query string, limit int64) ([]string, merry.Error)
 	TagValues(ctx context.Context, query string, limit int64) ([]string, merry.Error)
+	ScaleToCommonStep() bool
 }

--- a/cmd/carbonapi/zipper.go
+++ b/cmd/carbonapi/zipper.go
@@ -98,9 +98,6 @@ func (z zipper) Render(ctx context.Context, request pb.MultiFetchRequest) ([]*ty
 				Tags:          tags,
 			})
 		}
-		if z.z.ScaleToCommonStep {
-			result = helper.ScaleToCommonStep(result)
-		}
 	}
 
 	sort.Sort(helper.ByNameNatural(result))
@@ -127,4 +124,8 @@ func (z zipper) TagNames(ctx context.Context, query string, limit int64) ([]stri
 
 func (z zipper) TagValues(ctx context.Context, query string, limit int64) ([]string, merry.Error) {
 	return z.z.TagValues(ctx, query, limit)
+}
+
+func (z zipper) ScaleToCommonStep() bool {
+	return z.z.ScaleToCommonStep
 }

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -97,7 +97,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 	case "diffSeriesLists":
 		compute = func(l, r float64) float64 { return l - r }
 	case "powSeriesLists":
-		compute = func(l, r float64) float64 { return math.Pow(l, r) }
+		compute = math.Pow
 	}
 
 	if useConstant {

--- a/expr/functions/weightedAverage/function.go
+++ b/expr/functions/weightedAverage/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // weightedAverage(seriesListAvg, seriesListWeight, *nodes)
 func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	aggKeyPairs := make(map[string]map[string]*types.MetricData, 0)
+	aggKeyPairs := make(map[string]map[string]*types.MetricData)
 	var productList []*types.MetricData
 
 	avgs, err := helper.GetSeriesArg(e.Args()[0], from, until, values)

--- a/expr/helper/align.go
+++ b/expr/helper/align.go
@@ -37,20 +37,19 @@ func LCM(args ...int64) int64 {
 // GetCommonStep returns LCM(steps), changed (bool) for slice of metrics.
 // If all metrics have the same step, changed == false.
 func GetCommonStep(args []*types.MetricData) (commonStep int64, changed bool) {
-	changed = false
-	steps := make([]int64, 0, len(args))
-	firstStep := args[0].StepTime
+	steps := make([]int64, 0, 1)
+	stepsIndex := make(map[int64]struct{})
 	for _, arg := range args {
-		steps = append(steps, arg.StepTime)
-		if !changed && firstStep != arg.StepTime {
-			changed = true
+		if _, ok := stepsIndex[arg.StepTime]; !ok {
+			stepsIndex[arg.StepTime] = struct{}{}
+			steps = append(steps, arg.StepTime)
 		}
 	}
-	if !changed {
-		return firstStep, changed
+	if len(steps) == 1 {
+		return steps[0], false
 	}
 	commonStep = LCM(steps...)
-	return commonStep, changed
+	return commonStep, true
 }
 
 // ScaleToCommonStep returns the metrics, aligned LCM of all metrics steps.

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -345,6 +345,44 @@ func (r *MetricData) AggregateValues() {
 	r.aggregatedValues = aggV
 }
 
+// Copy returns the copy of r. If includeValues set to true, it copies values as well.
+func (r *MetricData) Copy(includeValues bool) *MetricData {
+	var values, aggregatedValues []float64
+	values = make([]float64, 0)
+	aggregatedValues = nil
+
+	if includeValues {
+		values = make([]float64, len(r.Values))
+		copy(values, r.Values)
+		if r.aggregatedValues != nil {
+			aggregatedValues = make([]float64, len(r.aggregatedValues))
+			copy(aggregatedValues, r.aggregatedValues)
+		}
+	}
+
+	return &MetricData{
+		FetchResponse: pb.FetchResponse{
+			Name:                    r.Name,
+			PathExpression:          r.PathExpression,
+			ConsolidationFunc:       r.ConsolidationFunc,
+			StartTime:               r.StartTime,
+			StopTime:                r.StopTime,
+			StepTime:                r.StepTime,
+			XFilesFactor:            r.XFilesFactor,
+			HighPrecisionTimestamps: r.HighPrecisionTimestamps,
+			Values:                  values,
+			AppliedFunctions:        r.AppliedFunctions,
+			RequestStartTime:        r.RequestStartTime,
+			RequestStopTime:         r.RequestStopTime,
+		},
+		GraphOptions:      r.GraphOptions,
+		ValuesPerPoint:    r.ValuesPerPoint,
+		aggregatedValues:  aggregatedValues,
+		Tags:              r.Tags,
+		AggregateFunction: r.AggregateFunction,
+	}
+}
+
 // MakeMetricData creates new metrics data with given metric timeseries
 func MakeMetricData(name string, values []float64, step, start int64) *MetricData {
 	return makeMetricDataWithTags(name, values, step, start, tags.ExtractTags(name))
@@ -354,13 +392,14 @@ func MakeMetricData(name string, values []float64, step, start int64) *MetricDat
 func makeMetricDataWithTags(name string, values []float64, step, start int64, tags map[string]string) *MetricData {
 	stop := start + int64(len(values))*step
 
-	return &MetricData{FetchResponse: pb.FetchResponse{
-		Name:      name,
-		Values:    values,
-		StartTime: start,
-		StepTime:  step,
-		StopTime:  stop,
-	},
+	return &MetricData{
+		FetchResponse: pb.FetchResponse{
+			Name:      name,
+			Values:    values,
+			StartTime: start,
+			StepTime:  step,
+			StopTime:  stop,
+		},
 		Tags: tags,
 	}
 }


### PR DESCRIPTION
It fixes an issue from #496.

With per-target strategy, it doesn't align StepTime always when it's needed. And sometimes the other way around, it aligns unnecessary values.

Changes here:

- Implement MetricData.Copy function
- Move ScaleToCommonStep logic from zipper to expr.FetchAndEvalExp
- Optimize GetCommonStep function
- Simplify powSeriesLists and make(map) in weightedAverage for DeepSource