### PR TITLE
allow custom fpm-like tool and equal version for all build scripts

### DIFF
--- a/contrib/carbonapi/fpm/create_package_deb.sh
+++ b/contrib/carbonapi/fpm/create_package_deb.sh
@@ -1,12 +1,14 @@
-#!/bin/bash -x
+#!/bin/bash
+
+FPM="${FPM:-fpm}"
 
 die() {
-    if [[ $1 -eq 0 ]]; then
+    if [ $1 -eq 0 ]; then
         rm -rf "${TMPDIR}"
     else
-        echo "Temporary data stored at '${TMPDIR}'"
+        echo "Temporary data stored at '${TMPDIR}'" >&2
     fi
-    echo "$2"
+    echo "$2" >&2
     exit $1
 }
 
@@ -40,19 +42,19 @@ fi
 if [[ ${is_upstart} -eq 0 ]]; then
        mkdir -p "${TMPDIR}"/etc/systemd/system/
        mkdir -p "${TMPDIR}"/etc/default/
-       cp ./contrib/carbonapi/deb/carbonapi.service "${TMPDIR}"/etc/systemd/system/
-       cp ./contrib/carbonapi/common/carbonapi.env "${TMPDIR}"/etc/default/carbonapi
+       cp ./contrib/carbonapi/deb/carbonapi.service "${TMPDIR}"/etc/systemd/system/ || die 1 "Copy error"
+       cp ./contrib/carbonapi/common/carbonapi.env "${TMPDIR}"/etc/default/carbonapi || die 1 "Copy error"
 else
        mkdir -p "${TMPDIR}"/etc/init/
-       cp ./contrib/carbonapi/deb/carbonapi.conf "${TMPDIR}"/etc/init/
+       cp ./contrib/carbonapi/deb/carbonapi.conf "${TMPDIR}"/etc/init/ || die 1 "Copy error"
 fi
 
 mkdir -p "${TMPDIR}"/var/log/carbonapi/
 mkdir -p "${TMPDIR}"/etc/logrotate.d/
-cp ./contrib/carbonapi/deb/carbonapi.logrotate "${TMPDIR}"/etc/logrotate.d/carbonapi
+cp ./contrib/carbonapi/deb/carbonapi.logrotate "${TMPDIR}"/etc/logrotate.d/carbonapi || die 1 "Copy error"
 
-fpm -s dir -t deb -n carbonapi -v ${VERSION} -C ${TMPDIR} \
-    -p carbonapi_VERSION_ARCH.deb \
+${FPM} -s dir -t deb -n carbonapi -v ${VERSION} -C ${TMPDIR} \
+    -p carbonapi-VERSION.ARCH.deb \
     -d "libcairo2 > 1.11" \
     --no-deb-systemd-restart-after-upgrade \
     --after-install contrib/carbonapi/fpm/systemd-reload.sh \

--- a/contrib/carbonapi/fpm/create_package_rpm.sh
+++ b/contrib/carbonapi/fpm/create_package_rpm.sh
@@ -1,11 +1,14 @@
-#!/bin/bash -x
+#!/bin/bash
+
+FPM="${FPM:-fpm}"
+
 die() {
-    if [[ $1 -eq 0 ]]; then
+    if [ $1 -eq 0 ]; then
         rm -rf "${TMPDIR}"
     else
-        echo "Temporary data stored at '${TMPDIR}'"
+        echo "Temporary data stored at '${TMPDIR}'" >&2
     fi
-    echo "$2"
+    echo "$2" >&2
     exit $1
 }
 
@@ -58,10 +61,10 @@ make || die 1 "Can't build package"
 make DESTDIR="${TMPDIR}" install || die 1 "Can't install package"
 mkdir -p "${TMPDIR}"/etc/systemd/system/
 mkdir -p "${TMPDIR}"/etc/sysconfig/
-cp ./contrib/carbonapi/rhel/carbonapi.service "${TMPDIR}"/etc/systemd/system/
-cp ./contrib/carbonapi/common/carbonapi.env "${TMPDIR}"/etc/sysconfig/carbonapi
+cp ./contrib/carbonapi/rhel/carbonapi.service "${TMPDIR}"/etc/systemd/system/ || die 1 "Copy error"
+cp ./contrib/carbonapi/common/carbonapi.env "${TMPDIR}"/etc/sysconfig/carbonapi || die 1 "Copy error"
 
-fpm -s dir -t rpm -n carbonapi -v ${VERSION} -C ${TMPDIR} \
+${FPM} -s dir -t rpm -n carbonapi -v ${VERSION} -C ${TMPDIR} \
     --iteration ${RELEASE} \
     -p carbonapi-VERSION-ITERATION.ARCH.rpm \
     -d "cairo" \
