### PR TITLE
fix pass context to zipper

### DIFF
--- a/expr/functions/absolute/function.go
+++ b/expr/functions/absolute/function.go
@@ -28,7 +28,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *absolute) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return helper.ForEachSeriesDo(e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
+	return helper.ForEachSeriesDo(ctx, e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
 		for i, v := range a.Values {
 			if math.IsNaN(a.Values[i]) {
 				r.Values[i] = math.NaN()

--- a/expr/functions/aggregate/function.go
+++ b/expr/functions/aggregate/function.go
@@ -47,7 +47,7 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		if e.Target() == "aggregate" {
 			return nil, err
 		} else {
-			args, err = helper.GetSeriesArgsAndRemoveNonExisting(e, from, until, values)
+			args, err = helper.GetSeriesArgsAndRemoveNonExisting(ctx, e, from, until, values)
 			if err != nil {
 				return nil, err
 			}
@@ -55,7 +55,7 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			isAggregateFunc = false
 		}
 	} else {
-		args, err = helper.GetSeriesArg(e.Args()[0], from, until, values)
+		args, err = helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
@@ -264,10 +264,10 @@ func (f *aggregate) Description() map[string]types.FunctionDescription {
 		},
 		"count": {
 			Description: "Draws a horizontal line representing the number of nodes found in the seriesList.\n\n.. code-block:: none\n\n  &target=count(carbon.agents.*.*)",
-			Function: "count(*seriesLists)",
-			Group: "Combine",
-			Module: "graphite.render.functions",
-			Name: "count",
+			Function:    "count(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "count",
 			Params: []types.FunctionParam{
 				{
 					Multiple: true,
@@ -279,10 +279,10 @@ func (f *aggregate) Description() map[string]types.FunctionDescription {
 		},
 		"countSeries": {
 			Description: "Draws a horizontal line representing the number of nodes found in the seriesList.\n\n.. code-block:: none\n\n  &target=countSeries(carbon.agents.*.*)",
-			Function: "countSeries(*seriesLists)",
-			Group: "Combine",
-			Module: "graphite.render.functions",
-			Name: "countSeries",
+			Function:    "countSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "countSeries",
 			Params: []types.FunctionParam{
 				{
 					Multiple: true,
@@ -294,10 +294,10 @@ func (f *aggregate) Description() map[string]types.FunctionDescription {
 		},
 		"diff": {
 			Description: "Subtracts series 2 through n from series 1.\n\nExample:\n\n.. code-block:: none\n\n  &target=diff(service.connections.total,service.connections.failed)\n\nTo diff a series and a constant, one should use offset instead of (or in\naddition to) diffSeries\n\nExample:\n\n.. code-block:: none\n\n  &target=offset(service.connections.total,-5)\n\n  &target=offset(diffSeries(service.connections.total,service.connections.failed),-4)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``diff``.",
-			Function: "diff(*seriesLists)",
-			Group: "Combine",
-			Module: "graphite.render.functions",
-			Name: "diff",
+			Function:    "diff(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "diff",
 			Params: []types.FunctionParam{
 				{
 					Multiple: true,
@@ -309,10 +309,10 @@ func (f *aggregate) Description() map[string]types.FunctionDescription {
 		},
 		"diffSeries": {
 			Description: "Subtracts series 2 through n from series 1.\n\nExample:\n\n.. code-block:: none\n\n  &target=diffSeries(service.connections.total,service.connections.failed)\n\nTo diff a series and a constant, one should use offset instead of (or in\naddition to) diffSeries\n\nExample:\n\n.. code-block:: none\n\n  &target=offset(service.connections.total,-5)\n\n  &target=offset(diffSeries(service.connections.total,service.connections.failed),-4)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``diff``.",
-			Function: "diffSeries(*seriesLists)",
-			Group: "Combine",
-			Module: "graphite.render.functions",
-			Name: "diffSeries",
+			Function:    "diffSeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "diffSeries",
 			Params: []types.FunctionParam{
 				{
 					Multiple: true,
@@ -324,10 +324,10 @@ func (f *aggregate) Description() map[string]types.FunctionDescription {
 		},
 		"multiply": {
 			Description: "Takes two or more series and multiplies their points. A constant may not be\nused. To multiply by a constant, use the scale() function.\n\nExample:\n\n.. code-block:: none\n\n  &target=multiplySeries(Series.dividends,Series.divisors)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``multiply``.",
-			Function: "multiply(*seriesLists)",
-			Group: "Combine",
-			Module: "graphite.render.functions",
-			Name: "multiply",
+			Function:    "multiply(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "multiply",
 			Params: []types.FunctionParam{
 				{
 					Multiple: true,
@@ -339,10 +339,10 @@ func (f *aggregate) Description() map[string]types.FunctionDescription {
 		},
 		"multiplySeries": {
 			Description: "Takes two or more series and multiplies their points. A constant may not be\nused. To multiply by a constant, use the scale() function.\n\nExample:\n\n.. code-block:: none\n\n  &target=multiplySeries(Series.dividends,Series.divisors)\n\nThis is an alias for :py:func:`aggregate <aggregate>` with aggregation ``multiply``.",
-			Function: "multiplySeries(*seriesLists)",
-			Group: "Combine",
-			Module: "graphite.render.functions",
-			Name: "multiplySeries",
+			Function:    "multiplySeries(*seriesLists)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "multiplySeries",
 			Params: []types.FunctionParam{
 				{
 					Multiple: true,

--- a/expr/functions/aggregateLine/function.go
+++ b/expr/functions/aggregateLine/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // aggregateLine(*seriesLists)
 func (f *aggregateLine) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/alias/function.go
+++ b/expr/functions/alias/function.go
@@ -28,7 +28,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *alias) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/aliasByBase64/function.go
+++ b/expr/functions/aliasByBase64/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aliasByBase64) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/aliasByMetric/function.go
+++ b/expr/functions/aliasByMetric/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aliasByMetric) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return helper.ForEachSeriesDo(e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
+	return helper.ForEachSeriesDo(ctx, e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
 		metric := helper.ExtractMetric(a.Name)
 		part := strings.Split(metric, ".")
 		ret := r.Copy(false)

--- a/expr/functions/aliasByNode/function.go
+++ b/expr/functions/aliasByNode/function.go
@@ -27,7 +27,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aliasByNode) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/aliasByPostgres/function.go
+++ b/expr/functions/aliasByPostgres/function.go
@@ -151,7 +151,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 func (f *aliasByPostgres) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	logger := zapwriter.Logger("functionInit").With(zap.String("function", "aliasByPostgres"))
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/aliasByRedis/function.go
+++ b/expr/functions/aliasByRedis/function.go
@@ -169,7 +169,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aliasByRedis) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/aliasSub/function.go
+++ b/expr/functions/aliasSub/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aliasSub) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // asPercent(seriesList, total=None, *nodes)
 func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			return fmt.Sprintf("asPercent(%s,%s)", a, b)
 		}
 	} else if len(e.Args()) == 2 && (e.Args()[1].IsName() || e.Args()[1].IsFunc()) {
-		total, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+		total, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +117,7 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			return fmt.Sprintf("asPercent(%s,%s)", a, b)
 		}
 	} else if len(e.Args()) >= 3 {
-		total, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+		total, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/averageSeriesWithWildcards/function.go
+++ b/expr/functions/averageSeriesWithWildcards/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 func (f *averageSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	/* TODO(dgryski): make sure the arrays are all the same 'size'
 	   (duplicated from sumSeriesWithWildcards because of similar logic but aggregation) */
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/baselines/function.go
+++ b/expr/functions/baselines/function.go
@@ -58,7 +58,7 @@ func (f *baselines) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	}
 
 	current := make(map[string]*types.MetricData)
-	arg, _ := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, _ := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	for _, a := range arg {
 		current[a.Name] = a
 	}
@@ -69,7 +69,7 @@ func (f *baselines) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			continue
 		}
 		offs := int64(i * unit)
-		arg, _ := helper.GetSeriesArg(e.Args()[0], from+offs, until+offs, values)
+		arg, _ := helper.GetSeriesArg(ctx, e.Args()[0], from+offs, until+offs, values)
 		for _, a := range arg {
 			r := *a
 			if _, ok := current[r.Name]; ok || !isAberration {
@@ -145,7 +145,7 @@ func (f *baselines) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	return results, nil
 }
 
-const baselineDescription = `Produce a baseline for the seriesList. Arguments are similar to timestack function. 
+const baselineDescription = `Produce a baseline for the seriesList. Arguments are similar to timestack function.
 
 For each series takes an array of shifted points and computes a median for that.
 

--- a/expr/functions/below/function.go
+++ b/expr/functions/below/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // averageAbove(seriesList, n), averageBelow(seriesList, n), currentAbove(seriesList, n), currentBelow(seriesList, n), maximumAbove(seriesList, n), maximumBelow(seriesList, n), minimumAbove(seriesList, n), minimumBelow
 func (f *below) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/cactiStyle/function.go
+++ b/expr/functions/cactiStyle/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // cactiStyle(seriesList, system=None, units=None)
 func (f *cactiStyle) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// Get the series data
-	original, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	original, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/cairo/function.go
+++ b/expr/functions/cairo/function.go
@@ -28,7 +28,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *cairo) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return png.EvalExprGraph(e, from, until, values)
+	return png.EvalExprGraph(ctx, e, from, until, values)
 }
 
 func (f *cairo) Description() map[string]types.FunctionDescription {

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -5,6 +5,7 @@ package png
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"image/color"
 	"io/ioutil"
@@ -669,7 +670,7 @@ func Description() map[string]types.FunctionDescription {
 }
 
 // TODO(civil): Split this into several separate functions.
-func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 
 	switch e.Target() {
 

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -1,3 +1,4 @@
+//go:build cairo
 // +build cairo
 
 package png
@@ -673,7 +674,7 @@ func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricReq
 	switch e.Target() {
 
 	case "color": // color(seriesList, theColor)
-		arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+		arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
@@ -694,7 +695,7 @@ func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricReq
 		return results, nil
 
 	case "stacked": // stacked(seriesList, stackname="__DEFAULT__")
-		arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+		arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
@@ -716,7 +717,7 @@ func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricReq
 		return results, nil
 
 	case "areaBetween":
-		arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+		arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
@@ -749,7 +750,7 @@ func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricReq
 		return []*types.MetricData{&lower, &upper}, nil
 
 	case "alpha": // alpha(seriesList, theAlpha)
-		arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+		arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
@@ -771,7 +772,7 @@ func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricReq
 		return results, nil
 
 	case "dashed", "drawAsInfinite", "secondYAxis":
-		arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+		arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
@@ -800,7 +801,7 @@ func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricReq
 		return results, nil
 
 	case "lineWidth": // lineWidth(seriesList, width)
-		arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+		arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
@@ -2252,7 +2253,7 @@ func drawLines(cr *cairoSurfaceContext, params *Params, results []*types.MetricD
 						PathExpression:    r.Name,
 						ConsolidationFunc: "average",
 					},
-					Tags: r.Tags,
+					Tags:           r.Tags,
 					ValuesPerPoint: 1,
 					GraphOptions: types.GraphOptions{
 						Color:       r.Color,

--- a/expr/functions/cairo/png/png.go
+++ b/expr/functions/cairo/png/png.go
@@ -3,6 +3,7 @@
 package png
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-graphite/carbonapi/expr/types"
@@ -11,7 +12,7 @@ import (
 
 const HaveGraphSupport = false
 
-func EvalExprGraph(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	return nil, nil
 }
 

--- a/expr/functions/changed/function.go
+++ b/expr/functions/changed/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // changed(SeriesList)
 func (f *changed) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/consolidateBy/function.go
+++ b/expr/functions/consolidateBy/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // consolidateBy(seriesList, aggregationMethod)
 func (f *consolidateBy) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/cumulative/function.go
+++ b/expr/functions/cumulative/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // cumulative(seriesList)
 func (f *cumulative) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/delay/function.go
+++ b/expr/functions/delay/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // delay(seriesList, steps)
 func (f *delay) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	seriesList, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	seriesList, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/derivative/function.go
+++ b/expr/functions/derivative/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // derivative(seriesList)
 func (f *derivative) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return helper.ForEachSeriesDo(e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
+	return helper.ForEachSeriesDo(ctx, e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
 		prev := math.NaN()
 		for i, v := range a.Values {
 			// We don't need to check for special case here. value-NaN == NaN

--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -36,7 +36,7 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		return nil, parser.ErrMissingTimeseries
 	}
 
-	firstArg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	firstArg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 	if len(e.Args()) == 2 {
 		useMetricNames = true
 		numerators = firstArg
-		denominators, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+		denominators, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/ewma/function.go
+++ b/expr/functions/ewma/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // ewma(seriesList, alpha)
 func (f *ewma) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/exclude/function.go
+++ b/expr/functions/exclude/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // exclude(seriesList, pattern)
 func (f *exclude) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/fallbackSeries/function.go
+++ b/expr/functions/fallbackSeries/function.go
@@ -33,8 +33,8 @@ func (f *fallbackSeries) Do(ctx context.Context, e parser.Expr, from, until int6
 		Takes a wildcard seriesList, and a second fallback metric.
 		If the wildcard does not match any series, draws the fallback metric.
 	*/
-	seriesList, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
-	fallback, errFallback := helper.GetSeriesArg(e.Args()[1], from, until, values)
+	seriesList, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	fallback, errFallback := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if errFallback != nil && err != nil {
 		return nil, errFallback
 	}

--- a/expr/functions/fft/function.go
+++ b/expr/functions/fft/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // fft(seriesList, mode)
 // mode: "", abs, phase. Empty string means "both"
 func (f *fft) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/filter/function.go
+++ b/expr/functions/filter/function.go
@@ -39,7 +39,7 @@ var supportedOperators = map[string]struct{}{
 
 // filterSeries(*seriesLists)
 func (f *filterSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/grep/function.go
+++ b/expr/functions/grep/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // grep(seriesList, pattern)
 func (f *grep) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/group/function.go
+++ b/expr/functions/group/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // group(*seriesLists)
 func (f *group) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArgsAndRemoveNonExisting(e, from, until, values)
+	args, err := helper.GetSeriesArgsAndRemoveNonExisting(ctx, e, from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/groupByNode/function.go
+++ b/expr/functions/groupByNode/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // groupByNode(seriesList, nodeNum, callback)
 // groupByNodes(seriesList, callback, *nodes)
 func (f *groupByNode) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/groupByTags/function.go
+++ b/expr/functions/groupByTags/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // seriesByTag("name=cpu")|groupByTags("average","dc","os")
 func (f *groupByTags) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/heatMap/function.go
+++ b/expr/functions/heatMap/function.go
@@ -29,7 +29,7 @@ func New(_ string) []interfaces.FunctionMetadata {
 }
 
 func (f *heatMap) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	series, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	series, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/highestLowest/function.go
+++ b/expr/functions/highestLowest/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // highestAverage(seriesList, n) , highestCurrent(seriesList, n), highestMax(seriesList, n)
 func (f *highest) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // hitcount(seriesList, intervalString, alignToInterval=False)
 func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/holtWintersAberration/function.go
+++ b/expr/functions/holtWintersAberration/function.go
@@ -37,7 +37,7 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 		return nil, err
 	}
 
-	args, err := helper.GetSeriesArg(e.Args()[0], from-bootstrapInterval, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from-bootstrapInterval, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 	for _, arg := range args {
 		var (
 			aberration []float64
-			series []float64
+			series     []float64
 		)
 
 		stepTime := arg.StepTime

--- a/expr/functions/holtWintersConfidenceBands/function.go
+++ b/expr/functions/holtWintersConfidenceBands/function.go
@@ -36,7 +36,7 @@ func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from
 		return nil, err
 	}
 
-	args, err := helper.GetSeriesArg(e.Args()[0], from-bootstrapInterval, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from-bootstrapInterval, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/holtWintersForecast/function.go
+++ b/expr/functions/holtWintersForecast/function.go
@@ -36,7 +36,7 @@ func (f *holtWintersForecast) Do(ctx context.Context, e parser.Expr, from, until
 		return nil, err
 	}
 
-	args, err := helper.GetSeriesArgsAndRemoveNonExisting(e, from-bootstrapInterval, until, values)
+	args, err := helper.GetSeriesArgsAndRemoveNonExisting(ctx, e, from-bootstrapInterval, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/ifft/function.go
+++ b/expr/functions/ifft/function.go
@@ -33,14 +33,14 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // ifft(absSeriesList, phaseSeriesList)
 func (f *ifft) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	absSeriesList, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	absSeriesList, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
 
 	var phaseSeriesList []*types.MetricData
 	if len(e.Args()) > 1 {
-		phaseSeriesList, err = helper.GetSeriesArg(e.Args()[1], from, until, values)
+		phaseSeriesList, err = helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/integral/function.go
+++ b/expr/functions/integral/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // integral(seriesList)
 func (f *integral) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return helper.ForEachSeriesDo(e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
+	return helper.ForEachSeriesDo(ctx, e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
 		current := 0.0
 		for i, v := range a.Values {
 			if math.IsNaN(v) {

--- a/expr/functions/integralByInterval/function.go
+++ b/expr/functions/integralByInterval/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // integralByInterval(seriesList, intervalString)
 func (f *integralByInterval) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/integralWithReset/function.go
+++ b/expr/functions/integralWithReset/function.go
@@ -33,11 +33,11 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // integralWithReset(seriesList, resettingSeries)
 func (f *integralWithReset) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
-	resettingSeriesList, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+	resettingSeriesList, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/interpolate/function.go
+++ b/expr/functions/interpolate/function.go
@@ -27,7 +27,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *interpolate) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (resultData []*types.MetricData, resultError error) {
-	seriesList, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	seriesList, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/invert/function.go
+++ b/expr/functions/invert/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // invert(seriesList)
 func (f *invert) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return helper.ForEachSeriesDo(e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
+	return helper.ForEachSeriesDo(ctx, e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
 		for i, v := range a.Values {
 			if v == 0 {
 				r.Values[i] = math.NaN()

--- a/expr/functions/isNotNull/function.go
+++ b/expr/functions/isNotNull/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 func (f *isNotNull) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	e.SetTarget("isNonNull")
 
-	return helper.ForEachSeriesDo(e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
+	return helper.ForEachSeriesDo(ctx, e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
 		for i, v := range a.Values {
 			if math.IsNaN(v) {
 				r.Values[i] = 0

--- a/expr/functions/keepLastValue/function.go
+++ b/expr/functions/keepLastValue/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // keepLastValue(seriesList, limit=inf)
 func (f *keepLastValue) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/kolmogorovSmirnovTest2/function.go
+++ b/expr/functions/kolmogorovSmirnovTest2/function.go
@@ -33,12 +33,12 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // ksTest2(series, series, points|"interval")
 // https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test
 func (f *kolmogorovSmirnovTest2) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg1, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg1, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
 
-	arg2, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+	arg2, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/legendValue/function.go
+++ b/expr/functions/legendValue/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // legendValue(seriesList, newName)
 func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/limit/function.go
+++ b/expr/functions/limit/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // limit(seriesList, n)
 func (f *limit) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/linearRegression/function.go
+++ b/expr/functions/linearRegression/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // linearRegression(seriesList, startSourceAt=None, endSourceAt=None)
 func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/logarithm/function.go
+++ b/expr/functions/logarithm/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // logarithm(seriesList, base=10)
 // Alias: log
 func (f *logarithm) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/lowPass/function.go
+++ b/expr/functions/lowPass/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // lowPass(seriesList, cutPercent)
 func (f *lowPass) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/mapSeries/function.go
+++ b/expr/functions/mapSeries/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // mapSeries(seriesList, *mapNodes)
 // Alias: map
 func (f *mapSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/mostDeviant/function.go
+++ b/expr/functions/mostDeviant/function.go
@@ -44,7 +44,7 @@ func (f *mostDeviant) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		return nil, err
 	}
 
-	args, err := helper.GetSeriesArg(e.Args()[seriesArg], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[seriesArg], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -104,7 +104,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		start -= int64(n)
 	}
 
-	arg, err := helper.GetSeriesArg(e.Args()[0], start, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], start, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -99,7 +99,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 		start -= int64(n)
 	}
 
-	arg, err := helper.GetSeriesArg(e.Args()[0], start, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], start, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/multiplySeriesWithWildcards/function.go
+++ b/expr/functions/multiplySeriesWithWildcards/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 func (f *multiplySeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	/* TODO(dgryski): make sure the arrays are all the same 'size'
 	   (duplicated from sumSeriesWithWildcards because of similar logic but multiplication) */
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/nPercentile/function.go
+++ b/expr/functions/nPercentile/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // nPercentile(seriesList, n)
 func (f *nPercentile) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/nonNegativeDerivative/function.go
+++ b/expr/functions/nonNegativeDerivative/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *nonNegativeDerivative) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/offset/function.go
+++ b/expr/functions/offset/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // offset(seriesList,factor)
 func (f *offset) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/offsetToZero/function.go
+++ b/expr/functions/offsetToZero/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // offsetToZero(seriesList)
 func (f *offsetToZero) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return helper.ForEachSeriesDo(e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
+	return helper.ForEachSeriesDo(ctx, e, from, until, values, func(a *types.MetricData, r *types.MetricData) *types.MetricData {
 		minimum := math.Inf(1)
 		for _, v := range a.Values {
 			// NaN < val is always false

--- a/expr/functions/pearson/function.go
+++ b/expr/functions/pearson/function.go
@@ -32,12 +32,12 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // pearson(series, series, windowSize)
 func (f *pearson) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg1, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg1, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
 
-	arg2, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+	arg2, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/pearsonClosest/function.go
+++ b/expr/functions/pearsonClosest/function.go
@@ -37,7 +37,7 @@ func (f *pearsonClosest) Do(ctx context.Context, e parser.Expr, from, until int6
 		return nil, types.ErrTooManyArguments
 	}
 
-	ref, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	ref, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (f *pearsonClosest) Do(ctx context.Context, e parser.Expr, from, until int6
 		return nil, types.ErrWildcardNotAllowed
 	}
 
-	compare, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+	compare, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ Implementation of Pearson product-moment correlation coefficient (PMCC) function
 
 	pearsonClosest( series, seriesList, n, direction="abs" )
 
-    
+
 Return the n series in seriesList with closest Pearson score to the first series argument.
 An optional direction parameter may also be given:
 	"abs"   - (default) Series with any Pearson score + or - [-1 .. 1].

--- a/expr/functions/perSecond/function.go
+++ b/expr/functions/perSecond/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // perSecond(seriesList, maxValue=None)
 func (f *perSecond) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/percentileOfSeries/function.go
+++ b/expr/functions/percentileOfSeries/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // percentileOfSeries(seriesList, n, interpolate=False)
 func (f *percentileOfSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/polyfit/function.go
+++ b/expr/functions/polyfit/function.go
@@ -36,7 +36,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 func (f *polyfit) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// Fitting Nth degree polynom to the dataset
 	// https://en.wikipedia.org/wiki/Polynomial_regression#Matrix_form_and_calculation_of_estimates
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/pow/function.go
+++ b/expr/functions/pow/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // pow(seriesList,factor)
 func (f *pow) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/rangeOfSeries/function.go
+++ b/expr/functions/rangeOfSeries/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // rangeOfSeries(*seriesLists)
 func (f *rangeOfSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	series, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	series, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/reduce/function.go
+++ b/expr/functions/reduce/function.go
@@ -36,7 +36,7 @@ func (f *reduce) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		return nil, parser.ErrMissingArgument
 	}
 
-	seriesList, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	seriesList, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/removeBelowSeries/function.go
+++ b/expr/functions/removeBelowSeries/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // removeBelowValue(seriesLists, n), removeAboveValue(seriesLists, n), removeBelowPercentile(seriesLists, percent), removeAbovePercentile(seriesLists, percent)
 func (f *removeBelowSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // removeEmptySeries(seriesLists, n), removeZeroSeries(seriesLists, n)
 func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/round/function.go
+++ b/expr/functions/round/function.go
@@ -31,7 +31,7 @@ func New(_ string) []interfaces.FunctionMetadata {
 
 // round(seriesList,precision)
 func (f *round) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/scale/function.go
+++ b/expr/functions/scale/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // scale(seriesList, factor)
 func (f *scale) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -72,14 +72,14 @@ func (f *scale) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
 		"scale": {
 			Description: "Takes one metric or a wildcard seriesList followed by a constant, and multiplies the datapoint\n" +
-				"by the constant provided at each point.\n"+
-				"carbonapi extends this function by optional 3-rd parameter that accepts unix-timestamp. If provided, only values with timestamp newer than it will be scaled\n\n"+
-				"Example:\n\n.. code-block:: none\n\n  &target=scale(Server.instance01.threads.busy,10)\n  &target=scale(Server.instance*.threads.busy,10)\n\n"+
+				"by the constant provided at each point.\n" +
+				"carbonapi extends this function by optional 3-rd parameter that accepts unix-timestamp. If provided, only values with timestamp newer than it will be scaled\n\n" +
+				"Example:\n\n.. code-block:: none\n\n  &target=scale(Server.instance01.threads.busy,10)\n  &target=scale(Server.instance*.threads.busy,10)\n\n" +
 				"Alias: scaleAfterTimestamp",
-			Function:    "scale(seriesList, factor)",
-			Group:       "Transform",
-			Module:      "graphite.render.functions",
-			Name:        "scale",
+			Function: "scale(seriesList, factor)",
+			Group:    "Transform",
+			Module:   "graphite.render.functions",
+			Name:     "scale",
 			Params: []types.FunctionParam{
 				{
 					Name:     "seriesList",
@@ -101,13 +101,13 @@ func (f *scale) Description() map[string]types.FunctionDescription {
 		},
 		"scaleAfterTimestamp": {
 			Description: "Takes one metric or a wildcard seriesList followed by a constant, and multiplies the datapoint\n" +
-				"by the constant provided at each point.\n"+
-				"carbonapi extends this function by optional 3-rd parameter that accepts unix-timestamp. If provided, only values with timestamp newer than it will be scaled\n\n"+
+				"by the constant provided at each point.\n" +
+				"carbonapi extends this function by optional 3-rd parameter that accepts unix-timestamp. If provided, only values with timestamp newer than it will be scaled\n\n" +
 				"Example:\n\n.. code-block:: none\n\n  &target=scale(Server.instance01.threads.busy,10)\n  &target=scale(Server.instance*.threads.busy,10)",
-			Function:    "scale(seriesList, factor)",
-			Group:       "Transform",
-			Module:      "graphite.render.functions",
-			Name:        "scale",
+			Function: "scale(seriesList, factor)",
+			Group:    "Transform",
+			Module:   "graphite.render.functions",
+			Name:     "scale",
 			Params: []types.FunctionParam{
 				{
 					Name:     "seriesList",

--- a/expr/functions/scaleToSeconds/function.go
+++ b/expr/functions/scaleToSeconds/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // scaleToSeconds(seriesList, seconds)
 func (f *scaleToSeconds) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -42,7 +42,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 		return nil, err
 	}
 
-	numerators, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	numerators, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		if merry.Is(err, parser.ErrSeriesDoesNotExist) && !math.IsNaN(defaultValue) {
 			useConstant = true
@@ -61,7 +61,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 	}
 	sort.Slice(numerators, func(i, j int) bool { return numerators[i].Name < numerators[j].Name })
 
-	denominators, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+	denominators, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
 		if merry.Is(err, parser.ErrSeriesDoesNotExist) && !math.IsNaN(defaultValue) && !useConstant {
 			useConstant = true

--- a/expr/functions/slo/function.go
+++ b/expr/functions/slo/function.go
@@ -38,7 +38,7 @@ func (f *slo) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 	)
 
 	// requested data points' window
-	argsWindowed, err = helper.GetSeriesArg(e.Args()[0], from, until, values)
+	argsWindowed, err = helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if len(argsWindowed) == 0 || err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (f *slo) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 	windowSize = until - from
 	if bucketSize > windowSize && !(from == 0 && until == 1) {
 		delta = bucketSize - windowSize
-		argsExtended, err = helper.GetSeriesArg(e.Args()[0], from-delta, until, values)
+		argsExtended, err = helper.GetSeriesArg(ctx, e.Args()[0], from-delta, until, values)
 
 		if err != nil {
 			return nil, err

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // smartSummarize(seriesList, intervalString, alignToInterval=False)
 func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/sortBy/function.go
+++ b/expr/functions/sortBy/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // sortByMaxima(seriesList), sortByMinima(seriesList), sortByTotal(seriesList)
 func (f *sortBy) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	original, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	original, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/sortByName/function.go
+++ b/expr/functions/sortByName/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // sortByName(seriesList, natural=false)
 func (f *sortByName) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	original, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	original, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/squareRoot/function.go
+++ b/expr/functions/squareRoot/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // squareRoot(seriesList)
 func (f *squareRoot) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/stdev/function.go
+++ b/expr/functions/stdev/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // stdev(seriesList, points, missingThreshold=0.1)
 // Alias: stddev
 func (f *stdev) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/substr/function.go
+++ b/expr/functions/substr/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // aliasSub(seriesList, start, stop)
 func (f *substr) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// BUG: affected by the same positional arg issue as 'threshold'.
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -65,11 +65,11 @@ func (f *substr) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			}
 			nodes = nodes[realStartField:]
 		}
-		if stopField != 0 && stopField < len(nodes) + realStartField {
+		if stopField != 0 && stopField < len(nodes)+realStartField {
 			realStopField := stopField
 			if stopField < 0 {
 				realStopField = len(nodes) + stopField
-			} else{ 
+			} else {
 				realStopField = realStopField - realStartField
 			}
 			if realStopField < 0 {

--- a/expr/functions/sumSeriesWithWildcards/function.go
+++ b/expr/functions/sumSeriesWithWildcards/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // sumSeriesWithWildcards(*seriesLists)
 func (f *sumSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // summarize(seriesList, intervalString, func='sum', alignToFrom=False)
 func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/timeShift/function.go
+++ b/expr/functions/timeShift/function.go
@@ -85,7 +85,7 @@ func (f *timeShift) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		return nil, err
 	}
 
-	arg, err := helper.GetSeriesArg(e.Args()[0], from+int64(offs), until+int64(offs), values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from+int64(offs), until+int64(offs), values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/timeShiftByMetric/function.go
+++ b/expr/functions/timeShiftByMetric/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // timeShiftByMetric(seriesList, markSource, versionRankIndex)
 func (f *timeShiftByMetric) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (resultData []*types.MetricData, resultError error) {
-	params, err := f.extractCallParams(e, from, until, values)
+	params, err := f.extractCallParams(ctx, e, from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -108,13 +108,13 @@ func (f *timeShiftByMetric) calculateOffsets(params *callParams, versions versio
 }
 
 // extractCallParams (preliminarily) validates and extracts parameters of timeShiftByMetric's call as structure
-func (f *timeShiftByMetric) extractCallParams(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (*callParams, error) {
-	metrics, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+func (f *timeShiftByMetric) extractCallParams(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (*callParams, error) {
+	metrics, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
 
-	marks, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+	marks, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/timeSlice/function.go
+++ b/expr/functions/timeSlice/function.go
@@ -45,7 +45,7 @@ func (f *timeSlice) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	start += now
 	end += now
 
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/timeStack/function.go
+++ b/expr/functions/timeStack/function.go
@@ -50,7 +50,7 @@ func (f *timeStack) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		offs := i * int64(unit)
 		fromNew := from + offs
 		untilNew := until + offs
-		arg, err := helper.GetSeriesArg(e.Args()[0], fromNew, untilNew, values)
+		arg, err := helper.GetSeriesArg(ctx, e.Args()[0], fromNew, untilNew, values)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/transformNull/function.go
+++ b/expr/functions/transformNull/function.go
@@ -33,7 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // transformNull(seriesList, default=0)
 func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64
 	var valMap []bool
 	referenceSeriesExpr := e.GetNamedArg("referenceSeries")
 	if !referenceSeriesExpr.IsInterfaceNil() {
-		referenceSeries, err := helper.GetSeriesArg(referenceSeriesExpr, from, until, values)
+		referenceSeries, err := helper.GetSeriesArg(ctx, referenceSeriesExpr, from, until, values)
 		if err != nil {
 			return nil, err
 		}
@@ -106,14 +106,14 @@ func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64
 	}
 	if len(arg) == 0 && defaultOnAbsent {
 		values := []float64{defv, defv}
-		step := until-from
+		step := until - from
 		results = append(results, &types.MetricData{
 			FetchResponse: pbv3.FetchResponse{
-				Name: e.ToString(),
+				Name:      e.ToString(),
 				StartTime: from,
-				StopTime: from+step*int64(len(values)),
-				StepTime: step,
-				Values: values,
+				StopTime:  from + step*int64(len(values)),
+				StepTime:  step,
+				Values:    values,
 			},
 			Tags: map[string]string{"name": e.ToString()},
 		})

--- a/expr/functions/tukey/function.go
+++ b/expr/functions/tukey/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // tukeyAbove(seriesList,basis,n,interval=0) , tukeyBelow(seriesList,basis,n,interval=0)
 func (f *tukey) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/weightedAverage/function.go
+++ b/expr/functions/weightedAverage/function.go
@@ -36,11 +36,11 @@ func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int
 	aggKeyPairs := make(map[string]map[string]*types.MetricData)
 	var productList []*types.MetricData
 
-	avgs, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	avgs, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
-	weights, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+	weights, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -33,12 +33,12 @@ func SetEvaluator(e interfaces.Evaluator) {
 }
 
 // GetSeriesArg returns argument from series.
-func GetSeriesArg(arg parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+func GetSeriesArg(ctx context.Context, arg parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	if !arg.IsName() && !arg.IsFunc() {
 		return nil, parser.ErrMissingTimeseries
 	}
 
-	a, err := evaluator.Eval(context.TODO(), arg, from, until, values)
+	a, err := evaluator.Eval(ctx, arg, from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -57,11 +57,11 @@ func RemoveEmptySeriesFromName(args []*types.MetricData) string {
 }
 
 // GetSeriesArgs returns arguments of series
-func GetSeriesArgs(e []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+func GetSeriesArgs(ctx context.Context, e []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	var args []*types.MetricData
 
 	for _, arg := range e {
-		a, err := GetSeriesArg(arg, from, until, values)
+		a, err := GetSeriesArg(ctx, arg, from, until, values)
 		if err != nil && !merry.Is(err, parser.ErrSeriesDoesNotExist) {
 			return nil, err
 		}
@@ -77,8 +77,8 @@ func GetSeriesArgs(e []parser.Expr, from, until int64, values map[parser.MetricR
 
 // GetSeriesArgsAndRemoveNonExisting will fetch all required arguments, but will also filter out non existing Series
 // This is needed to be graphite-web compatible in cases when you pass non-existing Series to, for example, sumSeries
-func GetSeriesArgsAndRemoveNonExisting(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := GetSeriesArgs(e.Args(), from, until, values)
+func GetSeriesArgsAndRemoveNonExisting(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := GetSeriesArgs(ctx, e.Args(), from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -120,8 +120,8 @@ func AggKey(arg *types.MetricData, nodesOrTags []parser.NodeOrTag) string {
 type seriesFunc func(*types.MetricData, *types.MetricData) *types.MetricData
 
 // ForEachSeriesDo do action for each serie in list.
-func ForEachSeriesDo(e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData, function seriesFunc) ([]*types.MetricData, error) {
-	arg, err := GetSeriesArg(e.Args()[0], from, until, values)
+func ForEachSeriesDo(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData, function seriesFunc) ([]*types.MetricData, error) {
+	arg, err := GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, parser.ErrMissingTimeseries
 	}

--- a/expr/rewrite/aboveSeries/function.go
+++ b/expr/rewrite/aboveSeries/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.RewriteFunctionMetadata {
 }
 
 func (f *aboveSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return false, nil, err
 	}

--- a/expr/rewrite/applyByNode/function.go
+++ b/expr/rewrite/applyByNode/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.RewriteFunctionMetadata {
 }
 
 func (f *applyByNode) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error) {
-	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return false, nil, err
 	}


### PR DESCRIPTION
Hi, I found that the current context is not passed correctly, and the context is lost when the function is nested.
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/3659110/157829985-089531b1-21a8-48cc-9263-f7adcd4acdfe.png">

Here I'll give an example of a query where the function after rewrite is not able to get maxDataPoints.
```
aliasByNode(highestAverage(applyByNode(host.dns[0-9]*.uptime.uptime.value,1,"scale(perSecond(%.interface-bond1.if_octets.tx), 0.000008)"), 5), 1, 2)
```
So I changed the signature of this method in this pr so that the context is passed correctly.

Also I have a suggestion, can we pass maxDataPoint in the Eval parameter in interfaces. Something like this.
```
Eval(ctx context.Context, e parser.Expr, from, until, maxDataPoints int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types. MetricData, error)
```