### PR TITLE
Add support for Graphite web toLowerCase function

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -163,188 +163,190 @@ reverse: default value mismatch: got (empty), should be false |
 | timeSlice | endSliceAt: type mismatch: got interval, should be date |
 
 ## Supported functions
-| Function      | Carbonapi-only                                            |
-| :-------------|:--------------------------------------------------------- |
-| absolute(seriesList) | no |
-| add(seriesList, constant) | no |
-| aggregate(seriesList, func, xFilesFactor=None) | no |
-| aggregateLine(seriesList, func='average', keepStep=False) | no |
-| aggregateWithWildcards(seriesList, func, *positions) | no |
-| alias(seriesList, newName) | no |
-| aliasByMetric(seriesList) | no |
-| aliasByNode(seriesList, *nodes) | no |
-| aliasByTags(seriesList, *tags) | no |
-| aliasSub(seriesList, search, replace) | no |
-| alpha(seriesList, alpha) | no |
-| applyByNode(seriesList, nodeNum, templateFunction, newName=None) | no |
-| areaBetween(seriesList) | no |
-| asPercent(seriesList, total=None, *nodes) | no |
-| averageAbove(seriesList, n) | no |
-| averageBelow(seriesList, n) | no |
-| averageOutsidePercentile(seriesList, n) | no |
-| averageSeries(*seriesLists) | no |
-| averageSeriesWithWildcards(seriesList, *position) | no |
-| avg(*seriesLists) | no |
-| cactiStyle(seriesList, system=None, units=None) | no |
-| changed(seriesList) | no |
-| color(seriesList, theColor) | no |
-| consolidateBy(seriesList, consolidationFunc) | no |
-| constantLine(value) | no |
-| countSeries(*seriesLists) | no |
-| cumulative(seriesList) | no |
-| currentAbove(seriesList, n) | no |
-| currentBelow(seriesList, n) | no |
-| dashed(seriesList, dashLength=5) | no |
-| delay(seriesList, steps) | no |
-| derivative(seriesList) | no |
-| diffSeries(*seriesLists) | no |
-| divideSeries(dividendSeriesList, divisorSeries) | no |
-| divideSeriesLists(dividendSeriesList, divisorSeriesList) | no |
-| drawAsInfinite(seriesList) | no |
-| exclude(seriesList, pattern) | no |
-| exp(seriesList) | no |
-| exponentialMovingAverage(seriesList, windowSize) | no |
-| fallbackSeries(seriesList, fallback) | no |
-| filterSeries(seriesList, func, operator, threshold) | no |
-| grep(seriesList, pattern) | no |
-| group(*seriesLists) | no |
-| groupByNode(seriesList, nodeNum, callback='average') | no |
-| groupByNodes(seriesList, callback, *nodes) | no |
-| groupByTags(seriesList, callback, *tags) | no |
-| highest(seriesList, n=1, func='average') | no |
-| highestAverage(seriesList, n) | no |
-| highestCurrent(seriesList, n) | no |
-| highestMax(seriesList, n) | no |
-| hitcount(seriesList, intervalString, alignToInterval=False) | no |
-| holtWintersAberration(seriesList, delta=3, bootstrapInterval='7d') | no |
-| holtWintersConfidenceBands(seriesList, delta=3, bootstrapInterval='7d') | no |
-| holtWintersForecast(seriesList, bootstrapInterval='7d') | no |
-| logit(seriesList) | no |
-| identity(name) | no |
-| integral(seriesList) | no |
-| integralByInterval(seriesList, intervalString) | no |
-| interpolate(seriesList, limit) | no |
-| invert(seriesList) | no |
-| isNonNull(seriesList) | no |
-| keepLastValue(seriesList, limit=inf) | no |
-| legendValue(seriesList, *valueTypes) | no |
-| limit(seriesList, n) | no |
-| lineWidth(seriesList, width) | no |
-| linearRegression(seriesList, startSourceAt=None, endSourceAt=None) | no |
-| log(seriesList, base=10) | no |
-| lowest(seriesList, n=1, func='average') | no |
-| lowestAverage(seriesList, n) | no |
-| lowestCurrent(seriesList, n) | no |
-| map(seriesList, *mapNodes) | no |
-| mapSeries(seriesList, *mapNodes) | no |
-| maxSeries(*seriesLists) | no |
-| maximumAbove(seriesList, n) | no |
-| maximumBelow(seriesList, n) | no |
-| minSeries(*seriesLists) | no |
-| minimumAbove(seriesList, n) | no |
-| minimumBelow(seriesList, n) | no |
-| minMax(seriesList) | no |
-| mostDeviant(seriesList, n) | no |
-| movingAverage(seriesList, windowSize, xFilesFactor=None) | no |
-| movingMax(seriesList, windowSize, xFilesFactor=None) | no |
-| movingMedian(seriesList, windowSize, xFilesFactor=None) | no |
-| movingMin(seriesList, windowSize, xFilesFactor=None) | no |
-| movingSum(seriesList, windowSize, xFilesFactor=None) | no |
-| movingWindow(seriesList, windowSize, func='average', xFilesFactor=None) | no |
-| multiplySeries(*seriesLists) | no |
-| multiplySeriesWithWildcards(seriesList, *position) | no |
-| nPercentile(seriesList, n) | no |
-| nonNegativeDerivative(seriesList, maxValue=None) | no |
-| offset(seriesList, factor) | no |
-| offsetToZero(seriesList) | no |
-| perSecond(seriesList, maxValue=None) | no |
-| percentileOfSeries(seriesList, n, interpolate=False) | no |
-| pow(seriesList, factor) | no |
-| powSeries(*seriesLists) | no |
-| randomWalk(name, step=60) | no |
-| randomWalkFunction(name, step=60) | no |
-| rangeOfSeries(*seriesLists) | no |
-| reduce(seriesLists, reduceFunction, reduceNode, *reduceMatchers) | no |
-| reduceSeries(seriesLists, reduceFunction, reduceNode, *reduceMatchers) | no |
-| removeAbovePercentile(seriesList, n) | no |
-| removeAboveValue(seriesList, n) | no |
-| removeBelowPercentile(seriesList, n) | no |
-| removeBelowValue(seriesList, n) | no |
-| removeBelowValue(seriesList, n) | no |
-| removeEmptySeries(seriesList, xFilesFactor=None) | no |
-| round(seriesList, precision) | no |
-| scale(seriesList, factor) | no |
-| scaleToSeconds(seriesList, seconds) | no |
-| secondYAxis(seriesList) | no |
-| seriesByTag(*tagExpressions) | no |
-| setXFilesFactor(seriesList, xFilesFactor) | no |
-| sigmoid(seriesList) | no |
-| sinFunction(seriesList, amplitude=1, step=60) | no |
-| smartSummarize(seriesList, intervalString, func='sum', alignTo=None) | no |
-| sortBy(seriesList, func='average', reverse=False) | no |
-| sortByMaxima(seriesList) | no |
-| sortByMinima(seriesList) | no |
-| sortByName(seriesList, natural=False, reverse=False) | no |
-| sortByTotal(seriesList) | no |
-| squareRoot(seriesList) | no |
-| stacked(seriesLists, stackName='__DEFAULT__') | no |
-| stddevSeries(*seriesLists) | no |
-| stdev(seriesList, points, windowTolerance=0.1) | no |
-| substr(seriesList, start=0, stop=0) | no |
-| sum(*seriesLists) | no |
-| sumSeries(*seriesLists) | no |
-| sumSeriesWithWildcards(seriesList, *position) | no |
-| summarize(seriesList, intervalString, func='sum', alignToFrom=False) | no |
-| threshold(value, label=None, color=None) | no |
-| time(name, step=60) | no |
-| timeFunction(name, step=60) | no |
-| timeShift(seriesList, timeShift, resetEnd=True, alignDST=False) | no |
-| timeSlice(seriesList, startSliceAt, endSliceAt='now') | no |
-| timeStack(seriesList, timeShiftUnit='1d', timeShiftStart=0, timeShiftEnd=7) | no |
-| transformNull(seriesList, default=0, referenceSeries=None) | no |
-| unique(*seriesLists) | no |
-| useSeriesAbove(seriesList, value, search, replace) | no |
-| weightedAverage(seriesListAvg, seriesListWeight, *nodes) | no |
-| verticalLine(ts, label=None, color=None) | no |
-| aliasByBase64(seriesList) | yes |
-| aliasByPostgres(seriesList, *nodes) | yes |
-| aliasByRedis(seriesList. keyName) | yes |
-| baseline(seriesList, timeShiftUnit, timeShiftStart, timeShiftEnd, [maxAbsentPercent, minAvg]) | yes |
-| baselineAberration(seriesList, timeShiftUnit, timeShiftStart, timeShiftEnd, [maxAbsentPercent, minAvg]) | yes |
-| count(*seriesLists) | yes |
-| diff(*seriesLists) | yes |
-| diffSeriesLists(firstSeriesList, secondSeriesList) | yes |
-| exponentialWeightedMovingAverage(seriesList, alpha) | yes |
-| exponentialWeightedMovingAverage(seriesList, alpha) | yes |
-| fft(seriesList, mode) | yes |
-| heatMap(seriesList) | yes |
-| highestMin(seriesList, n) | yes |
-| ifft(seriesList, phaseSeriesList) | yes |
-| integralWithReset(seriesList, resettingSeries) | yes |
-| isNotNull(seriesList) | yes |
-| kolmogorovSmirnovTest2(seriesList, seriesList, windowSize) | yes |
-| ksTest2(seriesList, seriesList, windowSize) | yes |
-| log(seriesList, base=10) | yes |
-| lowPass(seriesList, cutPercent) | yes |
-| lowestMax(seriesList, n) | yes |
-| lowestMin(seriesList, n) | yes |
-| lpf(seriesList, cutPercent) | yes |
-| maxSeries(*seriesLists) | yes |
-| minSeries(*seriesLists) | yes |
-| multiply(*seriesLists) | yes |
-| multiplySeriesLists(sourceSeriesList, factorSeriesList) | yes |
-| pearson(seriesList, seriesList, windowSize) | yes |
-| pearsonClosest(seriesList, seriesList, n, direction) | yes |
-| polyfit(seriesList, degree=1, offset="0d") | yes |
-| powSeriesLists(sourceSeriesList, factorSeriesList) | yes |
-| removeZeroSeries(seriesList, xFilesFactor=None) | yes |
-| scale(seriesList, factor) | yes |
-| slo(seriesList, interval, method, value) | yes |
-| sloErrorBudget(seriesList, interval, method, value, objective) | yes |
-| stddev(*seriesLists) | yes |
-| timeShiftByMetric(seriesList, markSource, versionRankIndex) | yes |
-| tukeyAbove(seriesList, basis, n, interval=0) | yes |
-| tukeyBelow(seriesList, basis, n, interval=0) | yes |
+| Function                                                                                                | Carbonapi-only |
+|:--------------------------------------------------------------------------------------------------------|:---------------|
+| absolute(seriesList)                                                                                    | no             |
+| add(seriesList, constant)                                                                               | no             |
+| aggregate(seriesList, func, xFilesFactor=None)                                                          | no             |
+| aggregateLine(seriesList, func='average', keepStep=False)                                               | no             |
+| aggregateWithWildcards(seriesList, func, *positions)                                                    | no             |
+| alias(seriesList, newName)                                                                              | no             |
+| aliasByMetric(seriesList)                                                                               | no             |
+| aliasByNode(seriesList, *nodes)                                                                         | no             |
+| aliasByTags(seriesList, *tags)                                                                          | no             |
+| aliasSub(seriesList, search, replace)                                                                   | no             |
+| alpha(seriesList, alpha)                                                                                | no             |
+| applyByNode(seriesList, nodeNum, templateFunction, newName=None)                                        | no             |
+| areaBetween(seriesList)                                                                                 | no             |
+| asPercent(seriesList, total=None, *nodes)                                                               | no             |
+| averageAbove(seriesList, n)                                                                             | no             |
+| averageBelow(seriesList, n)                                                                             | no             |
+| averageOutsidePercentile(seriesList, n)                                                                 | no             |
+| averageSeries(*seriesLists)                                                                             | no             |
+| averageSeriesWithWildcards(seriesList, *position)                                                       | no             |
+| avg(*seriesLists)                                                                                       | no             |
+| cactiStyle(seriesList, system=None, units=None)                                                         | no             |
+| changed(seriesList)                                                                                     | no             |
+| color(seriesList, theColor)                                                                             | no             |
+| consolidateBy(seriesList, consolidationFunc)                                                            | no             |
+| constantLine(value)                                                                                     | no             |
+| countSeries(*seriesLists)                                                                               | no             |
+| cumulative(seriesList)                                                                                  | no             |
+| currentAbove(seriesList, n)                                                                             | no             |
+| currentBelow(seriesList, n)                                                                             | no             |
+| dashed(seriesList, dashLength=5)                                                                        | no             |
+| delay(seriesList, steps)                                                                                | no             |
+| derivative(seriesList)                                                                                  | no             |
+| diffSeries(*seriesLists)                                                                                | no             |
+| divideSeries(dividendSeriesList, divisorSeries)                                                         | no             |
+| divideSeriesLists(dividendSeriesList, divisorSeriesList)                                                | no             |
+| drawAsInfinite(seriesList)                                                                              | no             |
+| exclude(seriesList, pattern)                                                                            | no             |
+| exp(seriesList)                                                                                         | no             |
+| exponentialMovingAverage(seriesList, windowSize)                                                        | no             |
+| fallbackSeries(seriesList, fallback)                                                                    | no             |
+| filterSeries(seriesList, func, operator, threshold)                                                     | no             |
+| grep(seriesList, pattern)                                                                               | no             |
+| group(*seriesLists)                                                                                     | no             |
+| groupByNode(seriesList, nodeNum, callback='average')                                                    | no             |
+| groupByNodes(seriesList, callback, *nodes)                                                              | no             |
+| groupByTags(seriesList, callback, *tags)                                                                | no             |
+| highest(seriesList, n=1, func='average')                                                                | no             |
+| highestAverage(seriesList, n)                                                                           | no             |
+| highestCurrent(seriesList, n)                                                                           | no             |
+| highestMax(seriesList, n)                                                                               | no             |
+| hitcount(seriesList, intervalString, alignToInterval=False)                                             | no             |
+| holtWintersAberration(seriesList, delta=3, bootstrapInterval='7d')                                      | no             |
+| holtWintersConfidenceBands(seriesList, delta=3, bootstrapInterval='7d')                                 | no             |
+| holtWintersForecast(seriesList, bootstrapInterval='7d')                                                 | no             |
+| logit(seriesList)                                                                                       | no             |
+| identity(name)                                                                                          | no             |
+| integral(seriesList)                                                                                    | no             |
+| integralByInterval(seriesList, intervalString)                                                          | no             |
+| interpolate(seriesList, limit)                                                                          | no             |
+| invert(seriesList)                                                                                      | no             |
+| isNonNull(seriesList)                                                                                   | no             |
+| keepLastValue(seriesList, limit=inf)                                                                    | no             |
+| legendValue(seriesList, *valueTypes)                                                                    | no             |
+| limit(seriesList, n)                                                                                    | no             |
+| lineWidth(seriesList, width)                                                                            | no             |
+| linearRegression(seriesList, startSourceAt=None, endSourceAt=None)                                      | no             |
+| log(seriesList, base=10)                                                                                | no             |
+| lowest(seriesList, n=1, func='average')                                                                 | no             |
+| lowestAverage(seriesList, n)                                                                            | no             |
+| lowestCurrent(seriesList, n)                                                                            | no             |
+| map(seriesList, *mapNodes)                                                                              | no             |
+| mapSeries(seriesList, *mapNodes)                                                                        | no             |
+| maxSeries(*seriesLists)                                                                                 | no             |
+| maximumAbove(seriesList, n)                                                                             | no             |
+| maximumBelow(seriesList, n)                                                                             | no             |
+| minSeries(*seriesLists)                                                                                 | no             |
+| minimumAbove(seriesList, n)                                                                             | no             |
+| minimumBelow(seriesList, n)                                                                             | no             |
+| minMax(seriesList)                                                                                      | no             |
+| mostDeviant(seriesList, n)                                                                              | no             |
+| movingAverage(seriesList, windowSize, xFilesFactor=None)                                                | no             |
+| movingMax(seriesList, windowSize, xFilesFactor=None)                                                    | no             |
+| movingMedian(seriesList, windowSize, xFilesFactor=None)                                                 | no             |
+| movingMin(seriesList, windowSize, xFilesFactor=None)                                                    | no             |
+| movingSum(seriesList, windowSize, xFilesFactor=None)                                                    | no             |
+| movingWindow(seriesList, windowSize, func='average', xFilesFactor=None)                                 | no             |
+| multiplySeries(*seriesLists)                                                                            | no             |
+| multiplySeriesWithWildcards(seriesList, *position)                                                      | no             |
+| nPercentile(seriesList, n)                                                                              | no             |
+| nonNegativeDerivative(seriesList, maxValue=None)                                                        | no             |
+| offset(seriesList, factor)                                                                              | no             |
+| offsetToZero(seriesList)                                                                                | no             |
+| perSecond(seriesList, maxValue=None)                                                                    | no             |
+| percentileOfSeries(seriesList, n, interpolate=False)                                                    | no             |
+| pow(seriesList, factor)                                                                                 | no             |
+| powSeries(*seriesLists)                                                                                 | no             |
+| randomWalk(name, step=60)                                                                               | no             |
+| randomWalkFunction(name, step=60)                                                                       | no             |
+| rangeOfSeries(*seriesLists)                                                                             | no             |
+| reduce(seriesLists, reduceFunction, reduceNode, *reduceMatchers)                                        | no             |
+| reduceSeries(seriesLists, reduceFunction, reduceNode, *reduceMatchers)                                  | no             |
+| removeAbovePercentile(seriesList, n)                                                                    | no             |
+| removeAboveValue(seriesList, n)                                                                         | no             |
+| removeBelowPercentile(seriesList, n)                                                                    | no             |
+| removeBelowValue(seriesList, n)                                                                         | no             |
+| removeBelowValue(seriesList, n)                                                                         | no             |
+| removeEmptySeries(seriesList, xFilesFactor=None)                                                        | no             |
+| round(seriesList, precision)                                                                            | no             |
+| scale(seriesList, factor)                                                                               | no             |
+| scaleToSeconds(seriesList, seconds)                                                                     | no             |
+| secondYAxis(seriesList)                                                                                 | no             |
+| seriesByTag(*tagExpressions)                                                                            | no             |
+| setXFilesFactor(seriesList, xFilesFactor)                                                               | no             |
+| sigmoid(seriesList)                                                                                     | no             |
+| sinFunction(seriesList, amplitude=1, step=60)                                                           | no             |
+| smartSummarize(seriesList, intervalString, func='sum', alignTo=None)                                    | no             |
+| sortBy(seriesList, func='average', reverse=False)                                                       | no             |
+| sortByMaxima(seriesList)                                                                                | no             |
+| sortByMinima(seriesList)                                                                                | no             |
+| sortByName(seriesList, natural=False, reverse=False)                                                    | no             |
+| sortByTotal(seriesList)                                                                                 | no             |
+| squareRoot(seriesList)                                                                                  | no             |
+| stacked(seriesLists, stackName='__DEFAULT__')                                                           | no             |
+| stddevSeries(*seriesLists)                                                                              | no             |
+| stdev(seriesList, points, windowTolerance=0.1)                                                          | no             |
+| substr(seriesList, start=0, stop=0)                                                                     | no             |
+| sum(*seriesLists)                                                                                       | no             |
+| sumSeries(*seriesLists)                                                                                 | no             |
+| sumSeriesWithWildcards(seriesList, *position)                                                           | no             |
+| summarize(seriesList, intervalString, func='sum', alignToFrom=False)                                    | no             |
+| threshold(value, label=None, color=None)                                                                | no             |
+| time(name, step=60)                                                                                     | no             |
+| timeFunction(name, step=60)                                                                             | no             |
+| timeShift(seriesList, timeShift, resetEnd=True, alignDST=False)                                         | no             |
+| timeSlice(seriesList, startSliceAt, endSliceAt='now')                                                   | no             |
+| timeStack(seriesList, timeShiftUnit='1d', timeShiftStart=0, timeShiftEnd=7)                             | no             |
+| toLowerCase(seruesList)                                                                                 | no             |
+| transformNull(seriesList, default=0, referenceSeries=None)                                              | no             |
+| unique(*seriesLists)                                                                                    | no             |
+| useSeriesAbove(seriesList, value, search, replace)                                                      | no             |
+| weightedAverage(seriesListAvg, seriesListWeight, *nodes)                                                | no             |
+| verticalLine(ts, label=None, color=None)                                                                | no             |
+| aliasByBase64(seriesList)                                                                               | yes            |
+| aliasByPostgres(seriesList, *nodes)                                                                     | yes            |
+| aliasByRedis(seriesList. keyName)                                                                       | yes            |
+| baseline(seriesList, timeShiftUnit, timeShiftStart, timeShiftEnd, [maxAbsentPercent, minAvg])           | yes            |
+| baselineAberration(seriesList, timeShiftUnit, timeShiftStart, timeShiftEnd, [maxAbsentPercent, minAvg]) | yes            |
+| count(*seriesLists)                                                                                     | yes            |
+| diff(*seriesLists)                                                                                      | yes            |
+| diffSeriesLists(firstSeriesList, secondSeriesList)                                                      | yes            |
+| exponentialWeightedMovingAverage(seriesList, alpha)                                                     | yes            |
+| exponentialWeightedMovingAverage(seriesList, alpha)                                                     | yes            |
+| fft(seriesList, mode)                                                                                   | yes            |
+| heatMap(seriesList)                                                                                     | yes            |
+| highestMin(seriesList, n)                                                                               | yes            |
+| ifft(seriesList, phaseSeriesList)                                                                       | yes            |
+| integralWithReset(seriesList, resettingSeries)                                                          | yes            |
+| isNotNull(seriesList)                                                                                   | yes            |
+| kolmogorovSmirnovTest2(seriesList, seriesList, windowSize)                                              | yes            |
+| ksTest2(seriesList, seriesList, windowSize)                                                             | yes            |
+| log(seriesList, base=10)                                                                                | yes            |
+| lowPass(seriesList, cutPercent)                                                                         | yes            |
+| lowestMax(seriesList, n)                                                                                | yes            |
+| lowestMin(seriesList, n)                                                                                | yes            |
+| lpf(seriesList, cutPercent)                                                                             | yes            |
+| maxSeries(*seriesLists)                                                                                 | yes            |
+| minSeries(*seriesLists)                                                                                 | yes            |
+| multiply(*seriesLists)                                                                                  | yes            |
+| multiplySeriesLists(sourceSeriesList, factorSeriesList)                                                 | yes            |
+| pearson(seriesList, seriesList, windowSize)                                                             | yes            |
+| pearsonClosest(seriesList, seriesList, n, direction)                                                    | yes            |
+| polyfit(seriesList, degree=1, offset="0d")                                                              | yes            |
+| powSeriesLists(sourceSeriesList, factorSeriesList)                                                      | yes            |
+| removeZeroSeries(seriesList, xFilesFactor=None)                                                         | yes            |
+| scale(seriesList, factor)                                                                               | yes            |
+| slo(seriesList, interval, method, value)                                                                | yes            |
+| sloErrorBudget(seriesList, interval, method, value, objective)                                          | yes            |
+| stddev(*seriesLists)                                                                                    | yes            |
+| timeShiftByMetric(seriesList, markSource, versionRankIndex)                                             | yes            |
+| stddev(*seriesLists)                                                                                    | yes            |
+| tukeyAbove(seriesList, basis, n, interval=0)                                                            | yes            |
+| tukeyBelow(seriesList, basis, n, interval=0)                                                            | yes            |
 <a name="functions-features"></a>
 ## Features of configuration functions
 ### aliasByPostgres

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -110,6 +110,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/functions/timeShiftByMetric"
 	"github.com/go-graphite/carbonapi/expr/functions/timeSlice"
 	"github.com/go-graphite/carbonapi/expr/functions/timeStack"
