### PR TITLE
Fix removeEmptySeries function

### DIFF
--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -56,7 +56,7 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 				}
 			}
 		}
-		if nonNull/float64(len(arg.Values)) >= factor {
+		if nonNull != 0 && nonNull/float64(len(arg.Values)) >= factor {
 			results = append(results, arg)
 		}
 	}

--- a/expr/functions/removeEmptySeries/function_test.go
+++ b/expr/functions/removeEmptySeries/function_test.go
@@ -37,8 +37,20 @@ func TestFunction(t *testing.T) {
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32),
-				types.MakeMetricData("metric2", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 				types.MakeMetricData("metric3", []float64{0, 0, 0, 0, 0, 0, 0, 0}, 1, now32),
+			},
+		},
+		{
+			"removeZeroSeries(metric*)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32),
+					types.MakeMetricData("metric2", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+					types.MakeMetricData("metric3", []float64{0, 0, 0, 0, 0, 0, 0, 0}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32),
 			},
 		},
 		{


### PR DESCRIPTION
When adding support for xFilesFactor for the removeEmptySeries function (commit 4348948) it incorrectly changed the behaviour for the default case for this function (xFilesFactor=0). It doesn't remove series even if all of their values are null. The same applies for the removeZeroSeries which doesn't delete the series even if all values are 0.

This change fixes that and now matches the graphite-web behaviour.