### PR TITLE
Add support for Graphite web sumSeriesLists function

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -163,188 +163,189 @@ reverse: default value mismatch: got (empty), should be false |
 | timeSlice | endSliceAt: type mismatch: got interval, should be date |
 
 ## Supported functions
-| Function      | Carbonapi-only                                            |
-| :-------------|:--------------------------------------------------------- |
-| absolute(seriesList) | no |
-| add(seriesList, constant) | no |
-| aggregate(seriesList, func, xFilesFactor=None) | no |
-| aggregateLine(seriesList, func='average', keepStep=False) | no |
-| aggregateWithWildcards(seriesList, func, *positions) | no |
-| alias(seriesList, newName) | no |
-| aliasByMetric(seriesList) | no |
-| aliasByNode(seriesList, *nodes) | no |
-| aliasByTags(seriesList, *tags) | no |
-| aliasSub(seriesList, search, replace) | no |
-| alpha(seriesList, alpha) | no |
-| applyByNode(seriesList, nodeNum, templateFunction, newName=None) | no |
-| areaBetween(seriesList) | no |
-| asPercent(seriesList, total=None, *nodes) | no |
-| averageAbove(seriesList, n) | no |
-| averageBelow(seriesList, n) | no |
-| averageOutsidePercentile(seriesList, n) | no |
-| averageSeries(*seriesLists) | no |
-| averageSeriesWithWildcards(seriesList, *position) | no |
-| avg(*seriesLists) | no |
-| cactiStyle(seriesList, system=None, units=None) | no |
-| changed(seriesList) | no |
-| color(seriesList, theColor) | no |
-| consolidateBy(seriesList, consolidationFunc) | no |
-| constantLine(value) | no |
-| countSeries(*seriesLists) | no |
-| cumulative(seriesList) | no |
-| currentAbove(seriesList, n) | no |
-| currentBelow(seriesList, n) | no |
-| dashed(seriesList, dashLength=5) | no |
-| delay(seriesList, steps) | no |
-| derivative(seriesList) | no |
-| diffSeries(*seriesLists) | no |
-| divideSeries(dividendSeriesList, divisorSeries) | no |
-| divideSeriesLists(dividendSeriesList, divisorSeriesList) | no |
-| drawAsInfinite(seriesList) | no |
-| exclude(seriesList, pattern) | no |
-| exp(seriesList) | no |
-| exponentialMovingAverage(seriesList, windowSize) | no |
-| fallbackSeries(seriesList, fallback) | no |
-| filterSeries(seriesList, func, operator, threshold) | no |
-| grep(seriesList, pattern) | no |
-| group(*seriesLists) | no |
-| groupByNode(seriesList, nodeNum, callback='average') | no |
-| groupByNodes(seriesList, callback, *nodes) | no |
-| groupByTags(seriesList, callback, *tags) | no |
-| highest(seriesList, n=1, func='average') | no |
-| highestAverage(seriesList, n) | no |
-| highestCurrent(seriesList, n) | no |
-| highestMax(seriesList, n) | no |
-| hitcount(seriesList, intervalString, alignToInterval=False) | no |
-| holtWintersAberration(seriesList, delta=3, bootstrapInterval='7d') | no |
-| holtWintersConfidenceBands(seriesList, delta=3, bootstrapInterval='7d') | no |
-| holtWintersForecast(seriesList, bootstrapInterval='7d') | no |
-| logit(seriesList) | no |
-| identity(name) | no |
-| integral(seriesList) | no |
-| integralByInterval(seriesList, intervalString) | no |
-| interpolate(seriesList, limit) | no |
-| invert(seriesList) | no |
-| isNonNull(seriesList) | no |
-| keepLastValue(seriesList, limit=inf) | no |
-| legendValue(seriesList, *valueTypes) | no |
-| limit(seriesList, n) | no |
-| lineWidth(seriesList, width) | no |
-| linearRegression(seriesList, startSourceAt=None, endSourceAt=None) | no |
-| log(seriesList, base=10) | no |
-| lowest(seriesList, n=1, func='average') | no |
-| lowestAverage(seriesList, n) | no |
-| lowestCurrent(seriesList, n) | no |
-| map(seriesList, *mapNodes) | no |
-| mapSeries(seriesList, *mapNodes) | no |
-| maxSeries(*seriesLists) | no |
-| maximumAbove(seriesList, n) | no |
-| maximumBelow(seriesList, n) | no |
-| minSeries(*seriesLists) | no |
-| minimumAbove(seriesList, n) | no |
-| minimumBelow(seriesList, n) | no |
-| minMax(seriesList) | no |
-| mostDeviant(seriesList, n) | no |
-| movingAverage(seriesList, windowSize, xFilesFactor=None) | no |
-| movingMax(seriesList, windowSize, xFilesFactor=None) | no |
-| movingMedian(seriesList, windowSize, xFilesFactor=None) | no |
-| movingMin(seriesList, windowSize, xFilesFactor=None) | no |
-| movingSum(seriesList, windowSize, xFilesFactor=None) | no |
-| movingWindow(seriesList, windowSize, func='average', xFilesFactor=None) | no |
-| multiplySeries(*seriesLists) | no |
-| multiplySeriesWithWildcards(seriesList, *position) | no |
-| nPercentile(seriesList, n) | no |
-| nonNegativeDerivative(seriesList, maxValue=None) | no |
-| offset(seriesList, factor) | no |
-| offsetToZero(seriesList) | no |
-| perSecond(seriesList, maxValue=None) | no |
-| percentileOfSeries(seriesList, n, interpolate=False) | no |
-| pow(seriesList, factor) | no |
-| powSeries(*seriesLists) | no |
-| randomWalk(name, step=60) | no |
-| randomWalkFunction(name, step=60) | no |
-| rangeOfSeries(*seriesLists) | no |
-| reduce(seriesLists, reduceFunction, reduceNode, *reduceMatchers) | no |
-| reduceSeries(seriesLists, reduceFunction, reduceNode, *reduceMatchers) | no |
-| removeAbovePercentile(seriesList, n) | no |
-| removeAboveValue(seriesList, n) | no |
-| removeBelowPercentile(seriesList, n) | no |
-| removeBelowValue(seriesList, n) | no |
-| removeBelowValue(seriesList, n) | no |
-| removeEmptySeries(seriesList, xFilesFactor=None) | no |
-| round(seriesList, precision) | no |
-| scale(seriesList, factor) | no |
-| scaleToSeconds(seriesList, seconds) | no |
-| secondYAxis(seriesList) | no |
-| seriesByTag(*tagExpressions) | no |
-| setXFilesFactor(seriesList, xFilesFactor) | no |
-| sigmoid(seriesList) | no |
-| sinFunction(seriesList, amplitude=1, step=60) | no |
-| smartSummarize(seriesList, intervalString, func='sum', alignTo=None) | no |
-| sortBy(seriesList, func='average', reverse=False) | no |
-| sortByMaxima(seriesList) | no |
-| sortByMinima(seriesList) | no |
-| sortByName(seriesList, natural=False, reverse=False) | no |
-| sortByTotal(seriesList) | no |
-| squareRoot(seriesList) | no |
-| stacked(seriesLists, stackName='__DEFAULT__') | no |
-| stddevSeries(*seriesLists) | no |
-| stdev(seriesList, points, windowTolerance=0.1) | no |
-| substr(seriesList, start=0, stop=0) | no |
-| sum(*seriesLists) | no |
-| sumSeries(*seriesLists) | no |
-| sumSeriesWithWildcards(seriesList, *position) | no |
-| summarize(seriesList, intervalString, func='sum', alignToFrom=False) | no |
-| threshold(value, label=None, color=None) | no |
-| time(name, step=60) | no |
-| timeFunction(name, step=60) | no |
-| timeShift(seriesList, timeShift, resetEnd=True, alignDST=False) | no |
-| timeSlice(seriesList, startSliceAt, endSliceAt='now') | no |
-| timeStack(seriesList, timeShiftUnit='1d', timeShiftStart=0, timeShiftEnd=7) | no |
-| transformNull(seriesList, default=0, referenceSeries=None) | no |
-| unique(*seriesLists) | no |
-| useSeriesAbove(seriesList, value, search, replace) | no |
-| weightedAverage(seriesListAvg, seriesListWeight, *nodes) | no |
-| verticalLine(ts, label=None, color=None) | no |
-| aliasByBase64(seriesList) | yes |
-| aliasByPostgres(seriesList, *nodes) | yes |
-| aliasByRedis(seriesList. keyName) | yes |
-| baseline(seriesList, timeShiftUnit, timeShiftStart, timeShiftEnd, [maxAbsentPercent, minAvg]) | yes |
+| Function                                                                                                | Carbonapi-only                                            |
+|:--------------------------------------------------------------------------------------------------------|:--------------------------------------------------------- |
+| absolute(seriesList)                                                                                    | no |
+| add(seriesList, constant)                                                                               | no |
+| aggregate(seriesList, func, xFilesFactor=None)                                                          | no |
+| aggregateLine(seriesList, func='average', keepStep=False)                                               | no |
+| aggregateWithWildcards(seriesList, func, *positions)                                                    | no |
+| alias(seriesList, newName)                                                                              | no |
+| aliasByMetric(seriesList)                                                                               | no |
+| aliasByNode(seriesList, *nodes)                                                                         | no |
+| aliasByTags(seriesList, *tags)                                                                          | no |
+| aliasSub(seriesList, search, replace)                                                                   | no |
+| alpha(seriesList, alpha)                                                                                | no |
+| applyByNode(seriesList, nodeNum, templateFunction, newName=None)                                        | no |
+| areaBetween(seriesList)                                                                                 | no |
+| asPercent(seriesList, total=None, *nodes)                                                               | no |
+| averageAbove(seriesList, n)                                                                             | no |
+| averageBelow(seriesList, n)                                                                             | no |
+| averageOutsidePercentile(seriesList, n)                                                                 | no |
+| averageSeries(*seriesLists)                                                                             | no |
+| averageSeriesWithWildcards(seriesList, *position)                                                       | no |
+| avg(*seriesLists)                                                                                       | no |
+| cactiStyle(seriesList, system=None, units=None)                                                         | no |
+| changed(seriesList)                                                                                     | no |
+| color(seriesList, theColor)                                                                             | no |
+| consolidateBy(seriesList, consolidationFunc)                                                            | no |
+| constantLine(value)                                                                                     | no |
+| countSeries(*seriesLists)                                                                               | no |
+| cumulative(seriesList)                                                                                  | no |
+| currentAbove(seriesList, n)                                                                             | no |
+| currentBelow(seriesList, n)                                                                             | no |
+| dashed(seriesList, dashLength=5)                                                                        | no |
+| delay(seriesList, steps)                                                                                | no |
+| derivative(seriesList)                                                                                  | no |
+| diffSeries(*seriesLists)                                                                                | no |
+| divideSeries(dividendSeriesList, divisorSeries)                                                         | no |
+| divideSeriesLists(dividendSeriesList, divisorSeriesList)                                                | no |
+| drawAsInfinite(seriesList)                                                                              | no |
+| exclude(seriesList, pattern)                                                                            | no |
+| exp(seriesList)                                                                                         | no |
+| exponentialMovingAverage(seriesList, windowSize)                                                        | no |
+| fallbackSeries(seriesList, fallback)                                                                    | no |
+| filterSeries(seriesList, func, operator, threshold)                                                     | no |
+| grep(seriesList, pattern)                                                                               | no |
+| group(*seriesLists)                                                                                     | no |
+| groupByNode(seriesList, nodeNum, callback='average')                                                    | no |
+| groupByNodes(seriesList, callback, *nodes)                                                              | no |
+| groupByTags(seriesList, callback, *tags)                                                                | no |
+| highest(seriesList, n=1, func='average')                                                                | no |
+| highestAverage(seriesList, n)                                                                           | no |
+| highestCurrent(seriesList, n)                                                                           | no |
+| highestMax(seriesList, n)                                                                               | no |
+| hitcount(seriesList, intervalString, alignToInterval=False)                                             | no |
+| holtWintersAberration(seriesList, delta=3, bootstrapInterval='7d')                                      | no |
+| holtWintersConfidenceBands(seriesList, delta=3, bootstrapInterval='7d')                                 | no |
+| holtWintersForecast(seriesList, bootstrapInterval='7d')                                                 | no |
+| logit(seriesList)                                                                                       | no |
+| identity(name)                                                                                          | no |
+| integral(seriesList)                                                                                    | no |
+| integralByInterval(seriesList, intervalString)                                                          | no |
+| interpolate(seriesList, limit)                                                                          | no |
+| invert(seriesList)                                                                                      | no |
+| isNonNull(seriesList)                                                                                   | no |
+| keepLastValue(seriesList, limit=inf)                                                                    | no |
+| legendValue(seriesList, *valueTypes)                                                                    | no |
+| limit(seriesList, n)                                                                                    | no |
+| lineWidth(seriesList, width)                                                                            | no |
+| linearRegression(seriesList, startSourceAt=None, endSourceAt=None)                                      | no |
+| log(seriesList, base=10)                                                                                | no |
+| lowest(seriesList, n=1, func='average')                                                                 | no |
+| lowestAverage(seriesList, n)                                                                            | no |
+| lowestCurrent(seriesList, n)                                                                            | no |
+| map(seriesList, *mapNodes)                                                                              | no |
+| mapSeries(seriesList, *mapNodes)                                                                        | no |
+| maxSeries(*seriesLists)                                                                                 | no |
+| maximumAbove(seriesList, n)                                                                             | no |
+| maximumBelow(seriesList, n)                                                                             | no |
+| minSeries(*seriesLists)                                                                                 | no |
+| minimumAbove(seriesList, n)                                                                             | no |
+| minimumBelow(seriesList, n)                                                                             | no |
+| minMax(seriesList)                                                                                      | no |
+| mostDeviant(seriesList, n)                                                                              | no |
+| movingAverage(seriesList, windowSize, xFilesFactor=None)                                                | no |
+| movingMax(seriesList, windowSize, xFilesFactor=None)                                                    | no |
+| movingMedian(seriesList, windowSize, xFilesFactor=None)                                                 | no |
+| movingMin(seriesList, windowSize, xFilesFactor=None)                                                    | no |
+| movingSum(seriesList, windowSize, xFilesFactor=None)                                                    | no |
+| movingWindow(seriesList, windowSize, func='average', xFilesFactor=None)                                 | no |
+| multiplySeries(*seriesLists)                                                                            | no |
+| multiplySeriesWithWildcards(seriesList, *position)                                                      | no |
+| nPercentile(seriesList, n)                                                                              | no |
+| nonNegativeDerivative(seriesList, maxValue=None)                                                        | no |
+| offset(seriesList, factor)                                                                              | no |
+| offsetToZero(seriesList)                                                                                | no |
+| perSecond(seriesList, maxValue=None)                                                                    | no |
+| percentileOfSeries(seriesList, n, interpolate=False)                                                    | no |
+| pow(seriesList, factor)                                                                                 | no |
+| powSeries(*seriesLists)                                                                                 | no |
+| randomWalk(name, step=60)                                                                               | no |
+| randomWalkFunction(name, step=60)                                                                       | no |
+| rangeOfSeries(*seriesLists)                                                                             | no |
+| reduce(seriesLists, reduceFunction, reduceNode, *reduceMatchers)                                        | no |
+| reduceSeries(seriesLists, reduceFunction, reduceNode, *reduceMatchers)                                  | no |
+| removeAbovePercentile(seriesList, n)                                                                    | no |
+| removeAboveValue(seriesList, n)                                                                         | no |
+| removeBelowPercentile(seriesList, n)                                                                    | no |
+| removeBelowValue(seriesList, n)                                                                         | no |
+| removeBelowValue(seriesList, n)                                                                         | no |
+| removeEmptySeries(seriesList, xFilesFactor=None)                                                        | no |
+| round(seriesList, precision)                                                                            | no |
+| scale(seriesList, factor)                                                                               | no |
+| scaleToSeconds(seriesList, seconds)                                                                     | no |
+| secondYAxis(seriesList)                                                                                 | no |
+| seriesByTag(*tagExpressions)                                                                            | no |
+| setXFilesFactor(seriesList, xFilesFactor)                                                               | no |
+| sigmoid(seriesList)                                                                                     | no |
+| sinFunction(seriesList, amplitude=1, step=60)                                                           | no |
+| smartSummarize(seriesList, intervalString, func='sum', alignTo=None)                                    | no |
+| sortBy(seriesList, func='average', reverse=False)                                                       | no |
+| sortByMaxima(seriesList)                                                                                | no |
+| sortByMinima(seriesList)                                                                                | no |
+| sortByName(seriesList, natural=False, reverse=False)                                                    | no |
+| sortByTotal(seriesList)                                                                                 | no |
+| squareRoot(seriesList)                                                                                  | no |
+| stacked(seriesLists, stackName='__DEFAULT__')                                                           | no |
+| stddevSeries(*seriesLists)                                                                              | no |
+| stdev(seriesList, points, windowTolerance=0.1)                                                          | no |
+| substr(seriesList, start=0, stop=0)                                                                     | no |
+| sum(*seriesLists)                                                                                       | no |
+| sumSeries(*seriesLists)                                                                                 | no |
+| sumSeriesLists(seriesListFirstPos, seriesListSecondPos)                                                                            | no |
+| sumSeriesWithWildcards(seriesList, *position)                                                           | no |
+| summarize(seriesList, intervalString, func='sum', alignToFrom=False)                                    | no |
+| threshold(value, label=None, color=None)                                                                | no |
+| time(name, step=60)                                                                                     | no |
+| timeFunction(name, step=60)                                                                             | no |
+| timeShift(seriesList, timeShift, resetEnd=True, alignDST=False)                                         | no |
+| timeSlice(seriesList, startSliceAt, endSliceAt='now')                                                   | no |
+| timeStack(seriesList, timeShiftUnit='1d', timeShiftStart=0, timeShiftEnd=7)                             | no |
+| transformNull(seriesList, default=0, referenceSeries=None)                                              | no |
+| unique(*seriesLists)                                                                                    | no |
+| useSeriesAbove(seriesList, value, search, replace)                                                      | no |
+| weightedAverage(seriesListAvg, seriesListWeight, *nodes)                                                | no |
+| verticalLine(ts, label=None, color=None)                                                                | no |
+| aliasByBase64(seriesList)                                                                               | yes |
+| aliasByPostgres(seriesList, *nodes)                                                                     | yes |
+| aliasByRedis(seriesList. keyName)                                                                       | yes |
+| baseline(seriesList, timeShiftUnit, timeShiftStart, timeShiftEnd, [maxAbsentPercent, minAvg])           | yes |
 | baselineAberration(seriesList, timeShiftUnit, timeShiftStart, timeShiftEnd, [maxAbsentPercent, minAvg]) | yes |
