### PR TITLE
Parse string input for params of type Integer or Float (#106)

### DIFF
--- a/cmd/mockbackend/testcases/pr560/pr560.yaml
+++ b/cmd/mockbackend/testcases/pr560/pr560.yaml
@@ -31,13 +31,6 @@ test:
             - endpoint: "http://127.0.0.1:8081"
               delay: 1
               type: "GET"
-              URL: "/render?target=constantLine('2222')"
-              expectedResponse:
-                  httpCode: 400
-                  contentType: "text/plain; charset=utf-8"
-            - endpoint: "http://127.0.0.1:8081"
-              delay: 1
-              type: "GET"
               URL: "/render?target=polyfit(a.b.c.d.e, 2, '12dd')"
               expectedResponse:
                   httpCode: 400

--- a/expr/functions/constantLine/function_test.go
+++ b/expr/functions/constantLine/function_test.go
@@ -28,6 +28,12 @@ func TestConstantLine(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("42.42",
 				[]float64{42.42, 42.42}, 1, 0)},
 		},
+		{
+			"constantLine('42.42')", // Verify string input can be parsed into int or float
+			map[parser.MetricRequest][]*types.MetricData{},
+			[]*types.MetricData{types.MakeMetricData("42.42",
+				[]float64{42.42, 42.42}, 1, 0)},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/functions/offset/function_test.go
+++ b/expr/functions/offset/function_test.go
@@ -35,7 +35,28 @@ func TestFunction(t *testing.T) {
 				[]float64{103, 104, 105, math.NaN(), 107, 108, 109, 110, 111}, 1, now32)},
 		},
 		{
+			"offset(metric1,'10')", // Verify string input can be parsed into int or float
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("offset(metric1,10)",
+				[]float64{103, 104, 105, math.NaN(), 107, 108, 109, 110, 111}, 1, now32)},
+		},
+		{
 			"add(metric*,-10)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32),
+					types.MakeMetricData("metric2", []float64{193, 194, 195, math.NaN(), 197, 198, 199, 200, 201}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("add(metric1,-10)", []float64{83, 84, 85, math.NaN(), 87, 88, 89, 90, 91}, 1, now32),
+				types.MakeMetricData("add(metric2,-10)", []float64{183, 184, 185, math.NaN(), 187, 188, 189, 190, 191}, 1, now32),
+			},
+		},
+		{
+			"add(metric*,'-10')", // Verify string input can be parsed into int or float
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric*", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32),

--- a/pkg/parser/internal.go
+++ b/pkg/parser/internal.go
@@ -2,12 +2,17 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 
 	"runtime/debug"
 )
 
 func (e *expr) doGetIntArg() (int, error) {
 	if e.etype != EtConst {
+		if e.etype == EtString {
+			f, err := strconv.ParseInt(e.valStr, 0, 64)
+			return int(f), err
+		}
 		return 0, ErrBadType
 	}
 
@@ -24,6 +29,10 @@ func (e *expr) getNamedArg(name string) *expr {
 
 func (e *expr) doGetFloatArg() (float64, error) {
 	if e.etype != EtConst {
+		if e.etype == EtString {
+			f, err := strconv.ParseFloat(e.valStr, 64)
+			return f, err
+		}
 		return 0, ErrBadType
 	}
 

--- a/pkg/parser/internal.go
+++ b/pkg/parser/internal.go
@@ -10,7 +10,7 @@ import (
 func (e *expr) doGetIntArg() (int, error) {
 	if e.etype != EtConst {
 		if e.etype == EtString {
-			f, err := strconv.ParseInt(e.valStr, 0, 64)
+			f, err := strconv.ParseInt(e.valStr, 0, 32)
 			return int(f), err
 		}
 		return 0, ErrBadType

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -429,3 +429,61 @@ func TestGetIntervalNamedOrPosArgDefault(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(-60), val)
 }
+
+func TestDoGetFloatArg(t *testing.T) {
+	tests := []struct {
+		s string
+		e *expr
+		r float64
+	}{
+		{
+			"parse float",
+			&expr{val: 1.0, etype: EtConst, valStr: "1.0"},
+			1.0,
+		},
+		{
+			"parse string to float",
+			&expr{etype: EtString, valStr: "1.0"},
+			1.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r, err := tt.e.doGetFloatArg()
+			if assert.NoError(err) {
+				assert.Equal(tt.r, r, tt.s)
+			}
+		})
+	}
+}
+
+func TestDoGetIntArg(t *testing.T) {
+	tests := []struct {
+		s string
+		e *expr
+		r int
+	}{
+		{
+			"parse int",
+			&expr{val: 5, etype: EtConst, valStr: "5"},
+			5,
+		},
+		{
+			"parse string to int",
+			&expr{etype: EtString, valStr: "1"},
+			1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r, err := tt.e.doGetIntArg()
+			if assert.NoError(err) {
+				assert.Equal(tt.r, r, tt.s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR will change the float and int parsing functions to be able to parse string input. If the param type is a string, it will attempt to use strconv.ParseFloat or strconv.ParseInt and if the string can be converted to a float, that float value will be used. This will allow more leniency for users input, and be more consistent with Graphite web. Graphite web's parsing of floats and strings can be found [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/functions/params.py).