### PR TITLE
Scale input series to same value if they are passed to aggregate func…

### DIFF
--- a/cmd/mockbackend/render.go
+++ b/cmd/mockbackend/render.go
@@ -112,13 +112,13 @@ func (cfg *listener) renderHandler(wr http.ResponseWriter, req *http.Request) {
 			time.Sleep(delay)
 		}
 		for _, m := range response.Data {
-			startTime := m.StartTime
-			if startTime == 0 {
-				startTime = 1
-			}
 			step := m.Step
 			if step == 0 {
 				step = 1
+			}
+			startTime := m.StartTime
+			if startTime == 0 {
+				startTime = step
 			}
 			isAbsent := make([]bool, 0, len(m.Values))
 			protov2Values := make([]float64, 0, len(m.Values))
@@ -134,7 +134,7 @@ func (cfg *listener) renderHandler(wr http.ResponseWriter, req *http.Request) {
 			fr2 := carbonapi_v2_pb.FetchResponse{
 				Name:      m.MetricName,
 				StartTime: int32(startTime),
-				StopTime:  int32(step * (startTime + len(protov2Values) - 1)),
+				StopTime:  int32(startTime + step*len(protov2Values)),
 				StepTime:  int32(step),
 				Values:    protov2Values,
 				IsAbsent:  isAbsent,
@@ -145,13 +145,13 @@ func (cfg *listener) renderHandler(wr http.ResponseWriter, req *http.Request) {
 				PathExpression:          target,
 				ConsolidationFunc:       "avg",
 				StartTime:               int64(startTime),
-				StopTime:                int64(step * (startTime + len(m.Values) - 1)),
+				StopTime:                int64(startTime + step*len(m.Values)),
 				StepTime:                int64(step),
 				XFilesFactor:            0,
 				HighPrecisionTimestamps: false,
 				Values:                  m.Values,
 				RequestStartTime:        1,
-				RequestStopTime:         int64(step * (startTime + len(m.Values) - 1)),
+				RequestStopTime:         int64(startTime + step*len(m.Values)),
 			}
 
 			multiv2.Metrics = append(multiv2.Metrics, fr2)

--- a/cmd/mockbackend/testcases/i584/i584.yaml
+++ b/cmd/mockbackend/testcases/i584/i584.yaml
@@ -1,0 +1,25 @@
+version: "v1"
+test:
+    apps:
+        - name: "carbonapi"
+          binary: "./carbonapi"
+          args:
+              - "-config"
+              - "./cmd/mockbackend/carbonapi_singlebackend.yaml"
+    queries:
+            - endpoint: "http://127.0.0.1:8081"
+              delay: 1
+              type: "GET"
+              URL: "/render?format=json&maxDataPoints=3&target=diffSeries(time(\"t\"), some.metric)&from=0&until=360"
+              expectedResponse:
+                  httpCode: 200
+                  contentType: "application/json"
+listeners:
+        - address: ":9070"
+          expressions:
+                     "some.metric":
+                         pathExpression: "some.metric"
+                         data:
+                             - metricName: "some.metric"
+                               values: [3.0, 3.0, 3.0]
+                               step: 120

--- a/cmd/mockbackend/testcases/i584/i584.yaml
+++ b/cmd/mockbackend/testcases/i584/i584.yaml
@@ -10,14 +10,25 @@ test:
             - endpoint: "http://127.0.0.1:8081"
               delay: 1
               type: "GET"
-              URL: "/render?format=json&maxDataPoints=3&target=diffSeries(time(\"t\"), some.metric)&from=0&until=360"
+              URL: "/render?format=json&maxDataPoints=3&target=diffSeries(time(\"t\"), some.metric)&from=120&until=361"
               expectedResponse:
                   httpCode: 200
                   contentType: "application/json"
                   expectedResults:
                           - metrics:
                                   - target: "diffSeries(time(\"t\"), some.metric)"
-                                    datapoints: [[57,0],[177,120],[297,240]]
+                                    datapoints: [[177,120],[297,240],[357,360]]
+            - endpoint: "http://127.0.0.1:8081"
+              delay: 1
+              type: "GET"
+              URL: "/render?format=json&maxDataPoints=3&target=diffSeries(time(\"t\", 1), some.metric)&from=120&until=361"
+              expectedResponse:
+                  httpCode: 200
+                  contentType: "application/json"
+                  expectedResults:
+                          - metrics:
+                                  - target: "diffSeries(time(\"t\", 1), some.metric)"
+                                    datapoints: [[236,120],[356,240],[357,360]]
 
 listeners:
         - address: ":9070"

--- a/cmd/mockbackend/testcases/i584/i584.yaml
+++ b/cmd/mockbackend/testcases/i584/i584.yaml
@@ -14,6 +14,11 @@ test:
               expectedResponse:
                   httpCode: 200
                   contentType: "application/json"
+                  expectedResults:
+                          - metrics:
+                                  - target: "diffSeries(time(\"t\"), some.metric)"
+                                    datapoints: [[57,0],[177,120],[297,240]]
+
 listeners:
         - address: ":9070"
           expressions:

--- a/date/date.go
+++ b/date/date.go
@@ -74,8 +74,8 @@ func DateParamToEpoch(s, qtz string, d int64, defaultTimeZone *time.Location) in
 	}
 
 	sint, err := strconv.Atoi(s)
-	// need to check that len(s) > 8 to avoid turning 20060102 into seconds
-	if err == nil && len(s) > 8 {
+	// need to check that len(s) != 8 to avoid turning 20060102 into seconds
+	if err == nil && len(s) != 8 {
 		return int64(sint) // We got a timestamp so returning it
 	}
 

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -142,14 +142,10 @@ type AggregateFunc func([]float64) float64
 // AggregateSeries aggregates series
 func AggregateSeries(e parser.Expr, args []*types.MetricData, function AggregateFunc) ([]*types.MetricData, error) {
 	args = AlignSeries(args)
-	length := len(args[0].Values)
-	r := *args[0]
-	r.Name = fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
-	r.Values = make([]float64, length)
 
 	needScale := false
 	for i := 1; i < len(args); i++ {
-		if args[i].StartTime != r.StepTime {
+		if args[i].StepTime != args[0].StepTime {
 			needScale = true
 			break
 		}
@@ -157,6 +153,11 @@ func AggregateSeries(e parser.Expr, args []*types.MetricData, function Aggregate
 	if needScale {
 		ScaleToCommonStep(args, 0)
 	}
+
+	length := len(args[0].Values)
+	r := *args[0]
+	r.Name = fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
+	r.Values = make([]float64, length)
 
 	for i := range args[0].Values {
 		var values []float64

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -147,6 +147,17 @@ func AggregateSeries(e parser.Expr, args []*types.MetricData, function Aggregate
 	r.Name = fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
 	r.Values = make([]float64, length)
 
+	needScale := false
+	for i := 1; i < len(args); i++ {
+		if args[i].StartTime != r.StepTime {
+			needScale = true
+			break
+		}
+	}
+	if needScale {
+		ScaleToCommonStep(args, 0)
+	}
+
 	for i := range args[0].Values {
 		var values []float64
 		for _, arg := range args {


### PR DESCRIPTION
…tion

 * Because test requires to support `from=0` fixes data-time parsing to closer match graphite's:
   https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/attime.py#L126
 * Add `ScaleToCommonStep` to aggregate helper function

Fixes #584