### PR TITLE
Add support to Graphite web toUpperCase function

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -301,6 +301,7 @@ reverse: default value mismatch: got (empty), should be false |
 | timeShift(seriesList, timeShift, resetEnd=True, alignDST=False) | no |
 | timeSlice(seriesList, startSliceAt, endSliceAt='now') | no |
 | timeStack(seriesList, timeShiftUnit='1d', timeShiftStart=0, timeShiftEnd=7) | no |
+| toUpperCase(seriesList, *pos) | no |
 | transformNull(seriesList, default=0, referenceSeries=None) | no |
 | unique(*seriesLists) | no |
 | useSeriesAbove(seriesList, value, search, replace) | no |

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -110,6 +110,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/functions/timeShiftByMetric"
 	"github.com/go-graphite/carbonapi/expr/functions/timeSlice"
 	"github.com/go-graphite/carbonapi/expr/functions/timeStack"
+	"github.com/go-graphite/carbonapi/expr/functions/toUpperCase"
 	"github.com/go-graphite/carbonapi/expr/functions/transformNull"
 	"github.com/go-graphite/carbonapi/expr/functions/tukey"
 	"github.com/go-graphite/carbonapi/expr/functions/unique"
@@ -234,6 +235,7 @@ func New(configs map[string]string) {
 		{name: "timeShiftByMetric", filename: "timeShiftByMetric", order: timeShiftByMetric.GetOrder(), f: timeShiftByMetric.New},
 		{name: "timeSlice", filename: "timeSlice", order: timeSlice.GetOrder(), f: timeSlice.New},
 		{name: "timeStack", filename: "timeStack", order: timeStack.GetOrder(), f: timeStack.New},
+		{name: "toUpperCase", filename: "toUpperCase", order: toUpperCase.GetOrder(), f: toUpperCase.New},
 		{name: "transformNull", filename: "transformNull", order: transformNull.GetOrder(), f: transformNull.New},
 		{name: "tukey", filename: "tukey", order: tukey.GetOrder(), f: tukey.New},
 		{name: "unique", filename: "unique", order: unique.GetOrder(), f: unique.New},

--- a/expr/functions/toUpperCase/function.go
+++ b/expr/functions/toUpperCase/function.go
@@ -1,0 +1,95 @@
+package toUpperCase
+
+import (
+	"context"
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"strings"
+
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+)
+
+type toUpperCase struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &toUpperCase{}
+	functions := []string{"toLowerCase"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// toUpperCase(seriesList, *pos)
+func (f *toUpperCase) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	var pos []int
+
+	if e.ArgsLen() >= 2 {
+		pos, err = e.GetIntArgs(1)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	results := make([]*types.MetricData, 0, len(args)+1)
+
+	for _, a := range args {
+		r := a.CopyLink()
+
+		if len(pos) == 0 {
+			r.Name = strings.ToUpper(a.Name)
+		} else {
+			for _, i := range pos {
+				if i < 0 { // Handle negative indices by indexing backwards
+					i = len(r.Name) + i
+				}
+				uppered := strings.ToUpper(string(r.Name[i]))
+				r.Name = r.Name[:i] + uppered + r.Name[i+1:]
+			}
+		}
+
+		results = append(results, r)
+	}
+
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *toUpperCase) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"toUpperCase": {
+			Description: "Takes one metric or a wildcard seriesList and uppers the case of each letter. \n Optionally, a letter position to upper case can be specified, in which case only the letter at the specified position gets upper-cased.\n The position parameter may be given multiple times. The position parameter may be negative to define a position relative to the end of the metric name.",
+			Function:    "toUpperCase(seriesList, *pos)",
+			Group:       "Alias",
+			Module:      "graphite.render.functions",
+			Name:        "toUpperCase",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Multiple: true,
+					Name:     "pos",
+					Type:     types.Node,
+				},
+			},
+			NameChange:   true, // name changed
+			ValuesChange: true, // values changed
+		},
+	}
+}

--- a/expr/functions/toUpperCase/function_test.go
+++ b/expr/functions/toUpperCase/function_test.go
@@ -1,0 +1,69 @@
+package toUpperCase
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestToUpperCaseFunction(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"toUpperCase(metric.test.foo)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("METRIC.TEST.FOO",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+		{
+			"toUpperCase(metric.test.foo,7)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric.Test.foo",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+		{
+			"toLowerCase(metric.test.foo,-3)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric.test.Foo",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+		{
+			"toUpperCase(metric.test.foo,0,7,12)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("Metric.Test.Foo",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for Graphite web's toLowerCase function. This function is defined as:

```
toUpperCase(seriesList, *pos)
Takes one metric or a wildcard seriesList and uppers the case of each letter.

Optionally, a letter position to upper case can be specified, in which case only the letter at the specified position gets upper-cased. The position parameter may be given multiple times. The position parameter may be negative to define a position relative to the end of the metric name.
```

This PR also includes tests to verify functionality according to the definition and [Graphite web's implementation](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L2833)