### PR TITLE
Fix tag parsing for various replies from backends

### DIFF
--- a/cmd/mockbackend/testcases/i565/i565.yaml
+++ b/cmd/mockbackend/testcases/i565/i565.yaml
@@ -1,0 +1,28 @@
+version: "v1"
+test:
+    apps:
+        - name: "carbonapi"
+          binary: "./carbonapi"
+          args:
+              - "-config"
+              - "./cmd/mockbackend/carbonapi_singlebackend.yaml"
+    queries:
+            - endpoint: "http://127.0.0.1:8081"
+              delay: 1
+              type: "GET"
+              URL: "/render?format=json&target=seriesByTag('tag1=v1', 'tag2=v2')"
+              expectedResponse:
+                  httpCode: 200
+                  contentType: "application/json"
+                  expectedResults:
+                          - metrics:
+                                  - target: "metric;tag1=v1;tag2=v2;;tag4=v4"
+                                    datapoints: [[1.0, 1],[3.0, 2],[2.0, 3]]
+listeners:
+        - address: ":9070"
+          expressions:
+                     "seriesByTag('tag1=v1', 'tag2=v2')":
+                         pathExpression: "seriesByTag('tag1=v1', 'tag2=v2')"
+                         data:
+                             - metricName: "metric;tag1=v1;tag2=v2;;tag4=v4"
+                               values: [1.0, 3.0, 2.0]

--- a/expr/tags/helper.go
+++ b/expr/tags/helper.go
@@ -6,6 +6,11 @@ import (
 
 // ExtractTags extracts all graphite-style tags out of metric name
 // E.x. cpu.usage_idle;cpu=cpu-total;host=test => {"name": "cpu.usage_idle", "cpu": "cpu-total", "host": "test"}
+// There are some differences between how we handle tags and how graphite-web can do that. In our case it is possible
+// to have empty value as it doesn't make sense to skip tag in that case but can be potentially useful
+// Also we do not fail on invalid cases, but rather than silently skipping broken tags as some backends might accept
+// invalid tag and store it and one of the purposes of carbonapi is to keep working even if backends gives us slightly
+// broken replies.
 func ExtractTags(s string) map[string]string {
 	result := make(map[string]string)
 	idx := strings.IndexRune(s, ';')
@@ -20,13 +25,36 @@ func ExtractTags(s string) map[string]string {
 	for {
 		idx := strings.IndexRune(newS, ';')
 		if idx < 0 {
-			kv := strings.Split(newS, "=")
-			result[kv[0]] = kv[1]
+			firstEqualSignIdx := strings.IndexRune(newS, '=')
+			// tag starts with `=` sign or have zero length
+			if len(newS) == 0 || firstEqualSignIdx == 0 {
+				break
+			}
+			// tag doesn't have = sign at all
+			if firstEqualSignIdx == -1 {
+				result[newS] = ""
+				break
+			}
+
+			result[newS[:firstEqualSignIdx]] = newS[firstEqualSignIdx+1:]
 			break
 		}
 
-		kv := strings.Split(newS[:idx], "=")
-		result[kv[0]] = kv[1]
+		firstEqualSignIdx := strings.IndexRune(newS[:idx], '=')
+		// Got an empty tag or tag starts with `=`. That is totally broken, so skipping that
+		if idx == 0 || firstEqualSignIdx == 0 {
+			newS = newS[idx+1:]
+			continue
+		}
+
+		// Tag doesn't have value
+		if firstEqualSignIdx == -1 {
+			result[newS[:idx]] = ""
+			newS = newS[idx+1:]
+			continue
+		}
+
+		result[newS[:firstEqualSignIdx]] = newS[firstEqualSignIdx+1 : idx]
 		newS = newS[idx+1:]
 	}
 

--- a/expr/tags/helper_test.go
+++ b/expr/tags/helper_test.go
@@ -1,0 +1,89 @@
+package tags
+
+import (
+	"testing"
+)
+
+type extractTagTestCase struct {
+	TestName string
+	Input    string
+	Output   map[string]string
+}
+
+func TestExtractTags(t *testing.T) {
+	tests := []extractTagTestCase{
+		{
+			TestName: "NoTags",
+			Input:    "metric",
+			Output: map[string]string{
+				"name": "metric",
+			},
+		},
+		{
+			TestName: "FewTags",
+			Input:    "metricWithSomeTags;tag1=v1;tag2=v2;tag3=this is value with string",
+			Output: map[string]string{
+				"name": "metricWithSomeTags",
+				"tag1": "v1",
+				"tag2": "v2",
+				"tag3": "this is value with string",
+			},
+		},
+		{
+			TestName: "BrokenTags",
+			Input:    "metric;tag1=v1;;tag2=v2;tag3=;tag4;tag5=value=with=other=equal=signs;tag6=value=with-equal-signs-2",
+			Output: map[string]string{
+				"name": "metric",
+				"tag1": "v1",
+				"tag2": "v2",
+				"tag3": "",
+				"tag4": "",
+				"tag5": "value=with=other=equal=signs",
+				"tag6": "value=with-equal-signs-2",
+			},
+		},
+		{
+			TestName: "BrokenTags2",
+			Input:    "metric;tag1=v1;",
+			Output: map[string]string{
+				"name": "metric",
+				"tag1": "v1",
+			},
+		},
+		{
+			TestName: "BrokenTags2",
+			Input:    "metric;tag1",
+			Output: map[string]string{
+				"name": "metric",
+				"tag1": "",
+			},
+		},
+		{
+			TestName: "BrokenTags3",
+			Input:    "metric;=;=",
+			Output: map[string]string{
+				"name": "metric",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Input, func(t *testing.T) {
+			res := ExtractTags(tt.Input)
+
+			if len(res) != len(tt.Output) {
+				t.Fatalf("result length mismatch, got %v, expected %v", len(res), len(tt.Output))
+			}
+
+			for k, v := range res {
+				if expectedValue, ok := tt.Output[k]; ok {
+					if v != expectedValue {
+						t.Fatalf("value mismatch for key '%v': got '%v', exepcted '%v'", k, v, expectedValue)
+					}
+				} else {
+					t.Fatalf("got unexpected key %v=%v in result", k, v)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
    Backends in some cases might send responses with tags that are not valid
    according to https://graphite.readthedocs.io/en/latest/tags.html
    
    In that case we want to do our best to handle such replies.
    
    This commit changes current behavior (panic on any invalid reply and truncate other replies)
    to be more sane but not necessary match graphite's.
    
    Beahvior change are:
    1. Ignore empty tags (cut `;` from the tag if it was present), e.x. `metric1;;tag`
    2. Proper handling of values that have `=` in them
    3. If tag doesn't have value - consider that an empty value, e.x. `metric1;tag`
    4. Tags might have empty values e.x. `metric1;tag1=;tag2=v2`
    
    Fixes #565