### PR TITLE
Bump go version requirement to 1.14 and add test build on 1.16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         go:
-          - ^1.13
           - ^1.14
           - ^1.15
+          - ^1.16
           - ^1
     steps:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ git:
 
 matrix:
   include:
-    - go: "1.13.x"
-    - go: "1.14.x"
-    - go: "1.15.x"
+    - go: "1.16.x"
       env:
         - BUILD_PACKAGES=true

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Supported protocols
 Requirements
 ------------
 
-You need to have Go >= 1.13 to build carbonapi from sources. Building with Go 1.10 or earlier is not supported since 0.11.0. Building with Go 1.12 or earlier is not supported since 0.13.0.
+You need to have Go >= 1.14 to build carbonapi from sources. Building with Go 1.10 or earlier is not supported since 0.11.0. Building with Go 1.12 or earlier is not supported since 0.13.0.
 
 CarbonAPI uses protobuf-based protocol to talk with underlying storages. For current version the compatibility list is:
 


### PR DESCRIPTION
Even though carbonapi technically builds with 1.13, there is no need
to test such an old version of golang. Remove corresponding test for
github actions.

Also remove all go versions except latest from travis autobuilds as
since we've mostly migrated to github actions it just only do extra
work with no benefit