### PR TITLE
Fix handling of partial-failed fetch requests that contain globs (onl…

### DIFF
--- a/cmd/mockbackend/runner.go
+++ b/cmd/mockbackend/runner.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 
 	"go.uber.org/zap"
@@ -41,9 +42,10 @@ func (r *runner) Run() {
 	if err != nil {
 		r.logger.Error("error running program",
 			zap.Any("config", r.App),
-			zap.String("output", string(out)),
+			zap.String("output", "will follow next"),
 			zap.Error(err),
 		)
+		fmt.Print(string(out))
 	}
 
 	r.isRunning = true

--- a/cmd/mockbackend/testcases/i545/carbonapi.yaml
+++ b/cmd/mockbackend/testcases/i545/carbonapi.yaml
@@ -1,0 +1,64 @@
+listen: "localhost:8081"
+notFoundStatusCode: 200
+
+cache:
+   type: "mem"
+   size_mb: 0
+   defaultTimeoutSec: 1
+
+backendCache:
+   type: "mem"
+   size_mb: 0
+   defaultTimeoutSec: 1
+
+upstreams:
+    graphite09compat: false
+    buckets: 10
+
+    concurrencyLimitPerServer: 0
+    keepAliveInterval: "3s"
+    maxIdleConnsPerHost: 100
+    timeouts:
+        find: "500ms"
+        render: "500ms"
+        connect: "250ms"
+
+    backendsv2:
+        backends:
+          -
+            groupName: "go-carbon-1"
+            protocol: "carbonapi_v3_pb"
+            lbMethod: "broadcast"
+            maxTries: 4
+            keepAliveInterval: "10s"
+            concurrencyLimit: 0
+            servers:
+                - "http://127.0.0.1:9070"
+                - "http://127.0.0.1:9071"
+          -
+            groupName: "go-carbon-2"
+            protocol: "carbonapi_v3_pb"
+            lbMethod: "broadcast"
+            maxTries: 4
+            keepAliveInterval: "10s"
+            concurrencyLimit: 0
+            servers:
+                - "http://127.0.0.1:9072"
+                - "http://127.0.0.1:9073"
+          -
+            groupName: "go-carbon-3"
+            protocol: "carbonapi_v3_pb"
+            lbMethod: "broadcast"
+            maxTries: 4
+            keepAliveInterval: "10s"
+            concurrencyLimit: 0
+            servers:
+                - "http://127.0.0.1:9074"
+                - "http://127.0.0.1:9075"
+logger:
+    - logger: ""
+      file: "stdout"
+      level: "debug"
+      encoding: "json"
+      encodingTime: "iso8601"
+      encodingDuration: "seconds"

--- a/cmd/mockbackend/testcases/i545/i545.yaml
+++ b/cmd/mockbackend/testcases/i545/i545.yaml
@@ -1,0 +1,36 @@
+version: "v1"
+test:
+    apps:
+        - name: "carbonapi"
+          binary: "./carbonapi"
+          args:
+              - "-config"
+              - "./cmd/mockbackend/testcases/i545/carbonapi.yaml"
+    queries:
+            - endpoint: "http://127.0.0.1:8081"
+              delay: 1
+              type: "GET"
+              URL: "/render/?target=a.*&format=json&from=1&until=6"
+              expectedResponse:
+                  httpCode: 200
+                  contentType: "application/json"
+                  expectedResults:
+                          - metrics:
+                                  - target: "a.open"
+                                    datapoints: [[0,1],[1,2],[2,3],[2,4],[3,5]]
+listeners:
+  - address: ":9070"
+    expressions:
+      "a.*":
+        pathExpression: "a.*"
+        data:
+            - metricName: "a.open"
+              values: [0,1,2,2,3]
+  - address: ":9072"
+    expressions:
+      "a.*":
+        pathExpression: "a.*"
+        replyDelayMS: 10000
+        data:
+            - metricName: "a.open"
+              values: [0,1,2,2,3]

--- a/zipper/broadcast/broadcast_group.go
+++ b/zipper/broadcast/broadcast_group.go
@@ -211,6 +211,7 @@ func (bg BroadcastGroup) MaxMetricsPerRequest() int {
 }
 
 func (bg *BroadcastGroup) doMultiFetch(ctx context.Context, logger *zap.Logger, backend types.BackendServer, reqs interface{}, resCh chan types.ServerFetcherResponse) {
+	logger = logger.With(zap.Bool("multi_fetch", true))
 	request, ok := reqs.(*protov3.MultiFetchRequest)
 	if !ok {
 		logger.Fatal("unhandled error in doMultiFetch",
@@ -221,7 +222,7 @@ func (bg *BroadcastGroup) doMultiFetch(ctx context.Context, logger *zap.Logger, 
 	}
 
 	requests, err := bg.splitRequest(ctx, request, backend)
-	if len(requests) == 0 || err != nil {
+	if len(requests) == 0 && err != nil {
 		response := types.NewServerFetchResponse()
 		response.Server = backend.Name()
 		response.AddError(err)
@@ -262,6 +263,7 @@ func (bg *BroadcastGroup) doMultiFetch(ctx context.Context, logger *zap.Logger, 
 }
 
 func (bg *BroadcastGroup) doSingleFetch(ctx context.Context, logger *zap.Logger, backend types.BackendServer, reqs interface{}, resCh chan types.ServerFetcherResponse) {
+	logger = logger.With(zap.Bool("multi_fetch", false))
 	request, ok := reqs.(*protov3.MultiFetchRequest)
 	if !ok {
 		logger.Fatal("unhandled error in doSingleFetch",
@@ -273,7 +275,7 @@ func (bg *BroadcastGroup) doSingleFetch(ctx context.Context, logger *zap.Logger,
 
 	//TODO(Civil): migrate limiter to merry
 	requests, splitErr := bg.splitRequest(ctx, request, backend)
-	if len(requests) == 0 || splitErr != nil {
+	if len(requests) == 0 && splitErr != nil {
 		response := types.NewServerFetchResponse()
 		response.Server = backend.Name()
 		response.AddError(splitErr)


### PR DESCRIPTION
…y when maxBatchSize > 0)

When request splitting was used and some of the servers didn't replied
but others did - such requests were handled as failed and no data
was returned, which resulted in error 500 from carbonapi.

Changing behavior in that case so requests that went through splitting
procedure will be fetched despite of partial failure to expand globs.

Fixes #545 