### PR TITLE
Inherit tags from series in summarize

### DIFF
--- a/expr/functions/aggregateLine/function.go
+++ b/expr/functions/aggregateLine/function.go
@@ -83,6 +83,7 @@ func (f *aggregateLine) Do(ctx context.Context, e parser.Expr, from, until int64
 				RequestStopTime:   a.FetchResponse.RequestStopTime,
 				XFilesFactor:      a.FetchResponse.XFilesFactor,
 			},
+			Tags: a.Tags,
 		}
 		if keepStep {
 			r.FetchResponse.Values = make([]float64, len(a.Values))

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -859,6 +859,7 @@ func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricReq
 				Values:            newValues,
 				ConsolidationFunc: "average",
 			},
+			Tags:         map[string]string{"name": name},
 			GraphOptions: types.GraphOptions{Color: color},
 		}
 

--- a/expr/functions/constantLine/function.go
+++ b/expr/functions/constantLine/function.go
@@ -46,6 +46,7 @@ func (f *constantLine) Do(ctx context.Context, e parser.Expr, from, until int64,
 			Values:            newValues,
 			ConsolidationFunc: "max",
 		},
+		Tags: map[string]string{"name": fmt.Sprintf("%g", value)},
 	}
 
 	return []*types.MetricData{&p}, nil

--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -69,14 +69,17 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 		}
 		name += ")"
 
-		r := types.MetricData{FetchResponse: pb.FetchResponse{
-			Name:              name,
-			Values:            make([]float64, buckets, buckets+1),
-			StepTime:          bucketSize,
-			StartTime:         start,
-			StopTime:          stop,
-			ConsolidationFunc: "max",
-		}}
+		r := types.MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:              name,
+				Values:            make([]float64, buckets, buckets+1),
+				StepTime:          bucketSize,
+				StartTime:         start,
+				StopTime:          stop,
+				ConsolidationFunc: "max",
+			},
+			Tags: arg.Tags,
+		}
 
 		bucketEnd := start + bucketSize
 		t := arg.StartTime

