### PR TITLE
Closes #611

### DIFF
--- a/cmd/carbonapi/carbonapi.example.prometheus.yaml
+++ b/cmd/carbonapi/carbonapi.example.prometheus.yaml
@@ -49,6 +49,7 @@ upstreams:
                 step: "60"
                 start: "-5m"
                 max_points_per_query: 5000
+                force_min_step_interval: 1h
             timeouts:
                 find: "2s"
                 render: "50s"

--- a/cmd/carbonapi/carbonapi.example.victoriametrics.yaml
+++ b/cmd/carbonapi/carbonapi.example.victoriametrics.yaml
@@ -51,6 +51,7 @@ upstreams:
                 max_points_per_query: 5000
                 probe_version_interval: "600s"
                 fallback_version: "v0.0.0"
+                force_min_step_interval: 0s
                 # vmClusterTenantID: "0" # use vmClisterTenantID for VM-cluster only
             timeouts:
                 find: "2s"

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -530,6 +530,7 @@ Supported options:
 
         For example `-5m` will mean "5 minutes ago", time will be resolved every time you do find query.
       - `max_points_per_query` - (`prometheus` or `victoriametrics` only) define maximum datapoints per query. It will be used to adjust step for queries over big range. Default limit for Prometheus is 11000.
+      - `force_min_step_interval` - (`prometheus` or `victoriametrics` only) define to force using `step` in all requests ignoring MaxDataPoints param for given interval. Default value for Prometheus and VictoriaMetrics is `0s` so feature is disabled.
       - `probe_version_interval` - (`victoriametrics` only) define how often VictoriaMetrics version will be checked (as VM supports certain API endpoints starting from a specific version). Special value to disable: `never`. Default: `600s`.
       - `fallback_version` - (`victoriametrics` only) define version string that will be used as a fallback if version_short will be empty (useful when you run master builds, as they will have it empty). Format: "vX.Y.Z", Default: `v0.0.0` (all special VM optimizations will be disabled)
       - `vmClusterTenantID` - `victoriametrics` in **cluster mode** only. Use this option to configure `accountID` and `projectID` in the VM-cluster API urls. Tenants are identified by "accountID" or "accountID:projectID". Type: `string`. Default: none (single node VictoriaMetrics).

--- a/zipper/protocols/victoriametrics/fetch.go
+++ b/zipper/protocols/victoriametrics/fetch.go
@@ -49,7 +49,7 @@ func (c *VictoriaMetricsGroup) Fetch(ctx context.Context, request *protov3.Multi
 	if len(request.Metrics) > 0 && request.Metrics[0].MaxDataPoints != 0 {
 		maxPointsPerQuery = request.Metrics[0].MaxDataPoints
 	}
-	step := helpers.AdjustStep(start, stop, maxPointsPerQuery, c.step)
+	step := helpers.AdjustStep(start, stop, maxPointsPerQuery, c.step, c.forceMinStepInterval)
 
 	stepStr := strconv.FormatInt(step, 10)
 	for pathExpr, targets := range pathExprToTargets {


### PR DESCRIPTION
Adds new configuration key `force_min_step_interval` for Prometheus/VictoriaMetrics, which results in using provided `step` param without adjustment for specified time interval for read requests. If interval > force_min_step_interval then adjustment is applied as before.

It is useful when I want to be sure I can rely on results of aggregating functions for a given period (say for `30d` for example) when using Grafana. However, if someone requests datapoints for 1 year this new logic won't affect the performance because `forcing` works only for specified period.

Note, that this value must be in sync with vmselect's `search.maxPointsPerTimeseries` configuration key when using VictoriaMetrics, otherwise vmselect would produce error.