### PR TITLE
Replace stop with end when calling Prometheus

### DIFF
--- a/zipper/protocols/prometheus/prometheus_group.go
+++ b/zipper/protocols/prometheus/prometheus_group.go
@@ -271,7 +271,7 @@ func (c *PrometheusGroup) Fetch(ctx context.Context, request *protov3.MultiFetch
 			v := url.Values{
 				"query": []string{target},
 				"start": []string{strconv.Itoa(int(start))},
-				"stop":  []string{strconv.Itoa(int(stop))},
+				"end":   []string{strconv.Itoa(int(stop))},
 				"step":  []string{stepLocalStr},
 			}
 


### PR DESCRIPTION
Prometheus uses end parameter to specify the time range. Stop is not recognized and will be ignored. If end is not specified it will use now as the default upper bound for the range.

Prometheus doc: https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
See comment: https://github.com/go-graphite/carbonapi/issues/504#issuecomment-668632252