### PR TITLE
Fix aggregate series panic

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	th "github.com/go-graphite/carbonapi/tests"
+	"github.com/go-graphite/carbonapi/tests/compare"
 	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )
 
@@ -494,7 +495,7 @@ func TestEvalCustomFromUntil(t *testing.T) {
 			if g[0].StepTime == 0 {
 				t.Errorf("missing step for %+v", g)
 			}
-			if !th.NearlyEqual(g[0].Values, tt.w) {
+			if !compare.NearlyEqual(g[0].Values, tt.w) {
 				t.Errorf("failed: %s: got %+v, want %+v", g[0].Name, g[0].Values, tt.w)
 			}
 			if g[0].Name != tt.name {

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -280,6 +280,16 @@ func TestAverageSeries(t *testing.T) {
 
 func TestAverageSeriesAlign(t *testing.T) {
 	tests := []th.EvalTestItem{
+		// Indx      |   0  |   1  |   2  |   3  |   4  |
+		// commonStep  2
+		// Start  0 (1 - 1 % 2)
+		// metric1_2 |      |   1  |   3  |   5  |      |
+		// metric1_2 |   1  |      |   4  |      |      |
+		//
+		// metric2_1 |      |   1  |      |   5  |      |
+		// metric2_1 |   1  |      |   5  |      |      |
+
+		// sum       |   2  |      |   9  |      |      |
 		{
 			// timeseries with different length
 			Target: "sum(metric1_2,metric2_1)",
@@ -288,7 +298,7 @@ func TestAverageSeriesAlign(t *testing.T) {
 				{"metric2_1", 0, 1}: {types.MakeMetricData("metric2", []float64{1, 5}, 2, 1)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData("sumSeries(metric1_2,metric2_1)",
-				[]float64{1, 6, 10, 5}, 1, 1)},
+				[]float64{2, 9}, 2, 0)},
 		},
 		{
 			// First timeseries with broker StopTime
@@ -305,7 +315,7 @@ func TestAverageSeriesAlign(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprResult(t, &tt)
 		})
 	}
 

--- a/expr/helper/align.go
+++ b/expr/helper/align.go
@@ -52,6 +52,24 @@ func GetCommonStep(args []*types.MetricData) (commonStep int64, changed bool) {
 	return commonStep, true
 }
 
+// GetStepRange returns min(steps), changed (bool) for slice of metrics.
+// If all metrics have the same step, changed == false.
+func GetStepRange(args []*types.MetricData) (minStep, maxStep int64, needScale bool) {
+	minStep = args[0].StepTime
+	maxStep = args[0].StepTime
+	for _, arg := range args {
+		if minStep > arg.StepTime {
+			minStep = arg.StepTime
+		}
+		if maxStep < arg.StepTime {
+			maxStep = arg.StepTime
+		}
+	}
+	needScale = minStep != maxStep
+
+	return
+}
+
 // ScaleToCommonStep returns the metrics, aligned LCM of all metrics steps.
 // If commonStep == 0, then it will be calculated automatically
 // It respects xFilesFactor and fills gaps in the begin and end with NaNs if needed.
@@ -62,50 +80,97 @@ func ScaleToCommonStep(args []*types.MetricData, commonStep int64) []*types.Metr
 	}
 
 	// If it's invoked with commonStep other than 0, changes are applied by default
-	changed := true
 	if commonStep == 0 {
-		commonStep, changed = GetCommonStep(args)
+		commonStep, _ = GetCommonStep(args)
 	}
 
-	if !changed {
-		return args
+	minStart := args[0].StartTime
+	for _, arg := range args {
+		if minStart > arg.StartTime {
+			minStart = arg.StartTime
+		}
 	}
+	minStart -= (minStart % commonStep) // align StartTime against step
 
-	for a, arg := range args {
+	maxVals := 0
+
+	for _, arg := range args {
 		if arg.StepTime == commonStep {
-			continue
-		}
-		arg = arg.Copy(true)
-		args[a] = arg
-		stepFactor := commonStep / arg.StepTime
-		newStart := arg.StartTime - (arg.StartTime % commonStep)
-		if (arg.StartTime % commonStep) != 0 {
-			// Fill with NaNs from newStart to arg.StartTime
-			valCnt := (arg.StartTime - newStart) / arg.StepTime
-			nans := genNaNs(int(valCnt))
-			arg.Values = append(nans, arg.Values...)
-			arg.StartTime = newStart
-		}
+			if minStart < arg.StartTime {
+				valCnt := (arg.StartTime - minStart) / arg.StepTime
+				newVals := genNaNs(int(valCnt))
+				arg.Values = append(newVals, arg.Values...)
+			}
+			arg.StartTime = minStart
 
-		newValsLen := 1 + int64(len(arg.Values)-1)/stepFactor
-		newStop := arg.StartTime + newValsLen*commonStep
-		newVals := make([]float64, 0, newValsLen)
+			if len(arg.Values) > maxVals {
+				maxVals = len(arg.Values)
+			}
+		} else {
+			// arg = arg.Copy(true)
+			// args[a] = arg
+			stepFactor := commonStep / arg.StepTime
+			// newStart := minStart - (arg.StartTime % commonStep)
+			if arg.StartTime > minStart {
+				// Fill with NaNs from newStart to arg.StartTime
+				valCnt := (arg.StartTime - minStart) / arg.StepTime
+				nans := genNaNs(int(valCnt))
+				arg.Values = append(nans, arg.Values...)
+				arg.StartTime = minStart
+			}
 
-		if len(arg.Values) != int(stepFactor*newValsLen) {
-			// Fill the last step with NaNs from newStart to (newStart + commonStep - arg.StepTime)
-			valCnt := int(stepFactor*newValsLen) - len(arg.Values)
-			nans := genNaNs(valCnt)
-			arg.Values = append(arg.Values, nans...)
+			newValsLen := 1 + int64(len(arg.Values)-1)/stepFactor
+			newStop := arg.StartTime + newValsLen*commonStep
+			newVals := make([]float64, 0, newValsLen)
+
+			if len(arg.Values) != int(stepFactor*newValsLen) {
+				// Fill the last step with NaNs from newStart to (newStart + commonStep - arg.StepTime)
+				valCnt := int(stepFactor*newValsLen) - len(arg.Values)
+				nans := genNaNs(valCnt)
+				arg.Values = append(arg.Values, nans...)
+			}
+			arg.StopTime = newStop
+			for i := 0; i < len(arg.Values); i += int(stepFactor) {
+				aggregatedBatch := aggregateBatch(arg.Values[i:i+int(stepFactor)], arg)
+				newVals = append(newVals, aggregatedBatch)
+			}
+			arg.StepTime = commonStep
+			arg.Values = newVals
+
+			if len(arg.Values) > maxVals {
+				maxVals = len(arg.Values)
+			}
 		}
-		arg.StopTime = newStop
-		for i := 0; i < len(arg.Values); i += int(stepFactor) {
-			aggregatedBatch := aggregateBatch(arg.Values[i:i+int(stepFactor)], arg)
-			newVals = append(newVals, aggregatedBatch)
-		}
-		arg.StepTime = commonStep
-		arg.Values = newVals
 	}
+
+	for _, arg := range args {
+		if maxVals > len(arg.Values) {
+			valCnt := maxVals - len(arg.Values)
+			newVals := genNaNs(valCnt)
+			arg.Values = append(arg.Values, newVals...)
+		}
+		arg.RecalcStopTime()
+	}
+
 	return args
+}
+
+// GetInterval returns minStartTime, maxStartTime for slice of metrics.
+func GetInterval(args []*types.MetricData) (minStartTime, maxStopTime int64) {
+	minStartTime = args[0].StartTime
+	maxStopTime = args[0].StopTime
+	for _, arg := range args {
+		if minStartTime > arg.StartTime {
+			minStartTime = arg.StartTime
+		}
+
+		arg.FixStopTime()
+		if maxStopTime < arg.StopTime {
+			maxStopTime = arg.StopTime
+		}
+	}
+
+	return
 }
 
 func aggregateBatch(vals []float64, arg *types.MetricData) float64 {
@@ -176,17 +241,12 @@ func AlignToBucketSize(start, stop, bucketSize int64) (int64, int64) {
 
 // AlignSeries aligns different series together. By default it only prepends and appends NaNs in case of different length, but if ExtrapolatePoints is enabled, it can extrapolate
 func AlignSeries(args []*types.MetricData) []*types.MetricData {
-	minStart := args[0].StartTime
-	maxStop := args[0].StopTime
-	maxVals := 0
-	minStepTime := args[0].StepTime
-	for j := 0; j < 2; j++ {
-		if ExtrapolatePoints {
-			for _, arg := range args {
-				if arg.StepTime < minStepTime {
-					minStepTime = arg.StepTime
-				}
+	minStart, maxStop := GetInterval(args)
 
+	if ExtrapolatePoints {
+		minStepTime, _, needScale := GetStepRange(args)
+		if needScale {
+			for _, arg := range args {
 				if arg.StepTime > minStepTime {
 					valsCnt := int(math.Ceil(float64(arg.StopTime-arg.StartTime) / float64(minStepTime)))
 					newVals := make([]float64, valsCnt)
@@ -214,14 +274,76 @@ func AlignSeries(args []*types.MetricData) []*types.MetricData {
 				}
 			}
 		}
+	}
 
+	for _, arg := range args {
+		if minStart < arg.StartTime {
+			valCnt := (arg.StartTime - minStart) / arg.StepTime
+			newVals := genNaNs(int(valCnt))
+			arg.Values = append(newVals, arg.Values...)
+		}
+
+		arg.StartTime = minStart
+
+		if maxStop > arg.StopTime {
+			valCnt := (maxStop - arg.StopTime) / arg.StepTime
+			newVals := genNaNs(int(valCnt))
+			arg.Values = append(arg.Values, newVals...)
+			arg.StopTime = maxStop
+		}
+
+		arg.RecalcStopTime()
+	}
+
+	return args
+}
+
+// ScaleSeries aligns and scale different series together. By default it only prepends and appends NaNs in case of different length, but if ExtrapolatePoints is enabled, it can extrapolate
+func ScaleSeries(args []*types.MetricData) []*types.MetricData {
+	minStart, maxStop := GetInterval(args)
+	var commonStep int64
+	var needScale bool
+
+	if ExtrapolatePoints {
+		commonStep, _, needScale = GetStepRange(args)
+		if needScale {
+			for _, arg := range args {
+				if arg.StepTime > commonStep {
+					valsCnt := int(math.Ceil(float64(arg.StopTime-arg.StartTime) / float64(commonStep)))
+					newVals := make([]float64, valsCnt)
+					ts := arg.StartTime
+					nextTs := arg.StartTime + arg.StepTime
+					i := 0
+					j := 0
+					pointsPerInterval := float64(ts-nextTs) / float64(commonStep)
+					v := arg.Values[0]
+					dv := (arg.Values[0] - arg.Values[1]) / pointsPerInterval
+					for ts < arg.StopTime {
+						newVals[i] = v
+						v += dv
+						if ts > nextTs {
+							j++
+							nextTs += arg.StepTime
+							v = arg.Values[j]
+							dv = (arg.Values[j-1] - v) / pointsPerInterval
+						}
+						ts += commonStep
+						i++
+					}
+					arg.Values = newVals
+					arg.StepTime = commonStep
+				}
+			}
+			needScale = false
+		}
+	} else {
+		commonStep, needScale = GetCommonStep(args)
+	}
+
+	if needScale {
+		ScaleToCommonStep(args, commonStep)
+	} else {
 		for _, arg := range args {
-			if len(arg.Values) > maxVals {
-				maxVals = len(arg.Values)
-			}
-			if arg.StartTime < minStart {
-				minStart = arg.StartTime
-			}
 			if minStart < arg.StartTime {
 				valCnt := (arg.StartTime - minStart) / arg.StepTime
 				newVals := genNaNs(int(valCnt))
@@ -229,17 +351,17 @@ func AlignSeries(args []*types.MetricData) []*types.MetricData {
 				arg.StartTime = minStart
 			}
 
-			if arg.StopTime > maxStop {
-				maxStop = arg.StopTime
-			}
 			if maxStop > arg.StopTime {
 				valCnt := (maxStop - arg.StopTime) / arg.StepTime
 				newVals := genNaNs(int(valCnt))
 				arg.Values = append(arg.Values, newVals...)
 				arg.StopTime = maxStop
 			}
+
+			arg.RecalcStopTime()
 		}
 	}
+
 	return args
 }
 

--- a/expr/helper/align_test.go
+++ b/expr/helper/align_test.go
@@ -1,0 +1,55 @@
+package helper
+
+import (
+	"math"
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/tests/compare"
+)
+
+func TestAlignSeries(t *testing.T) {
+	NaN := math.NaN()
+	tests := []struct {
+		name    string
+		metrics []*types.MetricData
+		want    []*types.MetricData
+	}{
+		{
+			"Normal metrics",
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 3, 5, 7, 9, 11, 13, 15, 17}, 1, 4), // 4..13
+				types.MakeMetricData("metric2", []float64{1, 5, 7, 9, 11, 13, 15, 18}, 1, 5),    // 5..13
+				types.MakeMetricData("metric3", []float64{0, 1, 2, 3, 4, 5}, 2, 2),              // 2..14
+				types.MakeMetricData("metric4", []float64{1, 2, 3, 4, 5, 6}, 3, 3),              // 3..21
+				types.MakeMetricData("metric5", []float64{1, 2, 3, 4}, 4, 4),                    // 4..20
+				types.MakeMetricData("metric6", []float64{1, 2, 3, 4}, 4, 2),                    // 2..18
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{NaN, NaN, 1, 3, 5, 7, 9, 11, 13, 15, 17, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, 1, 2),   // 2..21
+				types.MakeMetricData("metric2", []float64{NaN, NaN, NaN, 1, 5, 7, 9, 11, 13, 15, 18, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, 1, 2), // 2..21
+				types.MakeMetricData("metric3", []float64{0, 1, 2, 3, 4, 5, NaN, NaN, NaN}, 2, 2),                                                   // 2:21
+				types.MakeMetricData("metric4", []float64{1, 2, 3, 4, 5, 6}, 3, 3),                                                                  // 2:21
+				types.MakeMetricData("metric5", []float64{1, 2, 3, 4}, 4, 4),                                                                        // 4..18
+				types.MakeMetricData("metric6", []float64{1, 2, 3, 4}, 4, 2),                                                                        // 2..18
+			},
+		},
+		{
+			"Broken StopTime",
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 5, 7, 8}, 1, 1).AppendStopTime(-1),
+				types.MakeMetricData("metric2", []float64{1, 3, 5}, 1, 1),
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 5, 7, 8}, 1, 1),
+				types.MakeMetricData("metric2", []float64{1, 3, 5}, 1, 1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AlignSeries(tt.metrics)
+			compare.TestMetricData(t, got, tt.want)
+		})
+	}
+}

--- a/expr/helper/align_test.go
+++ b/expr/helper/align_test.go
@@ -16,22 +16,35 @@ func TestAlignSeries(t *testing.T) {
 		want    []*types.MetricData
 	}{
 		{
+			"Metrics with one step",
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 3, 5, 7, 9, 11, 13, 15, 17}, 2, 4), // 4..26
+				types.MakeMetricData("metric2", []float64{1, 5, 7, 9, 11, 13, 18}, 2, 5),        // 5..26
+				types.MakeMetricData("metric3", []float64{1, 5, 7, 9, 11, 13}, 2, 6),            // 4..22
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 3, 5, 7, 9, 11, 13, 15, 17}, 2, 4),     // 4..26
+				types.MakeMetricData("metric2", []float64{1, 5, 7, 9, 11, 13, 18, NaN}, 2, 4),       // 4..26
+				types.MakeMetricData("metric3", []float64{NaN, 1, 5, 7, 9, 11, 13, NaN, NaN}, 2, 4), // 4..26
+			},
+		},
+		{
 			"Normal metrics",
 			[]*types.MetricData{
 				types.MakeMetricData("metric1", []float64{1, 3, 5, 7, 9, 11, 13, 15, 17}, 1, 4), // 4..13
-				types.MakeMetricData("metric2", []float64{1, 5, 7, 9, 11, 13, 15, 18}, 1, 5),    // 5..13
+				types.MakeMetricData("metric2", []float64{1, 5, 7, 9, 11, 13, 18}, 1, 5),        // 5..13
 				types.MakeMetricData("metric3", []float64{0, 1, 2, 3, 4, 5}, 2, 2),              // 2..14
 				types.MakeMetricData("metric4", []float64{1, 2, 3, 4, 5, 6}, 3, 3),              // 3..21
 				types.MakeMetricData("metric5", []float64{1, 2, 3, 4}, 4, 4),                    // 4..20
 				types.MakeMetricData("metric6", []float64{1, 2, 3, 4}, 4, 2),                    // 2..18
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("metric1", []float64{NaN, NaN, 1, 3, 5, 7, 9, 11, 13, 15, 17, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, 1, 2),   // 2..21
-				types.MakeMetricData("metric2", []float64{NaN, NaN, NaN, 1, 5, 7, 9, 11, 13, 15, 18, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, 1, 2), // 2..21
-				types.MakeMetricData("metric3", []float64{0, 1, 2, 3, 4, 5, NaN, NaN, NaN}, 2, 2),                                                   // 2:21
-				types.MakeMetricData("metric4", []float64{1, 2, 3, 4, 5, 6}, 3, 3),                                                                  // 2:21
-				types.MakeMetricData("metric5", []float64{1, 2, 3, 4}, 4, 4),                                                                        // 4..18
-				types.MakeMetricData("metric6", []float64{1, 2, 3, 4}, 4, 2),                                                                        // 2..18
+				types.MakeMetricData("metric1", []float64{NaN, NaN, 1, 3, 5, 7, 9, 11, 13, 15, 17, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, 1, 2),    // 2..21
+				types.MakeMetricData("metric2", []float64{NaN, NaN, NaN, 1, 5, 7, 9, 11, 13, 18, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN}, 1, 2), // 2..21
+				types.MakeMetricData("metric3", []float64{0, 1, 2, 3, 4, 5, NaN, NaN, NaN}, 2, 2),                                                    // 2..20
+				types.MakeMetricData("metric4", []float64{1, 2, 3, 4, 5, 6}, 3, 2),                                                                   // 2..20
+				types.MakeMetricData("metric5", []float64{1, 2, 3, 4}, 4, 2),                                                                         // 2..18
+				types.MakeMetricData("metric6", []float64{1, 2, 3, 4}, 4, 2),                                                                         // 2..18
 			},
 		},
 		{
@@ -42,7 +55,7 @@ func TestAlignSeries(t *testing.T) {
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("metric1", []float64{1, 5, 7, 8}, 1, 1),
-				types.MakeMetricData("metric2", []float64{1, 3, 5}, 1, 1),
+				types.MakeMetricData("metric2", []float64{1, 3, 5, NaN}, 1, 1),
 			},
 		},
 	}
@@ -51,5 +64,119 @@ func TestAlignSeries(t *testing.T) {
 			got := AlignSeries(tt.metrics)
 			compare.TestMetricData(t, got, tt.want)
 		})
+	}
+}
+
+func BenchmarkAlignSeries(b *testing.B) {
+	metrics := []*types.MetricData{
+		types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 4),
+		types.MakeMetricData("metric2", compare.GenerateMetrics(1023, 1.0, 9.0, 1.0), 1, 4),
+		types.MakeMetricData("metric3", compare.GenerateMetrics(512, 1.0, 9.0, 1.0), 2, 2),
+		types.MakeMetricData("metric4", compare.GenerateMetrics(340, 1.0, 9.0, 1.0), 3, 3),
+		types.MakeMetricData("metric5", compare.GenerateMetrics(256, 1.0, 9.0, 1.0), 4, 4),
+		types.MakeMetricData("metric6", compare.GenerateMetrics(510, 1.0, 9.0, 1.0), 4, 2),
+	}
+
+	for n := 0; n < b.N; n++ {
+		got := AlignSeries(metrics)
+		_ = got
+
+	}
+}
+
+func TestScaleSeries(t *testing.T) {
+	NaN := math.NaN()
+	tests := []struct {
+		name    string
+		metrics []*types.MetricData
+		want    []*types.MetricData
+	}{
+		{
+			"Metrics with one step (avg)",
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 3, 5, 7, 9, 11, 13, 15, 17}, 2, 4), // 4..26
+				types.MakeMetricData("metric2", []float64{1, 5, 7, 9, 11, 13, 18}, 2, 5),        // 5..26
+				types.MakeMetricData("metric3", []float64{1, 5, 7, 9, 11, 13}, 2, 6),            // 4..22
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 3, 5, 7, 9, 11, 13, 15, 17}, 2, 4),     // 4..26
+				types.MakeMetricData("metric2", []float64{1, 5, 7, 9, 11, 13, 18, NaN}, 2, 4),       // 4..26
+				types.MakeMetricData("metric3", []float64{NaN, 1, 5, 7, 9, 11, 13, NaN, NaN}, 2, 4), // 4..26
+			},
+		},
+
+		// Indx     |  0   |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   10  |   11  |   12  |   13  |   14  |   15  |   20  |   21  |
+		// commonStep  12
+		// Start  0 (2 - 2 % 12)
+		//  metric1 |      |      |      |      |   1  |   3  |   5  |   7  |   9  |  11  |   13  |   15  |   17  |       |       |       |       |       |
+		//  metric1 |  N   |      |      |      |      |      |      |      |      |      |       |       |   17  |       |       |       |       |       |
+		//
+		//  metric2 |      |      |      |      |      |   1  |   5  |   7  |   9  |  11  |   13  |   18  |       |       |       |       |       |       |
+		//  metric2 | 9.142857142857143  |      |      |      |      |      |      |      |       |       |  NaN  |       |       |       |       |       |
+		//
+		//  metric3 |      |      |   0  |      |  1   |      |   2  |      |   3  |      |    4  |       |    5  |       |       |       |       |       |
+		//  metric3 |   2  |      |      |      |      |      |      |      |      |      |       |       |    5  |       |       |       |       |       |
+		//
+		//  metric4 |      |      |      |   1  |      |      |   2  |      |      |   3  |       |       |    4  |       |    5  |       |       |    6  |
+		//  metric4 |   2  |      |      |      |      |      |      |      |      |      |       |       |    5  |       |       |       |       |      |
+		//
+		//  metric5 |      |      |      |      |  1   |      |      |      |   2  |      |       |       |    3  |       |       |       |    4  |       |
+		//  metric5 | 1.5  |      |      |      |      |      |      |      |      |      |       |       |  3.5  |       |       |       |       |       |
+		//
+		//  metric6 |      |      |   1  |      |      |      |   2  |      |      |      |    3  |       |       |       |    4  |       |       |       |
+		//  metric6 |   2  |      |      |      |      |      |      |      |      |      |       |       |    4  |       |       |       |       |       |
+		{
+			"Normal metrics (avg)",
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 3, 5, 7, 9, 11, 13, 15, 17}, 1, 4),
+				types.MakeMetricData("metric2", []float64{1, 5, 7, 9, 11, 13, 18}, 1, 5),
+				types.MakeMetricData("metric3", []float64{0, 1, 2, 3, 4, 5}, 2, 2),
+				types.MakeMetricData("metric4", []float64{1, 2, 3, 4, 5, 6}, 3, 3),
+				types.MakeMetricData("metric5", []float64{1, 2, 3, 4}, 4, 4),
+				types.MakeMetricData("metric6", []float64{1, 2, 3, 4}, 4, 2),
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{8, 17}, 12, 0),
+				types.MakeMetricData("metric2", []float64{9.142857142857143, NaN}, 12, 0),
+				types.MakeMetricData("metric3", []float64{2, 5}, 12, 0),
+				types.MakeMetricData("metric4", []float64{2, 5}, 12, 0),
+				types.MakeMetricData("metric5", []float64{1.5, 3.5}, 12, 0),
+				types.MakeMetricData("metric6", []float64{2, 4}, 12, 0),
+			},
+		},
+		{
+			"Broken StopTime (avg)",
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 5, 7, 8}, 1, 1).AppendStopTime(-1),
+				types.MakeMetricData("metric2", []float64{1, 3, 5}, 1, 1),
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 5, 7, 8}, 1, 1),
+				types.MakeMetricData("metric2", []float64{1, 3, 5, NaN}, 1, 1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScaleSeries(tt.metrics)
+			compare.TestMetricData(t, got, tt.want)
+		})
+	}
+}
+
+func BenchmarkScaleSeries(b *testing.B) {
+	metrics := []*types.MetricData{
+		types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 4),
+		types.MakeMetricData("metric2", compare.GenerateMetrics(1023, 1.0, 9.0, 1.0), 1, 4),
+		types.MakeMetricData("metric3", compare.GenerateMetrics(512, 1.0, 9.0, 1.0), 2, 2),
+		types.MakeMetricData("metric4", compare.GenerateMetrics(340, 1.0, 9.0, 1.0), 3, 3),
+		types.MakeMetricData("metric5", compare.GenerateMetrics(256, 1.0, 9.0, 1.0), 4, 4),
+		types.MakeMetricData("metric6", compare.GenerateMetrics(510, 1.0, 9.0, 1.0), 4, 2),
+	}
+
+	for n := 0; n < b.N; n++ {
+		got := ScaleSeries(metrics)
+		_ = got
+
 	}
 }

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -141,18 +141,7 @@ type AggregateFunc func([]float64) float64
 
 // AggregateSeries aggregates series
 func AggregateSeries(e parser.Expr, args []*types.MetricData, function AggregateFunc) ([]*types.MetricData, error) {
-	args = AlignSeries(args)
-
-	needScale := false
-	for i := 1; i < len(args); i++ {
-		if args[i].StepTime != args[0].StepTime {
-			needScale = true
-			break
-		}
-	}
-	if needScale {
-		ScaleToCommonStep(args, 0)
-	}
+	args = ScaleSeries(args)
 
 	length := len(args[0].Values)
 	r := *args[0]

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -203,7 +203,7 @@ func MarshalPickle(results []*MetricData) []byte {
 func MarshalProtobufV2(results []*MetricData) ([]byte, error) {
 	response := pbv2.MultiFetchResponse{}
 	for _, metric := range results {
-		fmv3 := (*metric).FetchResponse
+		fmv3 := metric.FetchResponse
 		v := make([]float64, len(fmv3.Values))
 		isAbsent := make([]bool, len(fmv3.Values))
 		for i := range fmv3.Values {
@@ -236,7 +236,7 @@ func MarshalProtobufV2(results []*MetricData) ([]byte, error) {
 func MarshalProtobufV3(results []*MetricData) ([]byte, error) {
 	response := pb.MultiFetchResponse{}
 	for _, metric := range results {
-		response.Metrics = append(response.Metrics, (*metric).FetchResponse)
+		response.Metrics = append(response.Metrics, metric.FetchResponse)
 	}
 	b, err := response.Marshal()
 	if err != nil {

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -423,6 +423,24 @@ func (r *MetricData) CopyLink() *MetricData {
 	}
 }
 
+// SetConsolidationFunc set ConsolidationFunc
+func (r *MetricData) SetConsolidationFunc(f string) *MetricData {
+	r.ConsolidationFunc = f
+	return r
+}
+
+// SetXFilesFactor set XFilesFactor
+func (r *MetricData) SetXFilesFactor(x float32) *MetricData {
+	r.XFilesFactor = x
+	return r
+}
+
+// AppendStopTime append to StopTime for simulate broken time series
+func (r *MetricData) AppendStopTime(step int64) *MetricData {
+	r.StopTime += step
+	return r
+}
+
 // CopyMetricDataSlice returns the slice of metrics that should be changed later.
 // It allows to avoid a changing of source data, e.g. by AlignMetrics
 func CopyMetricDataSlice(args []*MetricData) (newData []*MetricData) {

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -441,6 +441,24 @@ func (r *MetricData) AppendStopTime(step int64) *MetricData {
 	return r
 }
 
+// FixStopTime fix broken StopTime (less than need for values)
+func (r *MetricData) FixStopTime() *MetricData {
+	stop := r.StartTime + int64(len(r.Values))*r.StepTime
+	if r.StopTime < stop {
+		r.StopTime = stop
+	}
+	return r
+}
+
+// RecalcStopTime recalc StopTime with StartTime and Values length
+func (r *MetricData) RecalcStopTime() *MetricData {
+	stop := r.StartTime + int64(len(r.Values))*r.StepTime
+	if r.StopTime != stop {
+		r.StopTime = stop
+	}
+	return r
+}
+
 // CopyMetricDataSlice returns the slice of metrics that should be changed later.
 // It allows to avoid a changing of source data, e.g. by AlignMetrics
 func CopyMetricDataSlice(args []*MetricData) (newData []*MetricData) {

--- a/tests/compare/compare.go
+++ b/tests/compare/compare.go
@@ -1,0 +1,201 @@
+package compare
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/types"
+)
+
+func compareFloat64(v1, v2 float64) bool {
+	if math.IsNaN(v1) && math.IsNaN(v2) {
+		return true
+	}
+	if math.IsInf(v1, 1) && math.IsInf(v2, 1) {
+		return true
+	}
+
+	if math.IsInf(v1, 0) && math.IsInf(v2, 0) {
+		return true
+	}
+
+	d := math.Abs(v1 - v2)
+	return d < eps
+}
+
+func deepCompareFields(v1, v2 reflect.Value) bool {
+	if !v1.CanInterface() {
+		return true
+	}
+	t1 := v1.Type()
+	if t1.Comparable() {
+		if t1.Name() == "float64" {
+			return compareFloat64(v1.Interface().(float64), v2.Interface().(float64))
+		}
+		if t1.Name() == "float32" {
+			v1f64 := float64(v1.Interface().(float32))
+			v2f64 := float64(v2.Interface().(float32))
+			return compareFloat64(v1f64, v2f64)
+		}
+		return reflect.DeepEqual(v1.Interface(), v2.Interface())
+	} else {
+		switch v1.Kind() {
+		case reflect.Struct:
+			if v1.NumField() == 0 {
+				// We don't know how to compare that
+				return false
+			}
+			for i := 0; i < v1.NumField(); i++ {
+				r := deepCompareFields(v1.Field(i), v2.Field(i))
+				if !r {
+					return r
+				}
+			}
+		case reflect.Slice, reflect.Array:
+			if v1.Len() != v2.Len() {
+				return false
+			}
+			if v1.Len() == 0 {
+				return true
+			}
+			if v1.Index(0).Kind() != v2.Index(0).Kind() {
+				return false
+			}
+			for i := 0; i < v1.Len(); i++ {
+				e1 := v1.Index(i)
+				e2 := v2.Index(i)
+				if !deepCompareFields(e1, e2) {
+					return false
+				}
+			}
+		case reflect.Map:
+			if v1.Len() != v2.Len() {
+				return false
+			}
+			if v1.Len() == 0 {
+				return true
+			}
+
+			keys1 := v1.MapKeys()
+			for _, k := range keys1 {
+				val1 := v1.MapIndex(k)
+				val2 := v2.MapIndex(k)
+				if !deepCompareFields(val1, val2) {
+					return false
+				}
+			}
+			return true
+		case reflect.Func:
+			return v1.Pointer() == v2.Pointer()
+		default:
+			fmt.Printf("unsupported v1.Kind=%v t1.Name=%v, t1.Value=%v\n\n", v1.Kind(), v1.Type().Name(), v1.String())
+			return false
+		}
+	}
+	return true
+}
+
+func MetricDataIsEqual(d1, d2 *types.MetricData, compareTags bool) bool {
+	v1 := reflect.ValueOf(*d1)
+	v2 := reflect.ValueOf(*d2)
+
+	for i := 0; i < v1.NumField(); i++ {
+		if v1.Type().Field(i).Name == "Tags" && !compareTags {
+			continue
+		}
+		r := deepCompareFields(v1.Field(i), v2.Field(i))
+		if !r {
+			return r
+		}
+	}
+	return true
+}
+
+const eps = 0.0000000001
+
+func NearlyEqual(a, b []float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i, v := range a {
+		// "same"
+		if math.IsNaN(a[i]) && math.IsNaN(b[i]) {
+			continue
+		}
+		if math.IsNaN(a[i]) || math.IsNaN(b[i]) {
+			// unexpected NaN
+			return false
+		}
+		// "close enough"
+		if math.Abs(v-b[i]) > eps {
+			return false
+		}
+	}
+
+	return true
+}
+
+func NearlyEqualMetrics(a, b *types.MetricData) bool {
+	if len(a.Values) != len(b.Values) {
+		return false
+	}
+	for i := range a.Values {
+		if (math.IsNaN(a.Values[i]) && !math.IsNaN(b.Values[i])) || (!math.IsNaN(a.Values[i]) && math.IsNaN(b.Values[i])) {
+			return false
+		}
+		// "close enough"
+		if math.Abs(a.Values[i]-b.Values[i]) > eps {
+			return false
+		}
+	}
+
+	return true
+}
+
+func MaxInt(a, b int) int {
+	if a >= b {
+		return a
+	} else {
+		return b
+	}
+}
+
+func TestMetricData(t *testing.T, got, want []*types.MetricData) {
+	for i := 0; i < MaxInt(len(want), len(got)); i++ {
+		if i >= len(got) {
+			t.Errorf("\n-[%d] = %v", i, want[i])
+		} else if i >= len(want) {
+			t.Errorf("\n+[%d] = %v", i, got[i])
+		} else {
+			actual := got[i]
+			if _, ok := actual.Tags["name"]; !ok {
+				t.Errorf("metric %+v with name %v doesn't contain 'name' tag", actual, actual.Name)
+			}
+			if actual == nil {
+				t.Errorf("returned no value")
+				return
+			}
+			if actual.StepTime == 0 {
+				t.Errorf("missing Step for %+v", actual)
+			}
+			if actual.Name != want[i].Name {
+				t.Errorf("bad Name metric[%d]: got %s, want %s", i, actual.Name, want[i].Name)
+			}
+			if !NearlyEqualMetrics(actual, want[i]) {
+				t.Errorf("different values metric[%d] %s: got %v, want %v", i, actual.Name, actual.Values, want[i].Values)
+			}
+			if actual.StepTime != want[i].StepTime {
+				t.Errorf("different StepTime metric[%d] %s: got %v, want %v", i, actual.Name, actual.StepTime, want[i].StepTime)
+			}
+			if actual.StartTime != want[i].StartTime {
+				t.Errorf("different StartTime metric[%d] %s: got %v, want %v", i, actual.Name, actual.StartTime, want[i].StartTime)
+			}
+			if actual.StopTime != want[i].StopTime {
+				t.Errorf("different StopTime metric[%d] %s: got %v, want %v", i, actual.Name, actual.StopTime, want[i].StopTime)
+			}
+		}
+	}
+}

--- a/tests/compare/compare.go
+++ b/tests/compare/compare.go
@@ -163,6 +163,19 @@ func MaxInt(a, b int) int {
 	}
 }
 
+func GenerateMetrics(n int, startValue, endValue, stepValue float64) []float64 {
+	values := make([]float64, n)
+	v := startValue
+	for i := 0; i < n; i++ {
+		values[i] = v
+		v += stepValue
+		if v > endValue {
+			v = startValue
+		}
+	}
+	return values
+}
+
 func TestMetricData(t *testing.T, got, want []*types.MetricData) {
 	for i := 0; i < MaxInt(len(want), len(got)); i++ {
 		if i >= len(got) {

--- a/zipper/protocols/prometheus/helpers/helpers_test.go
+++ b/zipper/protocols/prometheus/helpers/helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	th "github.com/go-graphite/carbonapi/tests"
+	"github.com/go-graphite/carbonapi/tests/compare"
 	"github.com/go-graphite/carbonapi/zipper/protocols/prometheus/types"
 )
 
@@ -77,7 +77,7 @@ func TestAlignValues(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := AlignValues(tt.args.startTime, tt.args.stopTime, tt.args.step, tt.args.promValues); !th.NearlyEqual(got, tt.want) {
+			if got := AlignValues(tt.args.startTime, tt.args.stopTime, tt.args.step, tt.args.promValues); !compare.NearlyEqual(got, tt.want) {
 				t.Errorf("AlignValues() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
On some metric series, AlignSeries/ScaleToCommonStep produce series with non-equal values length.
So helper helper.AggregateSeries will be panic.
For simplify, add ScaleSeries for use in helper.AggregateSeries (when scale to common step is needed).