-| count(*seriesLists) | yes |
-| diff(*seriesLists) | yes |
-| diffSeriesLists(firstSeriesList, secondSeriesList) | yes |
-| exponentialWeightedMovingAverage(seriesList, alpha) | yes |
-| exponentialWeightedMovingAverage(seriesList, alpha) | yes |
-| fft(seriesList, mode) | yes |
-| heatMap(seriesList) | yes |
-| highestMin(seriesList, n) | yes |
-| ifft(seriesList, phaseSeriesList) | yes |
-| integralWithReset(seriesList, resettingSeries) | yes |
-| isNotNull(seriesList) | yes |
-| kolmogorovSmirnovTest2(seriesList, seriesList, windowSize) | yes |
-| ksTest2(seriesList, seriesList, windowSize) | yes |
-| log(seriesList, base=10) | yes |
-| lowPass(seriesList, cutPercent) | yes |
-| lowestMax(seriesList, n) | yes |
-| lowestMin(seriesList, n) | yes |
-| lpf(seriesList, cutPercent) | yes |
-| maxSeries(*seriesLists) | yes |
-| minSeries(*seriesLists) | yes |
-| multiply(*seriesLists) | yes |
-| multiplySeriesLists(sourceSeriesList, factorSeriesList) | yes |
-| pearson(seriesList, seriesList, windowSize) | yes |
-| pearsonClosest(seriesList, seriesList, n, direction) | yes |
-| polyfit(seriesList, degree=1, offset="0d") | yes |
-| powSeriesLists(sourceSeriesList, factorSeriesList) | yes |
-| removeZeroSeries(seriesList, xFilesFactor=None) | yes |
-| scale(seriesList, factor) | yes |
-| slo(seriesList, interval, method, value) | yes |
-| sloErrorBudget(seriesList, interval, method, value, objective) | yes |
-| stddev(*seriesLists) | yes |
-| timeShiftByMetric(seriesList, markSource, versionRankIndex) | yes |
-| tukeyAbove(seriesList, basis, n, interval=0) | yes |
-| tukeyBelow(seriesList, basis, n, interval=0) | yes |
+| count(*seriesLists)                                                                                     | yes |
+| diff(*seriesLists)                                                                                      | yes |
+| diffSeriesLists(firstSeriesList, secondSeriesList)                                                      | yes |
+| exponentialWeightedMovingAverage(seriesList, alpha)                                                     | yes |
+| exponentialWeightedMovingAverage(seriesList, alpha)                                                     | yes |
+| fft(seriesList, mode)                                                                                   | yes |
+| heatMap(seriesList)                                                                                     | yes |
+| highestMin(seriesList, n)                                                                               | yes |
+| ifft(seriesList, phaseSeriesList)                                                                       | yes |
+| integralWithReset(seriesList, resettingSeries)                                                          | yes |
+| isNotNull(seriesList)                                                                                   | yes |
+| kolmogorovSmirnovTest2(seriesList, seriesList, windowSize)                                              | yes |
+| ksTest2(seriesList, seriesList, windowSize)                                                             | yes |
+| log(seriesList, base=10)                                                                                | yes |
+| lowPass(seriesList, cutPercent)                                                                         | yes |
+| lowestMax(seriesList, n)                                                                                | yes |
+| lowestMin(seriesList, n)                                                                                | yes |
+| lpf(seriesList, cutPercent)                                                                             | yes |
+| maxSeries(*seriesLists)                                                                                 | yes |
+| minSeries(*seriesLists)                                                                                 | yes |
+| multiply(*seriesLists)                                                                                  | yes |
+| multiplySeriesLists(sourceSeriesList, factorSeriesList)                                                 | yes |
+| pearson(seriesList, seriesList, windowSize)                                                             | yes |
+| pearsonClosest(seriesList, seriesList, n, direction)                                                    | yes |
+| polyfit(seriesList, degree=1, offset="0d")                                                              | yes |
+| powSeriesLists(sourceSeriesList, factorSeriesList)                                                      | yes |
+| removeZeroSeries(seriesList, xFilesFactor=None)                                                         | yes |
+| scale(seriesList, factor)                                                                               | yes |
+| slo(seriesList, interval, method, value)                                                                | yes |
+| sloErrorBudget(seriesList, interval, method, value, objective)                                          | yes |
+| stddev(*seriesLists)                                                                                    | yes |
+| timeShiftByMetric(seriesList, markSource, versionRankIndex)                                             | yes |
+| tukeyAbove(seriesList, basis, n, interval=0)                                                            | yes |
+| tukeyBelow(seriesList, basis, n, interval=0)                                                            | yes |
 <a name="functions-features"></a>
 ## Features of configuration functions
 ### aliasByPostgres