--- a/expr/functions/integralByInterval/function.go
+++ b/expr/functions/integralByInterval/function.go
@@ -53,16 +53,19 @@ func (f *integralByInterval) Do(ctx context.Context, e parser.Expr, from, until 
 		currentTime := arg.StartTime
 
 		name := fmt.Sprintf("integralByInterval(%s,'%s')", arg.Name, e.Args()[1].StringValue())
-		result := types.MetricData{FetchResponse: pb.FetchResponse{
-			Name:              name,
-			Values:            make([]float64, len(arg.Values)),
-			StepTime:          arg.StepTime,
-			StartTime:         arg.StartTime,
-			StopTime:          arg.StopTime,
-			XFilesFactor:      arg.XFilesFactor,
-			PathExpression:    name,
-			ConsolidationFunc: arg.ConsolidationFunc,
-		}}
+		result := types.MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:              name,
+				Values:            make([]float64, len(arg.Values)),
+				StepTime:          arg.StepTime,
+				StartTime:         arg.StartTime,
+				StopTime:          arg.StopTime,
+				XFilesFactor:      arg.XFilesFactor,
+				PathExpression:    name,
+				ConsolidationFunc: arg.ConsolidationFunc,
+			},
+			Tags: arg.Tags,
+		}
 		for i, v := range arg.Values {
 			if (currentTime-startTime)/bucketSize != (currentTime-startTime-arg.StepTime)/bucketSize {
 				current = 0

--- a/expr/functions/multiplySeries/function.go
+++ b/expr/functions/multiplySeries/function.go
@@ -35,12 +35,16 @@ func (f *multiplySeries) Do(ctx context.Context, e parser.Expr, from, until int6
 		FetchResponse: pb.FetchResponse{
 			Name: fmt.Sprintf("multiplySeries(%s)", e.RawArgs()),
 		},
+		Tags: nil,
 	}
 
 	for _, arg := range e.Args() {
 		series, err := helper.GetSeriesArg(arg, from, until, values)
 		if err != nil {
 			return nil, err
+		}
+		if r.Tags == nil {
+			r.Tags = series[0].Tags
 		}
 
 		if r.Values == nil {

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -76,14 +76,17 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 			name += ")"
 		}
 
-		r := types.MetricData{FetchResponse: pb.FetchResponse{
-			Name:              name,
-			Values:            make([]float64, buckets, buckets+1),
-			StepTime:          bucketSize,
-			StartTime:         start,
-			StopTime:          stop,
-			ConsolidationFunc: summarizeFunction,
-		}}
+		r := types.MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:              name,
+				Values:            make([]float64, buckets, buckets+1),
+				StepTime:          bucketSize,
+				StartTime:         start,
+				StopTime:          stop,
+				ConsolidationFunc: summarizeFunction,
+			},
+			Tags: arg.Tags,
+		}
 
 		t := arg.StartTime // unadjusted
 		bucketEnd := start + bucketSize

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -96,29 +96,35 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 
 		if arg.StepTime > bucketSize {
 			// We don't have enough data to do math
-			results = append(results, &types.MetricData{FetchResponse: pb.FetchResponse{
-				Name:              name,
-				Values:            arg.Values,
-				StepTime:          arg.StepTime,
-				StartTime:         arg.StartTime,
-				StopTime:          arg.StopTime,
-				XFilesFactor:      arg.XFilesFactor,
-				PathExpression:    arg.PathExpression,
-				ConsolidationFunc: arg.ConsolidationFunc,
-			}})
+			results = append(results, &types.MetricData{
+				FetchResponse: pb.FetchResponse{
+					Name:              name,
+					Values:            arg.Values,
+					StepTime:          arg.StepTime,
+					StartTime:         arg.StartTime,
+					StopTime:          arg.StopTime,
+					XFilesFactor:      arg.XFilesFactor,
+					PathExpression:    arg.PathExpression,
+					ConsolidationFunc: arg.ConsolidationFunc,
+				},
+				Tags: arg.Tags,
+			})
 			continue
 		}
 
-		r := types.MetricData{FetchResponse: pb.FetchResponse{
-			Name:              name,
-			Values:            make([]float64, buckets),
-			StepTime:          bucketSize,
-			StartTime:         start,
-			StopTime:          stop,
-			XFilesFactor:      arg.XFilesFactor,
-			PathExpression:    name,
-			ConsolidationFunc: arg.ConsolidationFunc,
-		}}
+		r := types.MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:              name,
+				Values:            make([]float64, buckets),
+				StepTime:          bucketSize,
+				StartTime:         start,
+				StopTime:          stop,
+				XFilesFactor:      arg.XFilesFactor,
+				PathExpression:    name,
+				ConsolidationFunc: arg.ConsolidationFunc,
+			},
+			Tags: arg.Tags,
+		}
 
 		t := arg.StartTime // unadjusted
 		bucketEnd := start + bucketSize

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -329,6 +329,9 @@ func TestSummarizeEvalExpr(t *testing.T, tt *SummarizeEvalTestItem) {
 		if g[0].Name != tt.Name {
 			t.Errorf("bad Name for %+v: got %v, want %v", g, g[0].Name, tt.Name)
 		}
+		if _, ok := g[0].Tags["name"]; !ok {
+			t.Errorf("metric with name %v doesn't contain 'name' tag", g[0].Name)
+		}
 	})
 }
 
@@ -470,6 +473,9 @@ func TestEvalExprModifiedOrigin(t *testing.T, tt *EvalTestItem) {
 
 	for i, want := range tt.Want {
 		actual := g[i]
+		if _, ok := actual.Tags["name"]; !ok {
+			t.Errorf("metric %+v with name %v doesn't contain 'name' tag", actual, actual.Name)
+		}
 		if actual == nil {
 			t.Errorf("returned no value %v", tt.Target)
 			return


### PR DESCRIPTION
This one fixes functions, that don't inherit or create tags for returned metrics.

Without this, `aliasByNode` is broken for every function without `name` tag after #507 