### PR TITLE
Check if metric name doesn't contain disallowed characters if matchin…

### DIFF
--- a/cmd/mockbackend/e2etesting.go
+++ b/cmd/mockbackend/e2etesting.go
@@ -261,7 +261,7 @@ func doTest(logger *zap.Logger, t *Query) []string {
 		for i := range res {
 			err := isMetricsEqual(res[i], t.ExpectedResponse.ExpectedResults[0].Metrics[i])
 			if err != nil {
-				failures = append(failures, fmt.Sprintf("metrics are not equal: %v", err))
+				failures = append(failures, fmt.Sprintf("metrics are not equal, err=`%v`, got=`%+v`, expected=`%+v`", err, res[i], t.ExpectedResponse.ExpectedResults[0].Metrics[i]))
 			}
 		}
 

--- a/cmd/mockbackend/testcases/i598/carbonapi.yaml
+++ b/cmd/mockbackend/testcases/i598/carbonapi.yaml
@@ -1,0 +1,79 @@
+listen: "localhost:8081"
+expvar:
+  enabled: true
+  pprofEnabled: false
+  listen: ""
+concurency: 1000
+notFoundStatusCode: 404
+cache:
+   type: "mem"
+   size_mb: 0
+   defaultTimeoutSec: 60
+   memcachedServers:
+       - "127.0.0.1:1234"
+       - "127.0.0.2:1235"
+cpus: 0
+tz: ""
+maxBatchSize: 0
+graphite:
+    host: ""
+    interval: "60s"
+    prefix: "carbon.api"
+    pattern: "{prefix}.{fqdn}"
+idleConnections: 10
+pidFile: ""
+upstreams:
+    buckets: 10
+    timeouts:
+        find: "2s"
+        render: "10s"
+        connect: "200ms"
+    concurrencyLimitPerServer: 0
+    keepAliveInterval: "30s"
+    maxIdleConnsPerHost: 100
+    backendsv2:
+        backends:
+          -
+            groupName: "mock-001"
+            protocol: "auto"
+            lbMethod: "all"
+            maxTries: 3
+            maxBatchSize: 0
+            keepAliveInterval: "10s"
+            concurrencyLimit: 0
+            maxIdleConnsPerHost: 1000
+            timeouts:
+                find: "15s"
+                render: "50s"
+                connect: "200ms"
+            servers:
+                - "http://127.0.0.1:9070"
+                - "http://127.0.0.1:9071"
+          -
+            groupName: "mock-002"
+            protocol: "auto"
+            lbMethod: "all"
+            maxTries: 3
+            maxBatchSize: 0
+            keepAliveInterval: "10s"
+            concurrencyLimit: 0
+            maxIdleConnsPerHost: 1000
+            timeouts:
+                find: "15s"
+                render: "50s"
+                connect: "200ms"
+            servers:
+                - "http://127.0.0.1:9072"
+                - "http://127.0.0.1:9073"
+    graphite09compat: false
+expireDelaySec: 10
+unicodeRangeTables:
+    - "Latin"
+    - "Common"
+logger:
+    - logger: ""
+      file: "stderr"
+      level: "debug"
+      encoding: "console"
+      encodingTime: "iso8601"
+      encodingDuration: "seconds"

--- a/cmd/mockbackend/testcases/i598/i598.yaml
+++ b/cmd/mockbackend/testcases/i598/i598.yaml
@@ -1,0 +1,40 @@
+version: "v1"
+test:
+    apps:
+        - name: "carbonapi"
+          binary: "./carbonapi"
+          args:
+              - "-config"
+              - "./cmd/mockbackend/testcases/i598/carbonapi.yaml"
+    queries:
+            - endpoint: "http://127.0.0.1:8081"
+              delay: 1
+              type: "GET"
+              URL: "/render/?target=sum(a.*)&format=json"
+              expectedResponse:
+                  httpCode: 200
+                  contentType: "application/json"
+                  expectedResults:
+                          - metrics:
+                                  - target: "sumSeries(a.*)"
+                                    datapoints: [[100,1],[111,2],[112,3],[112,4],[153,5]]
+listeners:
+  - address: ":9070"
+    expressions:
+      "a.open":
+        pathExpression: "a.open"
+        data:
+            - metricName: "a.open"
+              values: [0,1,2,2,3]
+      "a.waiting":
+        pathExpression: "a.waiting"
+        data:
+            - metricName: "a.waiting"
+              values: [100,110,110,110,150]
+      "a.*":
+        pathExpression: "a.*"
+        data:
+            - metricName: "a.waiting"
+              values: [100,110,110,110,150]
+            - metricName: "a.open"
+              values: [0,1,2,2,3]

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -683,6 +683,23 @@ func parseConst(s string) (float64, string, string, error) {
 // RangeTables is an array of *unicode.RangeTable
 var RangeTables []*unicode.RangeTable
 
+var disallowedCharactersInMetricName = map[rune]struct{}{
+	'(': struct{}{},
+	')': struct{}{},
+	'"': struct{}{},
+	'\'': struct{}{},
+	' ': struct{}{},
+	'/': struct{}{},
+}
+
+func unicodeRuneAllowedInName(r rune) bool {
+	if _, ok := disallowedCharactersInMetricName[r]; ok {
+		return false
+	}
+
+	return true
+}
+
 func parseName(s string) (string, string) {
 	var (
 		braces, i, w int
@@ -719,7 +736,7 @@ FOR:
 		/* */
 		default:
 			r, w = utf8.DecodeRuneInString(s[i:])
-			if unicode.In(r, RangeTables...) {
+			if unicodeRuneAllowedInName(r) && unicode.In(r, RangeTables...) {
 				continue
 			}
 			break FOR


### PR DESCRIPTION
…g for unicode

Graphite metrics cannot contain certain symbols in the name, such as '(' or '"'.

Skip those symbols when unicode tables are used (without unicode it's a white-list of allowed)

Fixes #598