### PR TITLE
Do not apply moving functions when step is greater than window size

### DIFF
--- a/cmd/carbonapi/carbonapi.example.yaml
+++ b/cmd/carbonapi/carbonapi.example.yaml
@@ -77,6 +77,8 @@ tz: ""
 functionsConfig:
     graphiteWeb: ./graphiteWeb.example.yaml
     timeShift: ./timeShift.example.yaml
+#    moving: ./moving.example.yaml
+#    movingMedian: ./moving.example.yaml
 #    aliasByRedis: ./aliasByRedis.example.yaml
 maxBatchSize: 100
 graphite:

--- a/cmd/carbonapi/moving.example.yaml
+++ b/cmd/carbonapi/moving.example.yaml
@@ -1,0 +1,4 @@
+# return NaNs when window size is larger than data step, otherwise return data unmodified
+# e.g. movingAverage(metric1, "30sec") for data with 1 minute step
+# default is true for graphite-web compatibility
+returnNaNsIfStepMismatch: false

--- a/cmd/carbonapi/moving.example.yaml
+++ b/cmd/carbonapi/moving.example.yaml
@@ -1,4 +1,4 @@
-# return NaNs when window size is larger than data step, otherwise return data unmodified
+# return NaNs when window size is smaller than data step, otherwise return data unmodified
 # e.g. movingAverage(metric1, "30sec") for data with 1 minute step
 # default is true for graphite-web compatibility
 returnNaNsIfStepMismatch: false

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -307,7 +307,11 @@ tz: "Europe/Zurich,7200"
 
 Extra config files for specific functions
 
-Currently only `grpahiteWeb` and `aliasByPostgres` supports it's own config
+Only the following functions currently support having their own config:
+  - `graphiteWeb`
+  - `aliasByPostgres`
+  - `movingMedian`
+  - `moving` (applies to `movingAverage`, `movingMin`, `movingMax`, `movingSum`)
 
 ### Example
 ```yaml

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -45,7 +45,7 @@ func TestMoving(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -5, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, now32)}, // step > windowSize
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,"5s")`, []float64{1, 2, 3}, 10, now32)}, // StartTime = from
+			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,"5s")`, []float64{math.NaN(), math.NaN(), math.NaN()}, 10, now32)}, // StartTime = from
 		},
 		{
 			"movingSum(metric1,2)",

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -41,6 +41,13 @@ func TestMoving(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("movingAverage(metric1,4)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1.25, 1.5, 1.75, 2.5, 3.5, 4, 5}, 1, 0)}, // StartTime = from
 		},
 		{
+			"movingAverage(metric1,'5s')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -5, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, now32)}, // step > windowSize
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,"5s")`, []float64{1, 2, 3}, 10, now32)}, // StartTime = from
+		},
+		{
 			"movingSum(metric1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, 6}, 1, now32)},

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -85,6 +85,11 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 	for _, a := range arg {
 		r := *a
 		r.Name = fmt.Sprintf("movingMedian(%s,%s)", a.Name, argstr)
+
+		if windowSize == 0 {
+			result = append(result, &r)
+			continue
+		}
 		r.Values = make([]float64, len(a.Values)-offset)
 		r.StartTime = (from + r.StepTime - 1) / r.StepTime * r.StepTime // align StartTime to closest >= StepTime
 		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -7,6 +7,10 @@ import (
 	"strconv"
 
 	"github.com/JaderDias/movingmedian"
+	"github.com/lomik/zapwriter"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
@@ -15,18 +19,49 @@ import (
 
 type movingMedian struct {
 	interfaces.FunctionBase
+
+	config movingMedianConfig
 }
 
 func GetOrder() interfaces.Order {
 	return interfaces.Any
 }
 
+type movingMedianConfig struct {
+	ReturnNaNsIfStepMismatch *bool
+}
+
 func New(configFile string) []interfaces.FunctionMetadata {
+	logger := zapwriter.Logger("functionInit").With(zap.String("function", "movingMedian"))
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &movingMedian{}
 	functions := []string{"movingMedian"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+
+	cfg := movingMedianConfig{}
+	v := viper.New()
+	v.SetConfigFile(configFile)
+	err := v.ReadInConfig()
+	if err != nil {
+		logger.Info("failed to read config file, using default",
+			zap.Error(err),
+		)
+	} else {
+		err = v.Unmarshal(&cfg)
+		if err != nil {
+			logger.Fatal("failed to parse config",
+				zap.Error(err),
+			)
+			return nil
+		}
+		f.config = cfg
+	}
+
+	if cfg.ReturnNaNsIfStepMismatch == nil {
+		v := true
+		f.config.ReturnNaNsIfStepMismatch = &v
 	}
 	return res
 }
@@ -87,6 +122,12 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 		r.Name = fmt.Sprintf("movingMedian(%s,%s)", a.Name, argstr)
 
 		if windowSize == 0 {
+			if *f.config.ReturnNaNsIfStepMismatch {
+				r.Values = make([]float64, len(a.Values))
+				for i := range a.Values {
+					r.Values[i] = math.NaN()
+				}
+			}
 			result = append(result, &r)
 			continue
 		}

--- a/expr/functions/movingMedian/function_test.go
+++ b/expr/functions/movingMedian/function_test.go
@@ -59,7 +59,7 @@ func TestMovingMedian(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -5, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, now32)}, // step > windowSize
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,\"5s\")", []float64{1, 2, 3}, 10, now32)}, // StartTime = from
+			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,\"5s\")", []float64{math.NaN(), math.NaN(), math.NaN()}, 10, now32)}, // StartTime = from
 		},
 	}
 

--- a/expr/functions/movingMedian/function_test.go
+++ b/expr/functions/movingMedian/function_test.go
@@ -54,6 +54,13 @@ func TestMovingMedian(t *testing.T) {
 			},
 			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,\"3s\")", []float64{0, 1, 1, 1, 1, 2, 2, 2, 4, 4, 6, 6, 6, 2}, 1, 0)}, // StartTime = from
 		},
+		{
+			"movingMedian(metric1,\"5s\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -5, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, now32)}, // step > windowSize
+			},
+			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,\"5s\")", []float64{1, 2, 3}, 10, now32)}, // StartTime = from
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #522 

This fix is particularly useful when using Prometheus or VictoriaMetrics as the backend.

If you have a function like `movingMedian(metric1, "2min")` and then change the Grafana dashboard time range to something large (e.g. 7 days) CarbonAPI will query the backend with a step that is greater than 2min which causes the function to return an error.

This change instead makes the moving functions return the data unmodified so that queries will work regardless of step changes. 