### PR TITLE
parser: accept escaped characters

### DIFF
--- a/cmd/mockbackend/testcases/i661/carbonapi.yaml
+++ b/cmd/mockbackend/testcases/i661/carbonapi.yaml
@@ -1,0 +1,79 @@
+listen: "localhost:8081"
+expvar:
+  enabled: true
+  pprofEnabled: false
+  listen: ""
+concurency: 1000
+notFoundStatusCode: 404
+cache:
+   type: "mem"
+   size_mb: 0
+   defaultTimeoutSec: 60
+   memcachedServers:
+       - "127.0.0.1:1234"
+       - "127.0.0.2:1235"
+cpus: 0
+tz: ""
+maxBatchSize: 0
+graphite:
+    host: ""
+    interval: "60s"
+    prefix: "carbon.api"
+    pattern: "{prefix}.{fqdn}"
+idleConnections: 10
+pidFile: ""
+upstreams:
+    buckets: 10
+    timeouts:
+        find: "2s"
+        render: "10s"
+        connect: "200ms"
+    concurrencyLimitPerServer: 0
+    keepAliveInterval: "30s"
+    maxIdleConnsPerHost: 100
+    backendsv2:
+        backends:
+          -
+            groupName: "mock-001"
+            protocol: "auto"
+            lbMethod: "all"
+            maxTries: 3
+            maxBatchSize: 0
+            keepAliveInterval: "10s"
+            concurrencyLimit: 0
+            maxIdleConnsPerHost: 1000
+            timeouts:
+                find: "15s"
+                render: "50s"
+                connect: "200ms"
+            servers:
+                - "http://127.0.0.1:9070"
+                - "http://127.0.0.1:9071"
+          -
+            groupName: "mock-002"
+            protocol: "auto"
+            lbMethod: "all"
+            maxTries: 3
+            maxBatchSize: 0
+            keepAliveInterval: "10s"
+            concurrencyLimit: 0
+            maxIdleConnsPerHost: 1000
+            timeouts:
+                find: "15s"
+                render: "50s"
+                connect: "200ms"
+            servers:
+                - "http://127.0.0.1:9072"
+                - "http://127.0.0.1:9073"
+    graphite09compat: false
+expireDelaySec: 10
+unicodeRangeTables:
+    - "Latin"
+    - "Common"
+logger:
+    - logger: ""
+      file: "stderr"
+      level: "debug"
+      encoding: "console"
+      encodingTime: "iso8601"
+      encodingDuration: "seconds"

--- a/cmd/mockbackend/testcases/i661/i661.yaml
+++ b/cmd/mockbackend/testcases/i661/i661.yaml
@@ -1,0 +1,44 @@
+version: "v1"
+test:
+    apps:
+        - name: "carbonapi"
+          binary: "./carbonapi"
+          args:
+              - "-config"
+              - "./cmd/mockbackend/testcases/i598/carbonapi.yaml"
+    queries:
+            - endpoint: "http://127.0.0.1:8081"
+              delay: 1
+              type: "GET"
+              URL: "/render/?target=fo\\(o\\).bar&format=json"
+              expectedResponse:
+                  httpCode: 200
+                  contentType: "application/json"
+                  expectedResults:
+                          - metrics:
+                                  - target: "fo(o).bar"
+                                    datapoints: [[0,1],[1,2],[2,3],[2,4],[3,5]]
+            - endpoint: "http://127.0.0.1:8081"
+              delay: 1
+              type: "GET"
+              URL: "/render/?target=metric\\\\a&format=json"
+              expectedResponse:
+                  httpCode: 200
+                  contentType: "application/json"
+                  expectedResults:
+                          - metrics:
+                                  - target: "metric\\a"
+                                    datapoints: [[0,1],[1,2],[2,3],[2,4],[3,5]]
+listeners:
+  - address: ":9070"
+    expressions:
+      "fo(o).bar":
+        pathExpression: "fo(o).bar"
+        data:
+            - metricName: "fo(o).bar"
+              values: [0,1,2,2,3]
+      "metric\\a":
+        pathExpression: "metric\\a"
+        data:
+            - metricName: "metric\\a"
+              values: [0,1,2,2,3]


### PR DESCRIPTION
graphite-web apparantly allow you to escape special reserved characters in metric names

Modify parser to allow to escape special characters as well

That should fix #661