### PR TITLE
Fix extract name for non ascii

### DIFF
--- a/expr/functions/alias/function_test.go
+++ b/expr/functions/alias/function_test.go
@@ -70,6 +70,31 @@ func TestAlias(t *testing.T) {
 				),
 			},
 		},
+		{
+			"alias(metric2, 'Метрика 2')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{
+					Metric: "metric2",
+					From:   0,
+					Until:  1,
+				}: {
+					types.MakeMetricData(
+						"metric2",
+						[]float64{1, 2, 3, 4, 5},
+						1,
+						now32,
+					),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData(
+					"Метрика 2",
+					[]float64{1, 2, 3, 4, 5},
+					1,
+					now32,
+				),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/types/extract.go
+++ b/expr/types/extract.go
@@ -1,12 +1,5 @@
 package types
 
-import (
-	"unicode"
-	"unicode/utf8"
-
-	"github.com/go-graphite/carbonapi/pkg/parser"
-)
-
 var allowedCharactersInMetricName = map[byte]struct{}{
 	'=': struct{}{},
 	'@': struct{}{},
@@ -24,21 +17,14 @@ func ExtractNameLoc(s string) (int, int) {
 
 	var (
 		start, braces, i, w int
-		r                   rune
 	)
 
 FOR:
 	for braces, i, w = 0, 0, 0; i < len(s); i += w {
 
 		w = 1
-		if parser.IsNameChar(s[i]) || byteAllowedInName(s[i]) {
-			continue
-		}
 
 		switch s[i] {
-		// If metric name have tags, we want to skip them
-		case ';':
-			break FOR
 		case '{':
 			braces++
 		case '}':
@@ -50,14 +36,10 @@ FOR:
 			if braces == 0 {
 				break FOR
 			}
+		case '(':
+			start = i + 1
 		case ')':
 			break FOR
-		default:
-			r, w = utf8.DecodeRuneInString(s[i:])
-			if unicode.In(r, parser.RangeTables...) {
-				continue
-			}
-			start = i + 1
 		}
 	}
 

--- a/expr/types/extract_test.go
+++ b/expr/types/extract_test.go
@@ -71,6 +71,11 @@ func TestExtractName(t *testing.T) {
 			"aliasByTags(alias(0.1.2.@.4, 2), 1)",
 			"0.1.2.@.4",
 		},
+		// non-ASCII symbols
+		{
+			"alias(Количество изменений)",
+			"Количество изменений",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix extract name with non-ascii symbols.
Also simplify name parser (no really need to detect unicode symbols, only special symbols are checked).