### PR TITLE
Fix extract tags from seriesByTag

### DIFF
--- a/cmd/carbonapi/carbonapi.example.clickhouse.yaml
+++ b/cmd/carbonapi/carbonapi.example.clickhouse.yaml
@@ -32,6 +32,9 @@ cpus: 0
 # Timezone, default - local
 tz: ""
 
+# By default, functions like aggregate inherit tags from first series (for compatibility with graphite-web)
+# If set to true, tags are extracted from seriesByTag arguments
+#extractTagsFromArgs: false
 functionsConfig:
     graphiteWeb: ./graphiteWeb.example.yaml
 maxBatchSize: 0

--- a/cmd/carbonapi/carbonapi.example.prometheus.yaml
+++ b/cmd/carbonapi/carbonapi.example.prometheus.yaml
@@ -13,6 +13,7 @@ headersToPass:
   - "X-Dashboard-Id"
   - "X-Grafana-Org-Id"
   - "X-Panel-Id"
+#extractTagsFromArgs: false  
 functionsConfig:
     graphiteWeb: ./graphiteWeb.example.yaml
 maxBatchSize: 0

--- a/cmd/carbonapi/carbonapi.example.toml
+++ b/cmd/carbonapi/carbonapi.example.toml
@@ -10,6 +10,7 @@ listen = "localhost:8081"
 pidFile = ""
 tz = ""
 graphTemplates = "graphTemplates.example.toml"
+#extractTagsFromArgs = false
 
 [cache]
 defaultTimeoutSec = 60

--- a/cmd/carbonapi/carbonapi.example.victoriametrics.yaml
+++ b/cmd/carbonapi/carbonapi.example.victoriametrics.yaml
@@ -13,6 +13,7 @@ headersToPass:
   - "X-Dashboard-Id"
   - "X-Grafana-Org-Id"
   - "X-Panel-Id"
+#extractTagsFromArgs: false
 functionsConfig:
     graphiteWeb: ./graphiteWeb.example.yaml
 maxBatchSize: 0

--- a/cmd/carbonapi/carbonapi.example.yaml
+++ b/cmd/carbonapi/carbonapi.example.yaml
@@ -74,6 +74,9 @@ cpus: 0
 # Timezone, default - local
 tz: ""
 
+# By default, functions like aggregate inherit tags from first series (for compatibility with graphite-web)
+# If set to true, tags are extracted from seriesByTag arguments
+#extractTagsFromArgs: false
 functionsConfig:
     graphiteWeb: ./graphiteWeb.example.yaml
     timeShift: ./timeShift.example.yaml

