### PR TITLE
Format date using UTC for CSV output

### DIFF
--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -45,7 +45,7 @@ func MarshalCSV(results []*MetricData) []byte {
 		step := r.StepTime
 		t := r.StartTime
 		for _, v := range r.Values {
-			b = append(b, "\""+r.Name+"\","+time.Unix(t, 0).Format("2006-01-02 15:04:05")+","...)
+			b = append(b, "\""+r.Name+"\","+time.Unix(t, 0).UTC().Format("2006-01-02 15:04:05")+","...)
 			if !math.IsNaN(v) {
 				b = strconv.AppendFloat(b, v, 'f', -1, 64)
 			}


### PR DESCRIPTION
When formatting as CSV, carbonapi will always format the timestamp based on local timezone. The `tz` config option and the `tz` URL param option have no effect on this.

The problem is that this format includes no timezone information (e.g. `2006-01-02 15:04:05`) to match the output from graphite-web. This is pariticularly an issue with Daylight Saving Time changes.

By default graphite-web will format as UTC so this changes matches that behaviour.