### PR TITLE
Align arguments of divideSeries when necessary

### DIFF
--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -64,8 +64,12 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		return nil, errors.New("must be called with 2 series or a wildcard that matches exactly 2 series")
 	}
 
+	alignedSeries := helper.AlignSeries(append(numerators, denominator))
+	numerators = alignedSeries[:len(numerators)]
+	denominator = alignedSeries[len(numerators)]
+
 	for _, numerator := range numerators {
-		if numerator.StepTime != denominator.StepTime || len(numerator.Values) != len(denominator.Values) {
+		if numerator.StepTime != denominator.StepTime {
 			return nil, fmt.Errorf("series %s must have the same length as %s", numerator.Name, denominator.Name)
 		}
 	}

--- a/expr/functions/divideSeries/function_test.go
+++ b/expr/functions/divideSeries/function_test.go
@@ -54,7 +54,6 @@ func TestDivideSeriesMultiReturn(t *testing.T) {
 			th.TestMultiReturnEvalExpr(t, &tt)
 		})
 	}
-
 }
 
 func TestDivideSeries(t *testing.T) {
@@ -89,5 +88,46 @@ func TestDivideSeries(t *testing.T) {
 			th.TestEvalExpr(t, &tt)
 		})
 	}
+}
 
+func TestDivideSeriesAligned(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"divideSeries(metric1,metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, now32),
+				},
+				{"metric2", 0, 1}: {
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("divideSeries(metric1,metric2)",
+				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, now32)},
+		},
+		{
+			"divideSeries(metric[23])",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[23]", 0, 1}: {
+					types.MakeMetricData("metric2", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, now32),
+					types.MakeMetricData("metric3", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("divideSeries(metric[23])",
+				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
+		})
+	}
 }


### PR DESCRIPTION
It's a quite high probability to get an error currently for apply devideSeries for results of some functions like movingMax and timeShift.