### PR TITLE
Make stop value of substr function behave the same as Graphite-Web

### DIFF
--- a/expr/functions/substr/function.go
+++ b/expr/functions/substr/function.go
@@ -65,7 +65,7 @@ func (f *substr) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			}
 			nodes = nodes[realStartField:]
 		}
-		if stopField != 0 {
+		if stopField != 0 && stopField < len(nodes) + realStartField {
 			realStopField := stopField
 			if stopField < 0 {
 				realStopField = len(nodes) + stopField

--- a/expr/functions/substr/function_test.go
+++ b/expr/functions/substr/function_test.go
@@ -37,6 +37,8 @@ func TestSubstr(t *testing.T) {
 		['metric1', 'foo', 'bar']
 		>>> a[0:-1]
 		['metric1', 'foo', 'bar']
+		>>> a[0:10]
+		['metric1', 'foo', 'bar', 'baz']
 	*/
 	tests := []th.EvalTestItem{
 		{
@@ -77,6 +79,30 @@ func TestSubstr(t *testing.T) {
 				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1.foo.bar",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			"substr(metric1.foo.bar.baz, 0, 10)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1.foo.bar.baz",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			"substr(metric1.foo.bar.baz, 2, 4)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("bar.baz",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			"substr(metric1.foo.bar.baz, 2, 6)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("bar.baz",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
 	}


### PR DESCRIPTION
Python's array slicing (which is what Graphite-Web's substr function uses behind the scenes) allows the stop value to be out of bounds, in which case it acts as if you specified to return the remainder of the array. For example:
````
>>> a = ["metric1", "foo", "bar", "baz"]
>>> a[2:10]
['bar', 'baz']
>>> a[2:]
['bar', 'baz']
````
While it's not likely "best practice" to specify an out of bounds stop value for the substr function, Graphite-Web allows it due to this characteristic of array slicing in Python. This change is intended to make carbonapi more of a drop in replacement for Graphite-Web.
