### PR TITLE
asPersent: fix panic on empty

### DIFF
--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -46,6 +46,9 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	var denominators []*types.MetricData
 
 	var results []*types.MetricData
+	if len(arg) == 0 {
+		return results, nil
+	}
 
 	if len(e.Args()) == 1 {
 		arg = helper.AlignSeries(types.CopyMetricDataSlice(arg))

--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -37,6 +37,9 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	if err != nil {
 		return nil, err
 	}
+	if len(arg) == 0 {
+		return nil, nil
+	}
 
 	var getTotal func(i int) float64
 	var formatName func(a, b string) string
@@ -46,9 +49,6 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	var denominators []*types.MetricData
 
 	var results []*types.MetricData
-	if len(arg) == 0 {
-		return results, nil
-	}
 
 	if len(e.Args()) == 1 {
 		arg = helper.AlignSeries(types.CopyMetricDataSlice(arg))


### PR DESCRIPTION
Got 500 status on asPersent execution on empty series
```
runtime error: index out of range [7] with length 1
Stack trace: github.com/go-graphite/carbonapi/cmd/carbonapi/http.renderHandler.func2
	/go/src/github.com/go-graphite/carbonapi/cmd/carbonapi/http/render_handler.go:257
runtime.gopanic
	/usr/local/go/src/runtime/panic.go:975
runtime.goPanicIndex
	/usr/local/go/src/runtime/panic.go:88
github.com/go-graphite/carbonapi/expr/functions/groupByNode.(*groupByNode).Do
	/go/src/github.com/go-graphite/carbonapi/expr/functions/groupByNode/function.go:81
github.com/go-graphite/carbonapi/expr.EvalExpr
	/go/src/github.com/go-graphite/carbonapi/expr/expr.go:160
github.com/go-graphite/carbonapi/expr.evaluator.Eval
	/go/src/github.com/go-graphite/carbonapi/expr/expr.go:119
github.com/go-graphite/carbonapi/expr.evaluator.FetchAndEvalExp
	/go/src/github.com/go-graphite/carbonapi/expr/expr.go:96
github.com/go-graphite/carbonapi/expr.FetchAndEvalExp
	/go/src/github.com/go-graphite/carbonapi/expr/expr.go:131
github.com/go-graphite/carbonapi/cmd/carbonapi/http.renderHandler
	/go/src/github.com/go-graphite/carbonapi/cmd/carbonapi/http/render_handler.go:293
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2042
github.com/go-graphite/carbonapi/util/ctx.ParseCtx.func1
	/go/src/github.com/go-graphite/carbonapi/util/ctx/ctx.go:90
github.com/go-graphite/carbonapi/cmd/carbonapi/http.enrichContextWithHeaders.func1
	/go/src/github.com/go-graphite/carbonapi/cmd/carbonapi/http/enrichcontext.go:32
github.com/dgryski/httputil.TimeHandler.func1
	/go/src/github.com/go-graphite/carbonapi/vendor/github.com/dgryski/httputil/times.go:26
github.com/dgryski/httputil.TrackConnections.func1
	/go/src/github.com/go-graphite/carbonapi/vendor/github.com/dgryski/httputil/track.go:40
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2042
net/http.(*ServeMux).ServeHTTP
	/usr/local/go/src/net/http/server.go:2417
github.com/gorilla/handlers.CompressHandlerLevel.func1
	/go/src/github.com/go-graphite/carbonapi/vendor/github.com/gorilla/handlers/compress.go:141
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2042
github.com/gorilla/handlers.(*cors).ServeHTTP
	/go/src/github.com/go-graphite/carbonapi/vendor/github.com/gorilla/handlers/cors.go:54
github.com/gorilla/handlers.ProxyHeaders.func1
	/go/src/github.com/go-graphite/carbonapi/vendor/github.com/gorilla/handlers/proxy_headers.go:59
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2042
net/http.serverHandler.ServeHTTP
	/usr/local/go/src/net/http/server.go:2843
net/http.(*conn).serve
	/usr/local/go/src/net/http/server.go:1925
```