### PR TITLE
Update divideSeries handling of missing denominators (from grafana fork)

### DIFF
--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -52,7 +52,21 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		if err != nil {
 			return nil, err
 		}
-		if len(denominators) != 1 {
+		if len(denominators) == 0 {
+			results := make([]*types.MetricData, 0, len(numerators))
+			for _, numerator := range numerators {
+				r := numerator.CopyLink()
+				r.Values = make([]float64, len(numerator.Values))
+				r.Name = fmt.Sprintf("divideSeries(%s,MISSING)", numerator.Name)
+				for i := range numerator.Values {
+					r.Values[i] = math.NaN()
+				}
+				results = append(results, r)
+			}
+			return results, nil
+		}
+
+		if len(denominators) > 1 {
 			return nil, types.ErrWildcardNotAllowed
 		}
 

--- a/expr/functions/divideSeries/function_test.go
+++ b/expr/functions/divideSeries/function_test.go
@@ -80,6 +80,14 @@ func TestDivideSeries(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("divideSeries(metric[12])",
 				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2}, 1, now32).SetNameTag("metric1")},
 		},
+		{
+			"divideSeries(testMetric,metric)", // verify that a non-existant denominator will not error out and instead will return a list of math.NaN() values
+			map[parser.MetricRequest][]*types.MetricData{
+				{"testMetric", 0, 1}: {types.MakeMetricData("testMetric", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("divideSeries(testMetric,MISSING)",
+				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
From https://github.com/grafana/carbonapi/pull/73

In the divideSeries function, if the length of the denominators is not equal to 1, an error is [returned](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L1120) in CarbonAPI. This appears to not be consistent with how this situation is handled in Graphite web, where a list of with values of None is returned.

Currently, we are seeing the following error when the length of denominators is either 0 or > 1:

function=divideSeries: found wildcard where series expected

To reproduce, run a query such as:

divideSeries(testMetric1,test)

where test is not a valid metric name.