### PR TITLE
Backend-specific maxGlobs settings should have higher priority than g…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,9 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
+**CarbonAPI Version**
+What's the CarbonAPI version you are running? Does this issue reproducible on current master?
+
 **Logs**
 If applicable, add logs (please use log level debug) that shows the whole duration of the request. Request can be identified by UUID if needed.
 
@@ -19,6 +22,8 @@ Please include carbonapi config file that you are using (please replace all info
 **Simplified query (if applicable)**
 Please provide a query that triggered the issue, ideally narrowed down to smallest possible set of functions.
 
+If you have a complex query like `someFunction(otherFunction(yetAnotherFunction(metric.name), some_paramters), some.other.metric.name)` it is very helpful to try to remove some of the functions around the `metric.name` and check which one triggers the problem.
+
 **Backend metric retention and aggregation schemas**
 Please provide backend's schema (most important thing - if query cross retention period or not), aggregation function, xFilesFactor (if applicable).
 
@@ -27,6 +32,10 @@ If that's possible - please share some sample set of backend responses. Most imp
 1. Are all backend responses the same? If not, what's the difference?
 2. Do they contain special values, like Inf/NaN values?
 3. Do all of them have same step?
+
+To get the backend response, you can send request for the same metrics towards the backend:
+1. You should remove all the functions from the request as most backends do not support any of them
+2. You might need to convert relative time offsets to unix time, e.x. if you have "from=-1h" you might need to pass `from={current-timestamp}-3600&until={current-timestamp}` where `{current timestamp}` should be replaced by actual value. On some systems you can use command line to get current timestamp `date +%s` or even you can ask for a timestamp that was 1 hour ago: `date +%s --date="1 hour ago"`
 
 **Additional context**
 Add any other context about the problem here. Like version of a backend.

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -22,7 +22,7 @@ for t in ${TESTS}; do
 		travis_fold end "test_${t}"
 	fi
 
-
+	sleep 10
 	if [[ ${status} -ne 0 ]]; then
 		FAILED_TESTS="${FAILED_TESTS} ${t}"
 		echo "test_${t}: FAIL"

--- a/expr/functions/cairo/png/picture_params.go
+++ b/expr/functions/cairo/png/picture_params.go
@@ -3,6 +3,7 @@ package png
 import (
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -215,8 +216,20 @@ func GetPictureParamsWithTemplate(r *http.Request, template string, metricData [
 	if !ok {
 		t = templates["default"]
 	}
+
+	pixelRatioParam := ""
+	if r.Header.Get("Referer") != "" {
+		u, err := url.Parse(r.Header.Get("Referer"))
+		if err == nil {
+			pixelRatioParam = u.Query().Get("pixelRatio")
+		}
+	}
+	if r.FormValue("pixelRatio") != "" {
+		pixelRatioParam = r.FormValue("pixelRatio")
+	}
+
 	return PictureParams{
-		PixelRatio: getFloat64(r.FormValue("pixelRatio"), 1.0),
+		PixelRatio: getFloat64(pixelRatioParam, 1.0),
 		Width:      getFloat64(r.FormValue("width"), t.Width),
 		Height:     getFloat64(r.FormValue("height"), t.Height),
 		Margin:     getInt(r.FormValue("margin"), t.Margin),

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -39,6 +39,10 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 
 	var argstr string
 
+	if len(e.Args()) < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	switch e.Args()[1].Type() {
 	case parser.EtConst:
 		n, err = e.GetIntArg(1)

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -27,6 +27,13 @@ func TestMoving(t *testing.T) {
 
 	tests := []th.EvalTestItem{
 		{
+			"movingAverage(metric1,'3sec')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,"3sec")`, []float64{2, 2, 2}, 1, 0)}, // StartTime = from
+		},
+		{
 			"movingAverage(metric1,4)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, now32)},

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -86,7 +86,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 		r := *a
 		r.Name = fmt.Sprintf("movingMedian(%s,%s)", a.Name, argstr)
 		r.Values = make([]float64, len(a.Values)-offset)
-		r.StartTime = from
+		r.StartTime = (from + r.StepTime - 1) / r.StepTime * r.StepTime // align StartTime to closest >= StepTime
 		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
 
 		data := movingmedian.NewMovingMedian(windowSize)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -184,6 +184,9 @@ func (e *expr) Metrics() []MetricRequest {
 				r[i].From -= 7 * 86400 // starts -7 days from where the original starts
 			}
 		case "movingAverage", "movingMedian", "movingMin", "movingMax", "movingSum":
+			if len(e.args) < 2 {
+				return nil
+			}
 			if e.args[1].etype == EtString {
 				offs, err := e.GetIntervalArg(1, 1)
 				if err != nil {

--- a/zipper/types/response.go
+++ b/zipper/types/response.go
@@ -36,14 +36,14 @@ func NoAnswerBackends(backends []BackendServer, answered map[string]struct{}) []
 }
 
 // Helper function
-func DoRequest(ctx context.Context, logger *zap.Logger, clients []BackendServer, result ServerFetcherResponse, requests interface{}, fetcher Fetcher) (ServerFetcherResponse, int) {
+func DoRequest(ctx context.Context, logger *zap.Logger, clients []BackendServer, result ServerFetcherResponse, request interface{}, fetcher Fetcher) (ServerFetcherResponse, int) {
 	resCh := make(chan ServerFetcherResponse, len(clients))
 
 	for _, client := range clients {
 		logger.Debug("single fetch",
 			zap.Any("client", client),
 		)
-		go fetcher(ctx, logger, client, requests, resCh)
+		go fetcher(ctx, logger, client, request, resCh)
 	}
 
 	answeredServers := make(map[string]struct{})


### PR DESCRIPTION
…lobal setting

It seems that current split logic doesn't work well as global value should be the default one,
but backends should be able to redefine it: enforce not splitting the request or actually enforce
request to be splitted, depending on preferences.

Rework splitting logic to actually use backend-specific setting.