### PR TITLE
Fix bashism

### DIFF
--- a/contrib/carbonapi/fpm/carbon-user-systemd-reload.sh
+++ b/contrib/carbonapi/fpm/carbon-user-systemd-reload.sh
@@ -37,4 +37,6 @@ if [ ! -e "${CONF}" ]; then
 fi
 
 # reload systemd
-[[ -e /bin/systemctl ]] && /bin/systemctl daemon-reload ||:
+if [ -e /bin/systemctl ]; then
+  /bin/systemctl daemon-reload
+fi


### PR DESCRIPTION
According to shellcheck, `[[` can be unavailable. And indeed, on my Debian box, it is not valid with `/bin/sh`