### PR TITLE
Catch panic in moving functions

### DIFF
--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -39,6 +39,10 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 
 	var argstr string
 
+	if len(e.Args()) < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	switch e.Args()[1].Type() {
 	case parser.EtConst:
 		n, err = e.GetIntArg(1)

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -27,6 +27,13 @@ func TestMoving(t *testing.T) {
 
 	tests := []th.EvalTestItem{
 		{
+			"movingAverage(metric1,'3sec')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,"3sec")`, []float64{2, 2, 2}, 1, 0)}, // StartTime = from
+		},
+		{
 			"movingAverage(metric1,4)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, now32)},

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -86,7 +86,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 		r := *a
 		r.Name = fmt.Sprintf("movingMedian(%s,%s)", a.Name, argstr)
 		r.Values = make([]float64, len(a.Values)-offset)
-		r.StartTime = from
+		r.StartTime = (from + r.StepTime - 1) / r.StepTime * r.StepTime // align StartTime to closest >= StepTime
 		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
 
 		data := movingmedian.NewMovingMedian(windowSize)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -184,6 +184,9 @@ func (e *expr) Metrics() []MetricRequest {
 				r[i].From -= 7 * 86400 // starts -7 days from where the original starts
 			}
 		case "movingAverage", "movingMedian", "movingMin", "movingMax", "movingSum":
+			if len(e.args) < 2 {
+				return nil
+			}
 			if e.args[1].etype == EtString {
 				offs, err := e.GetIntervalArg(1, 1)
 				if err != nil {


### PR DESCRIPTION
It fixes #537 and propagates the error from `moving*` functions