+	"github.com/go-graphite/carbonapi/expr/functions/toLowerCase"
 	"github.com/go-graphite/carbonapi/expr/functions/transformNull"
 	"github.com/go-graphite/carbonapi/expr/functions/tukey"
 	"github.com/go-graphite/carbonapi/expr/functions/unique"
@@ -234,6 +235,7 @@ func New(configs map[string]string) {
 		{name: "timeShiftByMetric", filename: "timeShiftByMetric", order: timeShiftByMetric.GetOrder(), f: timeShiftByMetric.New},
 		{name: "timeSlice", filename: "timeSlice", order: timeSlice.GetOrder(), f: timeSlice.New},
 		{name: "timeStack", filename: "timeStack", order: timeStack.GetOrder(), f: timeStack.New},
+		{name: "toLowerCase", filename: "toLowerCase", order: toLowerCase.GetOrder(), f: toLowerCase.New},
 		{name: "transformNull", filename: "transformNull", order: transformNull.GetOrder(), f: transformNull.New},
 		{name: "tukey", filename: "tukey", order: tukey.GetOrder(), f: tukey.New},
 		{name: "unique", filename: "unique", order: unique.GetOrder(), f: unique.New},

--- a/expr/functions/toLowerCase/function.go
+++ b/expr/functions/toLowerCase/function.go
@@ -1,0 +1,96 @@
+package toLowerCase
+
+import (
+	"context"
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"strings"
+
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+)
+
+type toLowerCase struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &toLowerCase{}
+	functions := []string{"toLowerCase"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// toLowerCase(seriesList, *pos)
+func (f *toLowerCase) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	var pos []int
+
+	if e.ArgsLen() >= 2 {
+		pos, err = e.GetIntArgs(1)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	results := make([]*types.MetricData, 0, len(args)+1)
+
+	for _, a := range args {
+		r := a.CopyLink()
+
+		if len(pos) == 0 {
+			r.Name = strings.ToLower(a.Name)
+		} else {
+			for _, i := range pos {
+				if i < 0 { // Handle negative indices by indexing backwards
+					i = len(r.Name) + i
+				}
+				lowered := strings.ToLower(string(r.Name[i]))
+				r.Name = r.Name[:i] + lowered + r.Name[i+1:]
+			}
+		}
+
+		results = append(results, r)
+	}
+
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *toLowerCase) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"toLowerCase": {
+			Description: "Takes one metric or a wildcard seriesList and lowers the case of each letter. \n Optionally, a letter position to lower case can be specified, in which case only the letter at the specified position gets lower-cased.\n The position parameter may be given multiple times. The position parameter may be negative to define a position relative to the end of the metric name.",
+			Function:    "toLowerCase(seriesList, *pos)",
+			Group:       "Alias",
+			Module:      "graphite.render.functions",
+			Name:        "toLowerCase",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Multiple: true,
+					Name:     "pos",
+					Type:     types.Node,
+					Required: false,
+				},
+			},
+			NameChange:   true, // name changed
+			ValuesChange: true, // values changed
+		},
+	}
+}

--- a/expr/functions/toLowerCase/function_test.go
+++ b/expr/functions/toLowerCase/function_test.go
@@ -1,0 +1,69 @@
+package toLowerCase
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestToLowerCaseFunction(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"toLowerCase(METRIC.TEST.FOO)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric.test.foo",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+		{
+			"toLowerCase(METRIC.TEST.FOO,7)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("METRIC.tEST.FOO",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+		{
+			"toLowerCase(METRIC.TEST.FOO,-3)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("METRIC.TEST.fOO",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+		{
+			"toLowerCase(METRIC.TEST.FOO,0,7,12)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("mETRIC.tEST.fOO",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for Graphite web's toLowerCase function. This function is defined as:

```
toLowerCase(seriesList, *pos)
Takes one metric or a wildcard seriesList and lowers the case of each letter.

Optionally, a letter position to lower case can be specified, in which case only the letter at the specified position gets lower-cased. The position parameter may be given multiple times. The position parameter may be negative to define a position relative to the end of the metric name.
```

This PR also includes tests to verify functionality according to the definition and [Graphite web's implementation](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L2867)