### PR TITLE
Honor isleaf atribute

### DIFF
--- a/zipper/broadcast/broadcast_group.go
+++ b/zipper/broadcast/broadcast_group.go
@@ -393,6 +393,9 @@ func (bg *BroadcastGroup) splitRequest(ctx context.Context, request *protov3.Mul
 
 		for _, m := range f.Metrics {
 			for _, match := range m.Matches {
+				if !match.IsLeaf {
+					continue
+				}
 				newRequest.Metrics = append(newRequest.Metrics, protov3.FetchRequest{
 					Name:            match.Path,
 					StartTime:       metric.StartTime,


### PR DESCRIPTION
this patch allow proper de duplication of metric names when some metric also have a children for example, whisper files layout:

```
put.wsp
put/
   somechild.wsp
```

without this carbonapi  will produce wrong results and some metrics for wildcard may put twice or more