--- a/cmd/carbonapi/config/config.go
+++ b/cmd/carbonapi/config/config.go
@@ -75,6 +75,7 @@ type ConfigType struct {
 	PidFile                    string             `mapstructure:"pidFile"`
 	SendGlobsAsIs              *bool              `mapstructure:"sendGlobsAsIs"`
 	AlwaysSendGlobsAsIs        *bool              `mapstructure:"alwaysSendGlobsAsIs"`
+	ExtractTagsFromArgs        bool               `mapstructure:"extractTagsFromArgs"`
 	MaxBatchSize               int                `mapstructure:"maxBatchSize"`
 	Zipper                     string             `mapstructure:"zipper"`
 	Upstreams                  zipperCfg.Config   `mapstructure:"upstreams"`

--- a/cmd/carbonapi/config/init.go
+++ b/cmd/carbonapi/config/init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-graphite/carbonapi/cache"
 	"github.com/go-graphite/carbonapi/expr/functions"
 	"github.com/go-graphite/carbonapi/expr/functions/cairo/png"
+	fconfig "github.com/go-graphite/carbonapi/expr/functions/config"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/rewrite"
 	"github.com/go-graphite/carbonapi/limiter"
@@ -362,7 +363,8 @@ func SetUpViper(logger *zap.Logger, configPath *string, viperPrefix string) {
 	viper.SetDefault("cpus", 0)
 	viper.SetDefault("tz", "")
 	viper.SetDefault("sendGlobsAsIs", nil)
-	viper.SetDefault("AlwaysSendGlobsAsIs", nil)
+	viper.SetDefault("alwaysSendGlobsAsIs", nil)
+	viper.SetDefault("extractTagsFromArgs", false)
 	viper.SetDefault("maxBatchSize", 100)
 	viper.SetDefault("graphite.host", "")
 	viper.SetDefault("graphite.interval", "60s")
@@ -394,6 +396,8 @@ func SetUpViper(logger *zap.Logger, configPath *string, viperPrefix string) {
 			zap.Error(err),
 		)
 	}
+
+	fconfig.Config.ExtractTagsFromArgs = Config.ExtractTagsFromArgs
 }
 
 func SetUpConfigUpstreams(logger *zap.Logger) {

--- a/cmd/carbonapi/config/init.go
+++ b/cmd/carbonapi/config/init.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"expvar"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"sort"
 	"strconv"
@@ -93,7 +93,7 @@ func SetUpConfig(logger *zap.Logger, BuildVersion string) {
 	if Config.GraphTemplates != "" {
 		graphTemplates = make(map[string]png.PictureParams)
 		graphTemplatesViper := viper.New()
-		b, err := ioutil.ReadFile(Config.GraphTemplates)
+		b, err := os.ReadFile(Config.GraphTemplates)
 		if err != nil {
 			logger.Fatal("error reading graphTemplates file",
 				zap.String("graphTemplate_path", Config.GraphTemplates),
@@ -321,7 +321,7 @@ func createCache(logger *zap.Logger, cacheName string, cacheConfig *CacheConfig)
 
 func SetUpViper(logger *zap.Logger, configPath *string, viperPrefix string) {
 	if *configPath != "" {
-		b, err := ioutil.ReadFile(*configPath)
+		b, err := os.ReadFile(*configPath)
 		if err != nil {
 			logger.Fatal("error reading config file",
 				zap.String("config_path", *configPath),

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -24,36 +24,38 @@ Table of Contents
     * [Example](#example-8)
   * [tz](#tz)
     * [Example](#example-9)
-  * [functionsConfig](#functionsconfig)
+  * [extractTagsFromArgs](#extractTagsFromArgs)
     * [Example](#example-10)
+  * [functionsConfig](#functionsconfig)
+    * [Example](#example-11)
     * [Example for timeShift](#example-for-timeshift)
   * [graphite](#graphite)
-    * [Example](#example-11)
-  * [pidFile](#pidfile)
     * [Example](#example-12)
-  * [graphTemplates](#graphtemplates)
+  * [pidFile](#pidfile)
     * [Example](#example-13)
-  * [defaultColors](#defaultcolors)
+  * [graphTemplates](#graphtemplates)
     * [Example](#example-14)
-  * [expvar](#expvar)
+  * [defaultColors](#defaultcolors)
     * [Example](#example-15)
-  * [logger](#logger)
+  * [expvar](#expvar)
     * [Example](#example-16)
+  * [logger](#logger)
+    * [Example](#example-17)
 * [Carbonzipper configuration](#carbonzipper-configuration)
   * [concurency](#concurency)
-    * [Example](#example-17)
-  * [maxBatchSize](#maxbatchsize)
     * [Example](#example-18)
+  * [maxBatchSize](#maxbatchsize)
+    * [Example](#example-19)
   * [idleConnections](#idleconnections)
   * [upstreams](#upstreams)
-    * [Example](#example-19)
+    * [Example](#example-20)
       * [For go\-carbon and prometheus](#for-go-carbon-and-prometheus)
       * [For VictoriaMetrics](#for-victoriametrics)
       * [For graphite\-clickhouse](#for-graphite-clickhouse)
       * [For metrictank](#for-metrictank)
       * [For IRONdb](#for-irondb)
   * [expireDelaySec](#expiredelaysec)
-    * [Example](#example-20)
+    * [Example](#example-21)
 
 # General configuration for carbonapi
 
@@ -325,6 +327,18 @@ tz: "Europe/Zurich,7200"
 ```
 
 ***
+## extractTagsFromArgs
+
+By default, functions like aggregate inherit tags from first series (for compatibility with graphite-web).
+
+If set extractTagsFromArgs to true, tags are extracted from seriesByTag arguments
+
+### Example
+
+```yaml
+extractTagsFromArgs: true
+```
+
 ## functionsConfig
 
 Extra config files for specific functions

--- a/expr/functions/aggregate/function.go
+++ b/expr/functions/aggregate/function.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-graphite/carbonapi/expr/consolidations"
+	fconfig "github.com/go-graphite/carbonapi/expr/functions/config"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
@@ -78,7 +79,7 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	if isAggregateFunc {
 		e.SetRawArgs(e.Arg(0).Target())
 	}
-	return helper.AggregateSeries(e, args, aggFunc)
+	return helper.AggregateSeries(e, args, aggFunc, fconfig.Config.ExtractTagsFromArgs)
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	fconfig "github.com/go-graphite/carbonapi/expr/functions/config"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/metadata"
 	"github.com/go-graphite/carbonapi/expr/types"
@@ -25,6 +26,8 @@ func init() {
 }
 
 func TestAverageSeries(t *testing.T) {
+	fconfig.Config.ExtractTagsFromArgs = false
+
 	now32 := int64(time.Now().Unix())
 
 	tests := []th.EvalTestItem{
@@ -268,6 +271,103 @@ func TestAverageSeries(t *testing.T) {
 			},
 			[]*types.MetricData{types.MakeMetricData("averageSeries(metric1,metric2,metric3)",
 				[]float64{2, math.NaN(), 3, 4, 5, 5.5}, 1, now32)},
+		},
+
+		// sumSeies with tags, tags from first metric
+		{
+			"sum(seriesByTag('tag2=value*', 'name=metric'))",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+					types.MakeMetricData("metric;tag1=value1;tag2=value21", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2=value*', 'name=metric'))",
+				// []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32).SetTags(map[string]string{"name": "metric", "tag2": "value____"})},
+				[]float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32).SetTags(map[string]string{"name": "metric", "tag1": "value1", "tag2": "value21"})},
+		},
+		{
+			"sum(seriesByTag('tag2!=value2*', 'name=metric.name'))",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('tag2!=value2*', 'name=metric.name')", 0, 1}: {
+					types.MakeMetricData("metric.name;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric.name;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+				{"metric.name", 0, 1}: {types.MakeMetricData("metric.name", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2!=value2*', 'name=metric.name'))",
+				// []float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "metric.name"})},
+				[]float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "metric.name", "tag2": "value22", "tag3": "value3"})},
+		},
+		{
+			"sum(seriesByTag('tag2=value21'))",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('tag2=value21')", 0, 1}: {
+					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2=value21'))",
+				// []float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "sumSeries", "tag2": "value21"})},
+				[]float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "metric", "tag2": "value22", "tag3": "value3"})},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}
+
+func TestAverageSeriesExtractSeriesByTag(t *testing.T) {
+	fconfig.Config.ExtractTagsFromArgs = true
+
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		// sumSeies with tags, tags from first metric
+		{
+			"sum(seriesByTag('tag2=value*', 'name=metric'))",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+					types.MakeMetricData("metric;tag1=value1;tag2=value21", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2=value*', 'name=metric'))",
+				[]float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32).SetTags(map[string]string{"name": "metric", "tag2": "value*"})},
+		},
+		{
+			"sum(seriesByTag('tag2!=value2*', 'name=metric.name'))",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('tag2!=value2*', 'name=metric.name')", 0, 1}: {
+					types.MakeMetricData("metric.name;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric.name;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+				{"metric.name", 0, 1}: {types.MakeMetricData("metric.name", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2!=value2*', 'name=metric.name'))",
+				[]float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "metric.name"})},
+		},
+		{
+			"sum(seriesByTag('tag2=value21'))",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('tag2=value21')", 0, 1}: {
+					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2=value21'))",
+				[]float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "sumSeries", "tag2": "value21"})},
 		},
 	}
 

--- a/expr/functions/aggregateLine/function.go
+++ b/expr/functions/aggregateLine/function.go
@@ -73,7 +73,7 @@ func (f *aggregateLine) Do(ctx context.Context, e parser.Expr, from, until int64
 			name = "aggregateLine(" + a.Name + ", None)"
 		}
 
-		r := a.CopyName(name)
+		r := a.CopyTag(name, a.Tags)
 
 		if keepStep {
 			r.Values = make([]float64, len(a.Values))

--- a/expr/functions/aliasByNode/function_test.go
+++ b/expr/functions/aliasByNode/function_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	th "github.com/go-graphite/carbonapi/tests"
 
+	"github.com/go-graphite/carbonapi/expr/functions/aggregate"
 	"github.com/go-graphite/carbonapi/expr/functions/aliasSub"
 	"github.com/go-graphite/carbonapi/expr/functions/perSecond"
 	"github.com/go-graphite/carbonapi/expr/functions/transformNull"
@@ -32,6 +33,10 @@ func init() {
 	}
 	psFunc := perSecond.New("")
 	for _, m := range psFunc {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+	aggFunc := aggregate.New("")
+	for _, m := range aggFunc {
 		metadata.RegisterFunction(m.Name, m.F)
 	}
 
@@ -134,6 +139,33 @@ func TestAliasByNode(t *testing.T) {
 			},
 			Want: []*types.MetricData{types.MakeMetricData("bam==.bar=.metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
+		// extract nodes with sumSeries
+		{
+			Target: `aliasByNode(sumSeries(metric.{a,b}*.b), 1, 2)`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric.{a,b}*.b", 0, 1}: {
+					types.MakeMetricData("metric.a1.b", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric.b2.b", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric.c2.b", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("{a,b}*.b", []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
+		},
+		// extract tags from seriesByTag
+		{
+			Target: `aliasByTags(sumSeries(seriesByTag('tag2=value*', 'name=metric')), 'tag2', 'name')`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+					types.MakeMetricData("metric;tag1=value1;tag2=value21", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+			},
+			// Want: []*types.MetricData{types.MakeMetricData("value____.metric", []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
+			Want: []*types.MetricData{types.MakeMetricData("value21.metric", []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
+		},
+		// TODO msaf1980: tests with extractTagsFromArgs = true
 	}
 
 	for _, tt := range tests {

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -141,6 +141,24 @@ func TestAsPersent(t *testing.T) {
 				types.MakeMetricData("asPercent(Server3.memory.used,MISSING)", []float64{NaN, NaN, NaN}, 1, now32),
 			},
 		},
+		// tagged series
+		{
+			"asPercent(seriesByTag('name=metric', 'tag=A*'),metricB*)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('name=metric', 'tag=A*')", 0, 1}: {
+					types.MakeMetricData("metric;tag=A1", []float64{1, 20, 10}, 1, now32),
+					types.MakeMetricData("metric;tag=A2", []float64{1, 10, 20}, 1, now32),
+				},
+				{"metricB*", 0, 1}: {
+					types.MakeMetricData("metricB1", []float64{4, 4, 8}, 1, now32),
+					types.MakeMetricData("metricB2", []float64{4, 16, 2}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("asPercent(metric;tag=A1,metricB1)", []float64{25, 500, 125}, 1, now32),
+				types.MakeMetricData("asPercent(metric;tag=A2,metricB2)", []float64{25, 62.5, 1000}, 1, now32),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/functions/baselines/function.go
+++ b/expr/functions/baselines/function.go
@@ -70,11 +70,11 @@ func (f *baselines) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		offs := int64(i * unit)
 		arg, _ := helper.GetSeriesArg(ctx, e.Arg(0), from+offs, until+offs, values)
 		for _, a := range arg {
-			r := *a
+			r := a.CopyLinkTags()
 			if _, ok := current[r.Name]; ok || !isAberration {
 				r.StartTime = a.StartTime - offs
 				r.StopTime = a.StopTime - offs
-				groups[r.Name] = append(groups[r.Name], &r)
+				groups[r.Name] = append(groups[r.Name], r)
 			}
 		}
 	}

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -709,10 +709,10 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 		results := make([]*types.MetricData, len(arg))
 
 		for i, a := range arg {
-			r := *a
+			r := a.CopyLinkTags()
 			r.Stacked = true
 			r.StackName = stackName
-			results[i] = &r
+			results[i] = r
 		}
 
 		return results, nil
@@ -729,16 +729,14 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 
 		name := e.Target() + "(" + e.RawArgs() + ")"
 
-		lower := *arg[0]
+		lower := arg[0].CopyTag(name, arg[0].Tags)
 		lower.Stacked = true
 		lower.StackName = types.DefaultStackName
 		lower.Invisible = true
-		lower.Name = name
 
-		upper := *arg[1]
+		upper := arg[1].CopyTag(name, arg[1].Tags)
 		upper.Stacked = true
 		upper.StackName = types.DefaultStackName
-		upper.Name = name
 
 		vals := make([]float64, len(upper.Values))
 
@@ -748,7 +746,7 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 
 		upper.Values = vals
 
-		return []*types.MetricData{&lower, &upper}, nil
+		return []*types.MetricData{lower, upper}, nil
 
 	case "alpha": // alpha(seriesList, theAlpha)
 		arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)

--- a/expr/functions/config/config.go
+++ b/expr/functions/config/config.go
@@ -1,0 +1,5 @@
+package config
+
+var Config = struct {
+	ExtractTagsFromArgs bool
+}{}

--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -76,12 +76,13 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 
 	results := make([]*types.MetricData, 0, len(numerators))
 	for _, numerator := range numerators {
-		r := *numerator
+		var name string
 		if useMetricNames {
-			r.Name = "divideSeries(" + numerator.Name + "," + denominator.Name + ")"
+			name = "divideSeries(" + numerator.Name + "," + denominator.Name + ")"
 		} else {
-			r.Name = "divideSeries(" + e.RawArgs() + ")"
+			name = "divideSeries(" + e.RawArgs() + ")"
 		}
+		r := numerator.CopyTag(name, numerator.Tags)
 		r.Values = make([]float64, len(numerator.Values))
 
 		for i, v := range numerator.Values {
@@ -93,7 +94,7 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 				r.Values[i] = v / denominator.Values[i]
 			}
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 
 	return results, nil

--- a/expr/functions/ewma/function.go
+++ b/expr/functions/ewma/function.go
@@ -49,7 +49,7 @@ func (f *ewma) Do(ctx context.Context, e parser.Expr, from, until int64, values 
 	for i, a := range arg {
 		name := "ewma(" + a.Name + "," + alphaStr + ")"
 
-		r := a.CopyName(name)
+		r := a.CopyTag(name, a.Tags)
 		r.Values = make([]float64, len(a.Values))
 
 		ewma := onlinestats.NewExpWeight(alpha)

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -122,8 +122,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 	result := make([]*types.MetricData, len(arg))
 
 	for n, a := range arg {
-		r := a.CopyLinkTags()
-		r.Name = e.Target() + "(" + a.Name + "," + argstr + ")"
+		r := a.CopyTag(e.Target()+"("+a.Name+","+argstr+")", a.Tags)
 
 		if windowSize == 0 {
 			if *f.config.ReturnNaNsIfStepMismatch {

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -117,8 +117,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 	result := make([]*types.MetricData, len(arg))
 
 	for n, a := range arg {
-		r := *a
-		r.Name = "movingMedian(" + a.Name + "," + argstr + ")"
+		r := a.CopyTag("movingMedian("+a.Name+","+argstr+")", a.Tags)
 
 		if windowSize == 0 {
 			if *f.config.ReturnNaNsIfStepMismatch {
@@ -145,7 +144,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 				}
 			}
 		}
-		result[n] = &r
+		result[n] = r
 	}
 	return result, nil
 }

--- a/expr/functions/percentileOfSeries/function.go
+++ b/expr/functions/percentileOfSeries/function.go
@@ -4,14 +4,21 @@ import (
 	"context"
 
 	"github.com/go-graphite/carbonapi/expr/consolidations"
+	fconfig "github.com/go-graphite/carbonapi/expr/functions/config"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 )
 
+type Config struct {
+	ExtractTagsFromArgs bool
+}
+
 type percentileOfSeries struct {
 	interfaces.FunctionBase
+
+	extractTagsFromArgs bool
 }
 
 func GetOrder() interfaces.Order {
@@ -48,7 +55,12 @@ func (f *percentileOfSeries) Do(ctx context.Context, e parser.Expr, from, until 
 
 	return helper.AggregateSeries(e, args, func(values []float64) float64 {
 		return consolidations.Percentile(values, percent, interpolate)
-	})
+	}, fconfig.Config.ExtractTagsFromArgs)
+}
+
+// SetExtractTagsFromArgs for use in tests
+func (f *percentileOfSeries) SetExtractTagsFromArgs(e bool) {
+	f.extractTagsFromArgs = e
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/percentileOfSeries/function_test.go
+++ b/expr/functions/percentileOfSeries/function_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	fconfig "github.com/go-graphite/carbonapi/expr/functions/config"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/metadata"
 	"github.com/go-graphite/carbonapi/expr/types"
@@ -22,7 +23,9 @@ func init() {
 	}
 }
 
-func TestPercentileOfSeriesSeries(t *testing.T) {
+func TestPercentileOfSeries(t *testing.T) {
+	fconfig.Config.ExtractTagsFromArgs = false
+
 	now32 := int64(time.Now().Unix())
 
 	tests := []th.EvalTestItem{
@@ -69,6 +72,52 @@ func TestPercentileOfSeriesSeries(t *testing.T) {
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("percentileOfSeries(metric1.foo.*.*,95,false)", []float64{0, 0, 0, 100500, 100501, 1005002}, 1, now32)},
+		},
+		// seriesByTag
+		{
+			`percentileOfSeries(seriesByTag('tag2=value*', 'name=metric'),95,false)`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+					types.MakeMetricData("metric;tag1=value1;tag2=value21;tag3=value3", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+					types.MakeMetricData("metric;tag2=value22", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32),
+					types.MakeMetricData("metric;tag1=value1;tag2=value23", []float64{0, 0, 0, 100500, 100501, 1005002}, 1, now32),
+					types.MakeMetricData("metric;tag1=value1;tag2=value24", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32),
+					types.MakeMetricData("metric;tag1=value1;tag2=value25", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData(`percentileOfSeries(seriesByTag('tag2=value*', 'name=metric'),95,false)`, []float64{0, 0, 0, 100500, 100501, 1005002}, 1, now32).
+				SetTags(map[string]string{"name": "metric", "tag1": "value1", "tag2": "value21", "tag3": "value3"})},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}
+
+func TestPercentileOfSeriesExtractSeriesByTag(t *testing.T) {
+	fconfig.Config.ExtractTagsFromArgs = true
+
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			`percentileOfSeries(seriesByTag('tag2=value*', 'name=metric'),95,false)`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+					types.MakeMetricData("metric;tag1=value1;tag2=value21;tag3=value3", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+					types.MakeMetricData("metric;tag2=value22", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32),
+					types.MakeMetricData("metric;tag1=value1;tag2=value23", []float64{0, 0, 0, 100500, 100501, 1005002}, 1, now32),
+					types.MakeMetricData("metric;tag1=value1;tag2=value24", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32),
+					types.MakeMetricData("metric;tag1=value1;tag2=value25", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData(`percentileOfSeries(seriesByTag('tag2=value*', 'name=metric'),95,false)`, []float64{0, 0, 0, 100500, 100501, 1005002}, 1, now32).
+				SetTags(map[string]string{"name": "metric", "tag2": "value*"})},
 		},
 	}
 

--- a/expr/functions/transformNull/function.go
+++ b/expr/functions/transformNull/function.go
@@ -91,8 +91,7 @@ func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64
 			name = "transformNull(" + a.Name + ")"
 		}
 
-		r := *a
-		r.Name = name
+		r := a.CopyTag(name, a.Tags)
 		r.Values = make([]float64, len(a.Values))
 
 		for i, v := range a.Values {
@@ -107,7 +106,7 @@ func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64
 			r.Values[i] = v
 		}
 
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	if len(arg) == 0 && defaultOnAbsent {
 		values := []float64{defv, defv}

--- a/expr/functions/weightedAverage/function.go
+++ b/expr/functions/weightedAverage/function.go
@@ -89,7 +89,7 @@ func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int
 		if _, ok := pair["weight"]; !ok {
 			continue
 		}
-		product, err := helper.AggregateSeries(e, []*types.MetricData{pair["avg"], pair["weight"]}, consolidations.ConsolidationToFunc["multiply"])
+		product, err := helper.AggregateSeries(e, []*types.MetricData{pair["avg"], pair["weight"]}, consolidations.ConsolidationToFunc["multiply"], false)
 		if err != nil {
 			return nil, err
 		}
@@ -99,15 +99,15 @@ func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int
 		return []*types.MetricData{}, nil
 	}
 
-	sumProducts, err := helper.AggregateSeries(e, productList, consolidations.AggSum)
+	sumProducts, err := helper.AggregateSeries(e, productList, consolidations.AggSum, false)
 	if err != nil {
 		return nil, err
 	}
-	sumWeights, err := helper.AggregateSeries(e, weights, consolidations.AggSum)
+	sumWeights, err := helper.AggregateSeries(e, weights, consolidations.AggSum, false)
 	if err != nil {
 		return nil, err
 	}
-	weightedAverageSeries, err := helper.AggregateSeries(e, append(sumProducts, sumWeights...), func(v []float64) float64 { return v[0] / v[1] })
+	weightedAverageSeries, err := helper.AggregateSeries(e, append(sumProducts, sumWeights...), func(v []float64) float64 { return v[0] / v[1] }, false)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -161,8 +161,7 @@ func ForEachSeriesDo(ctx context.Context, e parser.Expr, from, until int64, valu
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := a.CopyLinkTags()
-		r.Name = e.Target() + "(" + a.Name + ")"
+		r := a.CopyTag(e.Target()+"("+a.Name+")", a.Tags)
 		r.Values = make([]float64, len(a.Values))
 		results = append(results, function(a, r))
 	}
@@ -173,7 +172,7 @@ func ForEachSeriesDo(ctx context.Context, e parser.Expr, from, until int64, valu
 type AggregateFunc func([]float64) float64
 
 // AggregateSeries aggregates series
-func AggregateSeries(e parser.Expr, args []*types.MetricData, function AggregateFunc) ([]*types.MetricData, error) {
+func AggregateSeries(e parser.Expr, args []*types.MetricData, function AggregateFunc, extractTagsFromArgs bool) ([]*types.MetricData, error) {
 	if len(args) == 0 {
 		return args, nil
 	}
@@ -181,7 +180,7 @@ func AggregateSeries(e parser.Expr, args []*types.MetricData, function Aggregate
 	args = ScaleSeries(args)
 
 	length := len(args[0].Values)
-	r := args[0].CopyName(e.Target() + "(" + e.RawArgs() + ")")
+	r := args[0].CopyNameArg(e.Target()+"("+e.RawArgs()+")", e.Target(), args[0].Tags, extractTagsFromArgs)
 	r.Values = make([]float64, length)
 
 	values := make([]float64, len(args))

--- a/expr/helper/helper_test.go
+++ b/expr/helper/helper_test.go
@@ -5,51 +5,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/go-graphite/carbonapi/expr/tags"
 	"github.com/go-graphite/carbonapi/expr/types"
 )
-
-func TestExtractTags(t *testing.T) {
-	tests := []struct {
-		name     string
-		metric   string
-		expected map[string]string
-	}{
-		{
-			name:   "tagged metric",
-			metric: "cpu.usage_idle;cpu=cpu-total;host=test",
-			expected: map[string]string{
-				"name": "cpu.usage_idle",
-				"cpu":  "cpu-total",
-				"host": "test",
-			},
-		},
-		{
-			name:   "no tags in metric",
-			metric: "cpu.usage_idle",
-			expected: map[string]string{
-				"name": "cpu.usage_idle",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual := tags.ExtractTags(tt.metric)
-			if len(actual) != len(tt.expected) {
-				t.Fatalf("amount of tags doesn't match: got %v, expected %v", actual, tt.expected)
-			}
-			for tag, value := range actual {
-				vExpected, ok := tt.expected[tag]
-				if !ok {
-					t.Fatalf("tag %v not found in %+v", value, actual)
-				} else if vExpected != value {
-					t.Errorf("unexpected tag-value, got %v, expected %v", value, vExpected)
-				}
-			}
-		})
-	}
-}
 
 func TestGCD(t *testing.T) {
 	tests := []struct {

--- a/expr/tags/helper.go
+++ b/expr/tags/helper.go
@@ -2,7 +2,153 @@ package tags
 
 import (
 	"strings"
+	"unicode/utf8"
 )
+
+type ParseStep int8
+
+const (
+	WantTag ParseStep = iota
+	WantCmp
+	WantDelim
+)
+
+// . (dot) is a special symbol in regexp, so if user use =~ instead of =, name with dots a transformed (and also can produce unwanted results)
+// use \. for consistent results
+// `.*` prepended to regexp without ^ at start
+// `.*` appended to regexp without $ at end
+func sanitizeRegex(s string) string {
+	var result strings.Builder
+	result.Grow(len(s) + 20)
+
+	if strings.HasPrefix(s, "^") {
+		s = s[1:]
+	} else {
+		result.WriteString("__*")
+	}
+	var closedRegex bool
+	if strings.HasSuffix(s, "$") {
+		s = s[0 : len(s)-1]
+		closedRegex = true
+	}
+	// cleanup regexp
+	s = strings.TrimRight(s, ".*")
+
+	var prev rune
+	for _, c := range s {
+		switch c {
+		case '.':
+			if prev != '\\' {
+				result.WriteString("__")
+			} else {
+				result.WriteRune(c)
+			}
+		default:
+			result.WriteRune(c)
+		}
+		prev = c
+	}
+
+	if !closedRegex {
+		result.WriteString("__*")
+	}
+	return result.String()
+}
+
+// parse seriesByTag args
+func ExtractSeriesByTags(s, defaultName string) map[string]string {
+	if s == "" || len(s) < 13 {
+		return nil
+	}
+	s = s[12:]
+
+	tags := make(map[string]string)
+
+	startTag := 0
+	startVal := 0
+	step := WantTag
+	var (
+		i, w  int
+		c     rune
+		delim rune
+	)
+LOOP:
+	for i < len(s) {
+		c, w = utf8.DecodeRuneInString(s[i:])
+		switch c {
+		case ',':
+			if step == WantDelim {
+				step = WantTag
+			}
+			i++
+		case ')':
+			if step == WantTag || step == WantDelim {
+				break LOOP
+			}
+			i++
+		case '\'', '"':
+			if step == WantTag {
+				// new segment found
+				step = WantCmp
+				delim = c
+				startTag = i + 1
+			} else {
+				step = WantDelim
+			}
+			i++
+		case '=', '!', '~':
+			var add bool
+			var isRegex bool
+			if step == WantCmp {
+				tag := s[startTag:i]
+				if tag == "__name__" {
+					tag = "name"
+				}
+				p := s[i:]
+				if strings.HasPrefix(p, "!=~") {
+					isRegex = true
+					i += 3
+				} else if strings.HasPrefix(p, "!=") {
+					i += 2
+				} else if strings.HasPrefix(p, "=~") {
+					isRegex = true
+					add = true
+					i += 2
+				} else if strings.HasPrefix(p, "=") {
+					add = true
+					i++
+				} else {
+					i += w
+					// broken comparator, skip
+					continue
+				}
+				startVal = i
+				end := strings.IndexRune(s[startVal:], delim)
+				if add && tag != "" && end > 0 {
+					var v string
+					if isRegex {
+						v = sanitizeRegex(s[startVal : startVal+end])
+					} else {
+						v = s[startVal : startVal+end]
+					}
+					tags[tag] = v
+				}
+				step = WantDelim
+				i = startVal + end + 1
+			} else {
+				i += w
+			}
+		default:
+			i += w
+		}
+	}
+
+	if _, exist := tags["name"]; !exist {
+		tags["name"] = defaultName
+	}
+
+	return tags
+}
 
 // ExtractTags extracts all graphite-style tags out of metric name
 // E.x. cpu.usage_idle;cpu=cpu-total;host=test => {"name": "cpu.usage_idle", "cpu": "cpu-total", "host": "test"}

--- a/expr/tags/helper_test.go
+++ b/expr/tags/helper_test.go
@@ -10,6 +10,163 @@ type extractTagTestCase struct {
 	Output   map[string]string
 }
 
+func TestSanitizeRegex(t *testing.T) {
+	tests := []struct {
+		Input  string
+		Output string
+	}{
+		{
+			Input:  "^value.*",
+			Output: "value__*",
+		},
+		{
+			Input:  "^value",
+			Output: "value__*",
+		},
+		{
+			Input:  "value$",
+			Output: "__*value",
+		},
+		{
+			Input:  "^value$",
+			Output: "value",
+		},
+		{
+			Input:  "value",
+			Output: "__*value__*",
+		},
+		{
+			Input:  "value.*a",
+			Output: "__*value__*a__*",
+		},
+		{
+			Input:  "^all__symbols__a-z____-___a_b____not_replaced$",
+			Output: "all__symbols__a-z____-___a_b____not_replaced",
+		},
+		{
+			Input:  `some_symbols_[a-z]+.?-.*{a,b}?_\.are_replaced(a|b)`,
+			Output: `__*some_symbols_[a-z]+__?-__*{a,b}?_\.are_replaced(a|b)__*`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Input, func(t *testing.T) {
+			out := sanitizeRegex(tt.Input)
+			if tt.Output != out {
+				t.Errorf("sanitizeRegex(%s) got '%s', want '%s'", tt.Input, out, tt.Output)
+			}
+		})
+	}
+}
+
+func BenchmarkSanitizeRegex(b *testing.B) {
+	benchmarks := []string{
+		"_all__symbols__a-z____-___a_b___not_replaced_",
+		"^some_symbols_[a-z]+.?-.*{a,b}?_are_replaced$",
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				s := sanitizeRegex(bm)
+				_ = s
+			}
+		})
+	}
+}
+
+func TestExtractSeriesByTags(t *testing.T) {
+	defaultName := "sumSeries"
+	tests := []extractTagTestCase{
+		// from aggregation functions with seriesByTag
+		{
+			TestName: `seriesByTag("tag2=value*", 'name=metric')`,
+			Input:    `seriesByTag("tag2=value*", 'name=metric')`,
+			Output:   map[string]string{"name": "metric", "tag2": "value*"},
+		},
+		{
+			TestName: `seriesByTag('tag2=~(12|23)', "name=metric")`,
+			Input:    `seriesByTag('tag2=~(12|23)', "name=metric")`,
+			Output:   map[string]string{"name": "metric", "tag2": "__*(12|23)__*"},
+		},
+		{
+			TestName: "seriesByTag('tag1=val1', 'tag2=val2', 'name=~(ab|dc|ef)', 'tag3=val3')",
+			Input:    "seriesByTag('tag1=val1', 'tag2=val2', 'name=~(ab|dc|ef)', 'tag3=val3')",
+			Output:   map[string]string{"name": "__*(ab|dc|ef)__*", "tag1": "val1", "tag2": "val2", "tag3": "val3"},
+		},
+		{
+			TestName: "seriesByTag('tag2=~^value.*', 'name=metric')",
+			Input:    "seriesByTag('tag2=~^value.*', 'name=metric')",
+			Output:   map[string]string{"name": "metric", "tag2": "value__*"},
+		},
+		{
+			TestName: "seriesByTag('tag2!=value21', 'name=metric.name')",
+			Input:    "seriesByTag('tag2!=value21', 'name=metric.name')",
+			Output:   map[string]string{"name": "metric.name"},
+		},
+		{
+			TestName: "seriesByTag('tag2=value21')",
+			Input:    "seriesByTag('tag2=value21')",
+			Output:   map[string]string{"name": defaultName, "tag2": "value21"},
+		},
+		// brokken, from aggregation functions with seriesByTag
+		{
+			TestName: "seriesByTag('tag2=', 'name=metric')",
+			Input:    "seriesByTag('tag2=', 'tag3', 'name=metric')",
+			Output:   map[string]string{"name": "metric"},
+		},
+		{
+			TestName: "Broken seriesByTag (missed ')",
+			Input:    "seriesByTag(name=metric)",
+			Output:   map[string]string{"name": defaultName},
+		},
+		{
+			TestName: "Broken seriesByTag (missed ' at the end)",
+			Input:    "seriesByTag('name=metric)",
+			Output:   map[string]string{"name": defaultName},
+		},
+		{
+			TestName: "Broken seriesByTag (missed ' at the end)",
+			Input:    "seriesByTag('name=metric",
+			Output:   map[string]string{"name": defaultName},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Input, func(t *testing.T) {
+			res := ExtractSeriesByTags(tt.Input, defaultName)
+
+			if len(res) != len(tt.Output) {
+				t.Fatalf("result length mismatch, got %v, expected %v, %+v != %+v", len(res), len(tt.Output), res, tt.Output)
+			}
+
+			for k, v := range res {
+				if expectedValue, ok := tt.Output[k]; ok {
+					if v != expectedValue {
+						t.Fatalf("value mismatch for key '%v': got '%v', exepcted '%v'", k, v, expectedValue)
+					}
+				} else {
+					t.Fatalf("got unexpected key %v=%v in result", k, v)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkTestExtractSeriesByTags(b *testing.B) {
+	defaultName := "sumSeries"
+	benchmarks := []string{
+		"seriesByTag('tag1=val1', 'tag2=val2', 'name=metric.name', 'project=~(ab|dc|ef|Test123|Test23|Test459)', 'tag3!=val3')",
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				s := ExtractSeriesByTags(bm, defaultName)
+				_ = s
+			}
+		})
+	}
+}
+
 func TestExtractTags(t *testing.T) {
 	tests := []extractTagTestCase{
 		{
@@ -20,6 +177,13 @@ func TestExtractTags(t *testing.T) {
 			},
 		},
 		{
+			TestName: "no tags in metric",
+			Input:    "cpu.usage_idle",
+			Output: map[string]string{
+				"name": "cpu.usage_idle",
+			},
+		},
+		{
 			TestName: "FewTags",
 			Input:    "metricWithSomeTags;tag1=v1;tag2=v2;tag3=this is value with string",
 			Output: map[string]string{
@@ -27,6 +191,15 @@ func TestExtractTags(t *testing.T) {
 				"tag1": "v1",
 				"tag2": "v2",
 				"tag3": "this is value with string",
+			},
+		},
+		{
+			TestName: "tagged metric",
+			Input:    "cpu.usage_idle;cpu=cpu-total;host=test",
+			Output: map[string]string{
+				"name": "cpu.usage_idle",
+				"cpu":  "cpu-total",
+				"host": "test",
 			},
 		},
 		{
@@ -72,7 +245,7 @@ func TestExtractTags(t *testing.T) {
 			res := ExtractTags(tt.Input)
 
 			if len(res) != len(tt.Output) {
-				t.Fatalf("result length mismatch, got %v, expected %v", len(res), len(tt.Output))
+				t.Fatalf("result length mismatch, got %v, expected %v, %+v != %+v", len(res), len(tt.Output), res, tt.Output)
 			}
 
 			for k, v := range res {

--- a/expr/types/extract_test.go
+++ b/expr/types/extract_test.go
@@ -76,6 +76,18 @@ func TestExtractName(t *testing.T) {
 			"alias(Количество изменений)",
 			"Количество изменений",
 		},
+		{
+			"some(Количество изменений, Аргумент)",
+			"Количество изменений",
+		},
+		{
+			"seriesByTag('tag2=value*', 'name=metric')",
+			"seriesByTag('tag2=value*', 'name=metric')",
+		},
+		{
+			"sum(seriesByTag('tag2=value*', 'name=metric'))",
+			"seriesByTag('tag2=value*', 'name=metric')",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix extract tags from seriesByTag args (actual for aggregation functions like sumSeries, which can't correct extract tags from metrics tags correctly).
Also has some differences from current graphite-web  (which used tags from first metric).
In wildcarded/regexp args special symbols are replaced with some underscores.
