### PR TITLE
Fix logic for negative parameters to substr

### DIFF
--- a/cmd/carbonapi/moving.example.yaml
+++ b/cmd/carbonapi/moving.example.yaml
@@ -1,4 +1,4 @@
-# return NaNs when window size is larger than data step, otherwise return data unmodified
+# return NaNs when window size is smaller than data step, otherwise return data unmodified
 # e.g. movingAverage(metric1, "30sec") for data with 1 minute step
 # default is true for graphite-web compatibility
 returnNaNsIfStepMismatch: false

--- a/expr/functions/substr/function.go
+++ b/expr/functions/substr/function.go
@@ -69,17 +69,13 @@ func (f *substr) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			realStopField := stopField
 			if stopField < 0 {
 				realStopField = len(nodes) + stopField
-				if realStopField < 0 {
-					return nil, errors.New("stop out of range")
-				}
-				nodes = nodes[:realStopField]
 			} else{ 
 				realStopField = realStopField - realStartField
-				if realStopField < 0 {
-					return nil, errors.New("stop out of range")
-				}
-				nodes = nodes[:realStopField]
 			}
+			if realStopField < 0 {
+				return nil, errors.New("stop out of range")
+			}
+			nodes = nodes[:realStopField]
 		}
 
 		r := *a

--- a/expr/functions/substr/function.go
+++ b/expr/functions/substr/function.go
@@ -69,14 +69,17 @@ func (f *substr) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			realStopField := stopField
 			if stopField < 0 {
 				realStopField = len(nodes) + stopField
-				if realStartField > 0 {
-					realStopField++
+				if realStopField < 0 {
+					return nil, errors.New("stop out of range")
 				}
+				nodes = nodes[:realStopField]
+			} else{ 
+				realStopField = realStopField - realStartField
+				if realStopField < 0 {
+					return nil, errors.New("stop out of range")
+				}
+				nodes = nodes[:realStopField]
 			}
-			if realStopField < 0 || realStopField <= realStartField || realStopField-realStartField > len(nodes) {
-				return nil, errors.New("stop out of range")
-			}
-			nodes = nodes[:realStopField-realStartField]
 		}
 
 		r := *a

--- a/expr/functions/substr/function.go
+++ b/expr/functions/substr/function.go
@@ -65,7 +65,7 @@ func (f *substr) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			}
 			nodes = nodes[realStartField:]
 		}
-		if stopField != 0 {
+		if stopField != 0 && stopField < len(nodes) + realStartField {
 			realStopField := stopField
 			if stopField < 0 {
 				realStopField = len(nodes) + stopField

--- a/expr/functions/substr/function_test.go
+++ b/expr/functions/substr/function_test.go
@@ -37,6 +37,8 @@ func TestSubstr(t *testing.T) {
 		['metric1', 'foo', 'bar']
 		>>> a[0:-1]
 		['metric1', 'foo', 'bar']
+		>>> a[0:10]
+		['metric1', 'foo', 'bar', 'baz']
 	*/
 	tests := []th.EvalTestItem{
 		{
@@ -77,6 +79,30 @@ func TestSubstr(t *testing.T) {
 				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1.foo.bar",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			"substr(metric1.foo.bar.baz, 0, 10)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1.foo.bar.baz",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			"substr(metric1.foo.bar.baz, 2, 4)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("bar.baz",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			"substr(metric1.foo.bar.baz, 2, 6)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("bar.baz",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
 	}

--- a/expr/functions/substr/function_test.go
+++ b/expr/functions/substr/function_test.go
@@ -105,6 +105,14 @@ func TestSubstr(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("bar.baz",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
+		{
+			"substr(metric1.foo.bar.baz, -2, -1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("bar",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
I had a query that worked on the original graphite but got me a "stop out of range" error when using carbonapi (look at my added test case for the query). I started looking over the code for the substr function again and was having trouble understanding what the purpose of some of the logic in it was. 

Namely, `realStartField` should only be used with `realStopField` if `stopField` is positive, since we have to account for `nodes` being spliced. If `stopField` is negative, then `realStartField` isn't relevant since we're just going from the end of the array. We just do `len(nodes) + stopField` to get the `realStopField`.

In any case, this code is suppose to make it work the way the original graphite does.