### PR TITLE
Fix GetIntervalNamedOrPosArgDefault

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -240,7 +240,7 @@ func (e *expr) GetIntervalNamedOrPosArgDefault(k string, n, defaultSign int, v i
 	var val string
 	var err error
 	if a := e.getNamedArg(k); a != nil {
-		val, err = e.doGetStringArg()
+		val, err = a.doGetStringArg()
 		if err != nil {
 			return 0, ErrBadType
 		}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -420,3 +420,12 @@ func TestDoGetBoolVar(t *testing.T) {
 		})
 	}
 }
+
+func TestGetIntervalNamedOrPosArgDefault(t *testing.T) {
+	e, _, err := ParseExpr("func(metric, key='1min')")
+	assert.NoError(t, err)
+
+	val, err := e.GetIntervalNamedOrPosArgDefault("key", 1, -1, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(-60), val)
+}


### PR DESCRIPTION
The diff says it all, there was a typo and the wrong `expr` was being used.