@@ -70,6 +73,6 @@ fpm -s dir -t rpm -n carbonapi -v ${VERSION} -C ${TMPDIR} \
     --license BSD-2 \
     --url "https://github.com/go-graphite/carbonapi" \
     "${@}" \
-    etc usr/bin usr/share || die "Can't create package!"
+    etc usr/bin usr/share || die 1 "Can't create package!"
 
 die 0 "Success"

--- a/contrib/carbonapi/fpm/create_package_rpm.sh
+++ b/contrib/carbonapi/fpm/create_package_rpm.sh
@@ -12,47 +12,19 @@ die() {
     exit $1
 }
 
-pwd
-VERSION_GIT=$(git describe --abbrev=6 --always --tags | rev | sed 's/-/./' | rev)
-VERSION=$(cut -d'-' -f 1 <<< ${VERSION_GIT})
-RELEASE=$(cut -d'-' -f 2 <<< ${VERSION_GIT})
-COMMIT=$(cut -d'-' -f 3 <<< ${VERSION_GIT})
+GIT_VERSION="$(git describe --always --tags)" && {
+    set -f; IFS='-' ; set -- ${GIT_VERSION}
+    VERSION=$1; [ -z "$3" ] && RELEASE=$2 || RELEASE=$2.$3
+    set +f; unset IFS
 
-REL_VERSION=""
-REL_COMMIT=""
-if [[ "${VERSION}" == "${RELEASE}" ]]; then
-       RELEASE="1"
-else
-       REL_VERSION=$(cut -d'.' -f 1 <<< ${RELEASE})
-       REL_COMMIT=$(cut -d'.' -f 2 <<< ${RELEASE})
-       if [[ ! -z "${COMMIT}" ]]; then
-           REL_COMMIT=${COMMIT}
-       fi
-       case "${REL_VERSION}" in
-           "beta")
-               RELEASE="0.2.${RELEASE/./}"
-               if [[ ! -z "${REL_COMMIT}" ]]; then
-                   RELEASE="${RELEASE}.${REL_COMMIT}"
-               fi
-               ;;
-           "rc")
-               RELEASE="0.3.${RELEASE/./}"
-               if [[ ! -z "${REL_COMMIT}" ]]; then
-                   RELEASE="${RELEASE}.${REL_COMMIT}"
-               fi
-               ;;
-           *)
-               RELEASE="1.0.post$((REL_COMMIT+1))"
-               ;;
-       esac
-fi
-grep '^[0-9]\+\.[0-9]\+\.' <<< ${VERSION} || {
-	echo "Revision: $(git rev-parse HEAD)";
-	echo "Version: $(git describe --abbrev=6 --always --tags)";
-	echo "Known tags: $(git tag)";
-	echo;
-	echo;
-	die 1 "Can't get latest version from git";
+    [ "$RELEASE" == "" -a "$VERSION" != "" ] && RELEASE=0 
+
+    if echo $VERSION | egrep '^v[0-9]+\.[0-9]+(\.[0-9]+)?$' >/dev/null; then
+      VERSION=${VERSION:1:${#VERSION}}
+      printf "'%s' '%s'\n" "$VERSION" "$RELEASE"
+    fi
+} || {
+    exit 1
 }
 
 TMPDIR=$(mktemp -d)
@@ -72,7 +44,6 @@ ${FPM} -s dir -t rpm -n carbonapi -v ${VERSION} -C ${TMPDIR} \
     --description "carbonapi: replacement graphite API server" \
     --license BSD-2 \
     --url "https://github.com/go-graphite/carbonapi" \
-    "${@}" \
     etc usr/bin usr/share || die 1 "Can't create package!"
 
 die 0 "Success"

--- a/contrib/carbonzipper/fpm/create_package_deb.sh
+++ b/contrib/carbonzipper/fpm/create_package_deb.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+FPM="${FPM:-fpm}"
+
 VERSION=$(git describe --abbrev=4 --always --tags)
 TMPDIR=$(mktemp -d)
 
@@ -7,12 +10,12 @@ RELEASE=$(lsb_release -r -s)
 NAME="carbonzipper"
 
 die() {
-    if [[ $1 -eq 0 ]]; then
+    if [ $1 -eq 0 ]; then
         rm -rf "${TMPDIR}"
     else
-        echo "Temporary data stored at '${TMPDIR}'"
+        echo "Temporary data stored at '${TMPDIR}'"  >&2
     fi
-    echo "$2"
+    echo "$2" >&2
     exit $1
 }
 
@@ -29,14 +32,14 @@ fi
 if [[ ${is_upstart} -eq 0 ]]; then
        mkdir -p "${TMPDIR}"/etc/systemd/system/
        mkdir -p "${TMPDIR}"/etc/default/
-       cp ./contrib/carbonzipper/deb/${NAME}.service "${TMPDIR}"/etc/systemd/system/
-       cp ./contrib/carbonzipper/common/${NAME}.env "${TMPDIR}"/etc/default/${NAME}
+       cp ./contrib/carbonzipper/deb/${NAME}.service "${TMPDIR}"/etc/systemd/system/ || die 1 "Copy error"
+       cp ./contrib/carbonzipper/common/${NAME}.env "${TMPDIR}"/etc/default/${NAME} || die 1 "Copy error"
 else
        mkdir -p "${TMPDIR}"/etc/init/
-       cp ./contrib/carbonzipper/deb/${NAME}.conf "${TMPDIR}"/etc/init/
+       cp ./contrib/carbonzipper/deb/${NAME}.conf "${TMPDIR}"/etc/init/ || die 1 "Copy error"
 fi
 
-fpm -s dir -t deb -n ${NAME} -v ${VERSION} -C ${TMPDIR} \
+${FPM} -s dir -t deb -n ${NAME} -v ${VERSION} -C ${TMPDIR} \
     -p ${NAME}_VERSION_ARCH.deb \
     --no-deb-systemd-restart-after-upgrade \
     --after-install contrib/carbonzipper/fpm/systemd-reload.sh \

--- a/contrib/carbonzipper/fpm/create_package_rpm.sh
+++ b/contrib/carbonzipper/fpm/create_package_rpm.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+FPM="${FPM:-fpm}"
+
 VERSION_GIT=$(git describe --abbrev=4 --always --tags | rev | sed 's/-/./' | rev) 
 VERSION=$(cut -d'-' -f 1 <<< ${VERSION_GIT})
 RELEASE=$(cut -d'-' -f 2 <<< ${VERSION_GIT})
@@ -13,31 +16,32 @@ TMPDIR=$(mktemp -d)
 NAME="carbonzipper"
 
 die() {
-    if [[ $1 -eq 0 ]]; then
+    if [ $1 -eq 0 ]; then
         rm -rf "${TMPDIR}"
     else
-        echo "Temporary data stored at '${TMPDIR}'"
+        echo "Temporary data stored at '${TMPDIR}'" >&2
     fi
-    echo "$2"
+    echo "$2" >&2
     exit $1
 }
 
-MAJOR_DISTRO_VERSION=$(lsb_release -s -r | cut -c 1)
+MAJOR_DISTRO_VERSION=$(lsb_release -s -r | sed -e 's/\..*//')
+[ "${MAJOR_DISTRO_VERSION}" == "" ] && MAJOR_DISTRO_VERSION="7"
 
 make || die 1 "Can't build package"
 make DESTDIR="${TMPDIR}" install || die 1 "Can't install package"
 mkdir -p "${TMPDIR}"/etc/sysconfig/
-cp ./contrib/carbonzipper/common/${NAME}.env "${TMPDIR}"/etc/sysconfig/${NAME}
+cp ./contrib/carbonzipper/common/${NAME}.env "${TMPDIR}"/etc/sysconfig/${NAME} || dir 1 "Copy error"
 if [[ "${MAJOR_DISTRO_VERSION}" -le 6 ]]; then
 	mkdir -p "${TMPDIR}"/init.d
-	cp ./contrib/carbonzipper/rhel/${NAME}.init "${TMPDIR}"/etc/init.d/${NAME}
+	cp ./contrib/carbonzipper/rhel/${NAME}.init "${TMPDIR}"/etc/init.d/${NAME} || dir 1 "Copy error"
 else
 	mkdir -p "${TMPDIR}"/etc/systemd/system/
-	cp ./contrib/carbonzipper/rhel/${NAME}.service "${TMPDIR}"/etc/systemd/system/
+	cp ./contrib/carbonzipper/rhel/${NAME}.service "${TMPDIR}"/etc/systemd/system/ || dir 1 "Copy error"
 fi
 
 
-fpm -s dir -t rpm -n ${NAME} -v ${VERSION} -C ${TMPDIR} \
+${FPM} -s dir -t rpm -n ${NAME} -v ${VERSION} -C ${TMPDIR} \
     --iteration ${RELEASE} \
     -p ${NAME}_VERSION-ITERATION_ARCH.rpm \
     --after-install contrib/carbonzipper/fpm/systemd-reload.sh \
@@ -45,6 +49,6 @@ fpm -s dir -t rpm -n ${NAME} -v ${VERSION} -C ${TMPDIR} \
     --license MIT \
     --url "https://github.com/go-graphite/carbonapi" \
     "${@}" \
-    etc usr/bin usr/share || die "Can't create package!"
+    etc usr/bin usr/share || die 1 "Can't create package!"
 
 die 0 "Success"


### PR DESCRIPTION
Changes in this PR:
1) Allow to choose custom fpm-like cli tool (no Ruby dependency for build)
2) Equal version for carbonapi/carbonzipper packages (RPM/DEB)