--- a/expr/functions/seriesList/function_test.go
+++ b/expr/functions/seriesList/function_test.go
@@ -35,6 +35,15 @@ func TestFunction(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("diffSeries(metric1,metric2)",
 				[]float64{-1, math.NaN(), math.NaN(), math.NaN(), 4, 6}, 1, now32)},
 		},
+		{
+			"sumSeriesLists(metric1,metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2)",
+				[]float64{3, math.NaN(), math.NaN(), math.NaN(), 4, 18}, 1, now32)},
+		},
 	}
 
 	for _, tt := range tests {
@@ -107,6 +116,20 @@ func TestSeriesListMultiReturn(t *testing.T) {
 			"diffSeriesListSameGroups",
 			map[string][]*types.MetricData{
 				"diffSeries(metric1,metric1)": {types.MakeMetricData("diffSeries(metric1,metric1)", []float64{0, 0, 0, 0, 0}, 1, now32)},
+			},
+		},
+		{
+			"sumSeriesLists(metric[12],metric[12])",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[12]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
+				},
+			},
+			"sumSeriesListSameGroups",
+			map[string][]*types.MetricData{
+				"sumSeries(metric1,metric1)": {types.MakeMetricData("sumSeries(metric1,metric1)", []float64{2, 4, 6, 8, 10}, 1, now32)},
+				"sumSeries(metric2,metric2)": {types.MakeMetricData("sumSeries(metric2,metric2)", []float64{4, 8, 12, 16, 20}, 1, now32)},
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds support for the Graphite web sumSeriesLists function, defined as:

```
sumSeriesLists(seriesListFirstPos, seriesListSecondPos)
Iterates over a two lists and subtracts series lists 2 through n from series 1 list1[0] to list2[0], list1[1] to list2[1] and so on. The lists will need to be the same length

Example:

&target=sumSeriesLists(mining.{carbon,graphite,diamond}.extracted,mining.{carbon,graphite,diamond}.shipped)
An example above would be the same as running [sumSeries](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.sumSeries) for each member of the list:

?target=sumSeries(mining.carbon.extracted,mining.carbon.shipped)
&target=sumSeries(mining.graphite.extracted,mining.graphite.shipped)

This un
&target=sumSeries(mining.diamond.extracted,mining.diamond.shipped)
This is an alias for [aggregateSeriesLists](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.aggregateSeriesLists) with aggregation sum.
```

The function definition can also be found [here](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.sumSeriesLists).

Tests were added to verify the functionality according to the Graphite web implementation and the function definition.