### PR TITLE
Add a check if multiFetchRequest already contain the metric

### DIFF
--- a/cmd/mockbackend/e2etesting.go
+++ b/cmd/mockbackend/e2etesting.go
@@ -136,6 +136,9 @@ func isMetricsEqual(m1, m2 CarbonAPIResponse) error {
 	}
 	datapointsMismatch := false
 	for i := range m1.Datapoints {
+		if math.IsNaN(m1.Datapoints[i].Value) && math.IsNaN(m2.Datapoints[i].Value) {
+			continue
+		}
 		if m1.Datapoints[i].Value != m2.Datapoints[i].Value {
 			datapointsMismatch = true
 			break

--- a/cmd/mockbackend/testcases/pr529/pr529.yaml
+++ b/cmd/mockbackend/testcases/pr529/pr529.yaml
@@ -1,0 +1,30 @@
+version: "v1"
+test:
+    apps:
+        - name: "carbonapi"
+          binary: "./carbonapi"
+          args:
+              - "-config"
+              - "./cmd/mockbackend/carbonapi_singlebackend.yaml"
+    queries:
+            - endpoint: "http://127.0.0.1:8081"
+              delay: 1
+              type: "GET"
+              URL: "/render?format=json&target=maxSeries(metric,asPercent(timeShift(metric,'1s'),metric))"
+              expectedResponse:
+                  httpCode: 200
+                  contentType: "application/json"
+                  expectedResults:
+                          - metrics:
+                                  - target: "maxSeries(metric,asPercent(timeShift(metric,'1s'),metric))"
+                                    datapoints: [[1,3],[100,4],[100,5],[100,6],[100,7],["null", 8]]
+listeners:
+        - address: ":9070"
+          expressions:
+                     "metric":
+                         pathExpression: "metric"
+                         data:
+                             - metricName: "metric"
+                               values: [1.0, 1.0, 1.0, 1.0, 1.0]
+                               step: 1
+                               startTime: 3

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -55,6 +55,11 @@ func (eval evaluator) FetchAndEvalExp(ctx context.Context, exp parser.Expr, from
 			continue
 		}
 
+		// avoid multiple requests from the same target, e.g. target=max(a,asPercent(holtWintersForecast(a),a))
+		if _, ok := targetValues[metricRequest]; ok {
+			continue
+		}
+
 		metricRequestCache[m.Metric] = metricRequest
 		targetValues[metricRequest] = nil
 		multiFetchRequest.Metrics = append(multiFetchRequest.Metrics, fetchRequest)


### PR DESCRIPTION
@lomik has reported an issue when the request is failed for some reason. 

Maybe #526 is related to this as well