### PR TITLE
Set default Listeners only if Listen is omited

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ Changes
 
 CHANGELOG
 ---------
+
+**0.15.1**
+ - [Fix] Fix back compatibility for default listen on `localhost:8081` (thx to @Felixoid)
+
 **0.15.0**
  - **[Breaking]** - cache (including memcache) now uses sha256 for a hash function for keys. This might break existing setup
  - **[Breaking]** - new config variable `slowLogThreshold` under `upstreams` section controls what request time would be required for request to be logged in `slow` logger.

--- a/cmd/carbonapi/config/init.go
+++ b/cmd/carbonapi/config/init.go
@@ -246,6 +246,10 @@ func SetUpConfig(logger *zap.Logger, BuildVersion string) {
 		}
 	}
 
+	if len(Config.Listeners) == 0 {
+		Config.Listeners = append(Config.Listeners, Listener{Address: "localhost:8081"})
+	}
+
 	for _, define := range Config.Define {
 		if define.Name == "" {
 			logger.Fatal("empty define name")
@@ -321,9 +325,7 @@ func SetUpViper(logger *zap.Logger, configPath *string, viperPrefix string) {
 	}
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	_ = viper.BindEnv("tz", "carbonapi_tz")
-	viper.SetDefault("listeners", []Listener{{
-		Address: "localhost:8081",
-	}})
+	viper.SetDefault("listeners", []Listener{})
 	viper.SetDefault("concurency", 20)
 	viper.SetDefault("cache.type", "mem")
 	viper.SetDefault("cache.size_mb", 0)


### PR DESCRIPTION
Currently, if listeners are unspecified, it always has the default value. It was found in #576.

This PR sets the default Config.Listeners only if both `listen` and `listeners` omitted.