### PR TITLE
Fix tags for *WithWildcards, leave origin metrics unmodified in asPercent and diffSeries

### DIFF
--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -48,7 +48,7 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	var results []*types.MetricData
 
 	if len(e.Args()) == 1 {
-		arg = helper.AlignSeries(arg)
+		arg = helper.AlignSeries(types.CopyMetricDataSlice(arg))
 		getTotal = func(i int) float64 {
 			var t float64
 			var atLeastOne bool
@@ -73,7 +73,7 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		if err != nil {
 			return nil, err
 		}
-		arg = helper.AlignSeries(arg)
+		arg = helper.AlignSeries(types.CopyMetricDataSlice(arg))
 		getTotal = func(i int) float64 { return total }
 		totalString = fmt.Sprintf("%g", total)
 		formatName = func(a, b string) string {
@@ -89,7 +89,7 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			return nil, types.ErrWildcardNotAllowed
 		}
 
-		alignedSeries := helper.AlignSeries(append(arg, total...))
+		alignedSeries := helper.AlignSeries(types.CopyMetricDataSlice(append(arg, total...)))
 		arg = alignedSeries[0:len(arg)]
 		total = alignedSeries[len(arg):]
 
@@ -123,7 +123,7 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			return nil, types.ErrWildcardNotAllowed
 		}
 
-		alignedSeries := helper.AlignSeries(append(arg, total...))
+		alignedSeries := helper.AlignSeries(types.CopyMetricDataSlice(append(arg, total...)))
 		arg = alignedSeries[0:len(arg)]
 		total = alignedSeries[len(arg):]
 

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -149,7 +149,7 @@ func TestAliasByNode(t *testing.T) {
 	for _, tt := range testAlignments {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt)
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 }

--- a/expr/functions/averageSeriesWithWildcards/function.go
+++ b/expr/functions/averageSeriesWithWildcards/function.go
@@ -74,6 +74,11 @@ func (f *averageSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from
 		args := groups[series]
 		r := *args[0]
 		r.Name = fmt.Sprintf("averageSeriesWithWildcards(%s)", series)
+		r.Tags = make(map[string]string)
+		for k, v := range args[0].Tags {
+			r.Tags[k] = v
+		}
+		r.Tags["name"] = series
 		r.Values = make([]float64, len(args[0].Values))
 
 		length := make([]float64, len(args[0].Values))

--- a/expr/functions/diffSeries/function.go
+++ b/expr/functions/diffSeries/function.go
@@ -55,7 +55,7 @@ func (f *diffSeries) Do(ctx context.Context, e parser.Expr, from, until int64, v
 		e.SetRawArgs(strings.Join(args, ","))
 	}
 
-	alignedSeries := helper.AlignSeries(append(minuends, subtrahends...))
+	alignedSeries := helper.AlignSeries(types.CopyMetricDataSlice(append(minuends, subtrahends...)))
 	minuends = alignedSeries[0:len(minuends)]
 	subtrahends = alignedSeries[len(minuends):]
 

--- a/expr/functions/diffSeries/function_test.go
+++ b/expr/functions/diffSeries/function_test.go
@@ -91,7 +91,7 @@ func TestDiffSeries(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt)
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/multiplySeriesWithWildcards/function.go
+++ b/expr/functions/multiplySeriesWithWildcards/function.go
@@ -75,6 +75,11 @@ func (f *multiplySeriesWithWildcards) Do(ctx context.Context, e parser.Expr, fro
 		args := groups[series]
 		r := *args[0]
 		r.Name = fmt.Sprintf("multiplySeriesWithWildcards(%s)", series)
+		r.Tags = make(map[string]string)
+		for k, v := range args[0].Tags {
+			r.Tags[k] = v
+		}
+		r.Tags["name"] = series
 		r.Values = make([]float64, len(args[0].Values))
 
 		atLeastOne := make([]bool, len(args[0].Values))

--- a/expr/functions/sumSeriesWithWildcards/function.go
+++ b/expr/functions/sumSeriesWithWildcards/function.go
@@ -74,6 +74,11 @@ func (f *sumSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from, un
 		args := groups[series]
 		r := *args[0]
 		r.Name = fmt.Sprintf("sumSeriesWithWildcards(%s)", series)
+		r.Tags = make(map[string]string)
+		for k, v := range args[0].Tags {
+			r.Tags[k] = v
+		}
+		r.Tags["name"] = series
 		r.Values = make([]float64, len(args[0].Values))
 
 		atLeastOne := make([]bool, len(args[0].Values))

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -349,15 +349,25 @@ func (r *MetricData) AggregateValues() {
 func (r *MetricData) Copy(includeValues bool) *MetricData {
 	var values, aggregatedValues []float64
 	values = make([]float64, 0)
+	appliedFunctions := make([]string, 0)
 	aggregatedValues = nil
 
 	if includeValues {
 		values = make([]float64, len(r.Values))
 		copy(values, r.Values)
+
 		if r.aggregatedValues != nil {
 			aggregatedValues = make([]float64, len(r.aggregatedValues))
 			copy(aggregatedValues, r.aggregatedValues)
 		}
+
+		appliedFunctions = make([]string, len(r.AppliedFunctions))
+		copy(appliedFunctions, r.AppliedFunctions)
+	}
+
+	tags := make(map[string]string)
+	for k, v := range r.Tags {
+		tags[k] = v
 	}
 
 	return &MetricData{
@@ -371,14 +381,14 @@ func (r *MetricData) Copy(includeValues bool) *MetricData {
 			XFilesFactor:            r.XFilesFactor,
 			HighPrecisionTimestamps: r.HighPrecisionTimestamps,
 			Values:                  values,
-			AppliedFunctions:        r.AppliedFunctions,
+			AppliedFunctions:        appliedFunctions,
 			RequestStartTime:        r.RequestStartTime,
 			RequestStopTime:         r.RequestStopTime,
 		},
 		GraphOptions:      r.GraphOptions,
 		ValuesPerPoint:    r.ValuesPerPoint,
 		aggregatedValues:  aggregatedValues,
-		Tags:              r.Tags,
+		Tags:              tags,
 		AggregateFunction: r.AggregateFunction,
 	}
 }

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -383,6 +383,16 @@ func (r *MetricData) Copy(includeValues bool) *MetricData {
 	}
 }
 
+// CopyMetricDataSlice returns the slice of metrics that should be changed later.
+// It allows to avoid a changing of source data, e.g. by AlignMetrics
+func CopyMetricDataSlice(args []*MetricData) (newData []*MetricData) {
+	newData = make([]*MetricData, len(args))
+	for i, m := range args {
+		newData[i] = m.Copy(true)
+	}
+	return newData
+}
+
 // MakeMetricData creates new metrics data with given metric timeseries
 func MakeMetricData(name string, values []float64, step, start int64) *MetricData {
 	return makeMetricDataWithTags(name, values, step, start, tags.ExtractTags(name))


### PR DESCRIPTION
- Update tag `name` in *WithWildcards functions
- Implement types.CopyMetricDataSlice function
- Use it to leave metrics unmodified by helper.AlignSeries
- Preserv all origin maps and slices during MetricData.Copy


The place where it is better to apply types.CopyMetricDataSlice, outside or inside of AlignSeries, is discussable, though.