### PR TITLE
Add `add` function and tests for it

### DIFF
--- a/expr/functions/offset/function.go
+++ b/expr/functions/offset/function.go
@@ -21,7 +21,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &offset{}
-	functions := []string{"offset"}
+	functions := []string{"add", "offset"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
@@ -42,7 +42,7 @@ func (f *offset) Do(ctx context.Context, e parser.Expr, from, until int64, value
 
 	for _, a := range arg {
 		r := *a
-		r.Name = fmt.Sprintf("offset(%s,%g)", a.Name, factor)
+		r.Name = fmt.Sprintf("%s(%s,%g)", e.Target(), a.Name, factor)
 		r.Values = make([]float64, len(a.Values))
 
 		for i, v := range a.Values {
@@ -56,6 +56,25 @@ func (f *offset) Do(ctx context.Context, e parser.Expr, from, until int64, value
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
 func (f *offset) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
+		"add": {
+			Description: "Takes one metric or a wildcard seriesList followed by a constant, and adds the constant to\neach datapoint.\n\nExample:\n\n.. code-block:: none\n\n  &target=add(Server.instance01.threads.busy,10)\n  &target=add(Server.instance*.threads.busy, 10)",
+			Function:    "add(seriesList, constant)",
+			Group:       "Transform",
+			Module:      "graphite.render.functions",
+			Name:        "add",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "constant",
+					Required: true,
+					Type:     types.Float,
+				},
+			},
+		},
 		"offset": {
 			Description: "Takes one metric or a wildcard seriesList followed by a constant, and adds the constant to\neach datapoint.\n\nExample:\n\n.. code-block:: none\n\n  &target=offset(Server.instance01.threads.busy,10)",
 			Function:    "offset(seriesList, factor)",

--- a/expr/functions/offset/function_test.go
+++ b/expr/functions/offset/function_test.go
@@ -34,6 +34,19 @@ func TestFunction(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("offset(metric1,10)",
 				[]float64{103, 104, 105, math.NaN(), 107, 108, 109, 110, 111}, 1, now32)},
 		},
+		{
+			"add(metric*,-10)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32),
+					types.MakeMetricData("metric2", []float64{193, 194, 195, math.NaN(), 197, 198, 199, 200, 201}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("add(metric1,-10)", []float64{83, 84, 85, math.NaN(), 87, 88, 89, 90, 91}, 1, now32),
+				types.MakeMetricData("add(metric2,-10)", []float64{183, 184, 185, math.NaN(), 187, 188, 189, 190, 191}, 1, now32),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The function `add` is an alias to the `offset` pretty much, see https://github.com/graphite-project/graphite-web/issues/2669.

This PR adds it to the functions list