### PR TITLE
Fix panic in asPercent when length of series is greater than the length of the total

### DIFF
--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -156,14 +156,8 @@ func seriesAsPercent(arg, total []*types.MetricData) []*types.MetricData {
 			// len(seriesList) > len(totalSeriesList)
 			for n := range total {
 				a := arg[n]
-				for i := range a.Values {
-					t := total[n].Values[i]
-					if math.IsNaN(a.Values[i]) || math.IsNaN(t) || t == 0 {
-						a.Values[i] = math.NaN()
-					} else {
-						a.Values[i] *= 100 / t
-					}
-				}
+				getPercentages(a, total[n])
+
 				a.Name = "asPercent(" + a.Name + "," + total[n].Name + ")"
 			}
 			for n := len(total); n < len(arg); n++ {

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -29,49 +29,6 @@ func TestAsPercent(t *testing.T) {
 
 	tests := []th.EvalTestItem{
 		{
-			"asPercent(metric1,metric2)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 12}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, NaN, 3, NaN, 0, 6}, 1, now32)},
-			},
-			[]*types.MetricData{types.MakeMetricData("asPercent(metric1,metric2)",
-				[]float64{50, NaN, NaN, NaN, NaN, 200}, 1, now32)},
-		},
-		{
-			"asPercent(metricA*,metricB*)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metricA*", 0, 1}: {
-					types.MakeMetricData("metricA1", []float64{1, 20, 10}, 1, now32),
-					types.MakeMetricData("metricA2", []float64{1, 10, 20}, 1, now32),
-				},
-				{"metricB*", 0, 1}: {
-					types.MakeMetricData("metricB1", []float64{4, 4, 8}, 1, now32),
-					types.MakeMetricData("metricB2", []float64{4, 16, 2}, 1, now32),
-				},
-			},
-			[]*types.MetricData{types.MakeMetricData("asPercent(metricA1,metricB1)",
-				[]float64{25, 500, 125}, 1, now32),
-				types.MakeMetricData("asPercent(metricA2,metricB2)",
-					[]float64{25, 62.5, 1000}, 1, now32)},
-		},
-		{
-			"asPercent(Server{1,2}.memory.used,Server{1,3}.memory.total)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.used", 0, 1}: {
-					types.MakeMetricData("Server1.memory.used", []float64{1, 20, 10}, 1, now32),
-					types.MakeMetricData("Server2.memory.used", []float64{1, 10, 20}, 1, now32),
-				},
-				{"Server{1,3}.memory.total", 0, 1}: {
-					types.MakeMetricData("Server1.memory.total", []float64{4, 4, 8}, 1, now32),
-					types.MakeMetricData("Server3.memory.total", []float64{4, 16, 2}, 1, now32),
-				},
-			},
-			[]*types.MetricData{
-				types.MakeMetricData("asPercent(Server1.memory.used,Server1.memory.total)", []float64{25, 500, 125}, 1, now32),
-				types.MakeMetricData("asPercent(Server2.memory.used,Server3.memory.total)", []float64{25, 62.5, 1000}, 1, now32),
-			},
-		},
-		{
 			"asPercent(metricC*,metricD*)", // This test is to verify that passing in metrics with different number of values and different step values for the series and the totalSeries does not throw an error
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metricC*", 0, 1}: {
@@ -87,6 +44,26 @@ func TestAsPercent(t *testing.T) {
 				[]float64{25, 500, 125, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 				types.MakeMetricData("asPercent(metricC2,metricD2)",
 					[]float64{25, 62.5, 1000, math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+		},
+		{
+			"asPercent(metricE*,metricF*)", // This test is to verify that passing in metrics with different lengths and different number of values and different step values for the series and the totalSeries does not throw an error
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metricE*", 0, 1}: {
+					types.MakeMetricData("metricE1", []float64{1, 20, 10, 15, 5}, 1, now32), // Test that error isn't thrown when seriesList has more values than totalSeries
+					types.MakeMetricData("metricE2", []float64{1, 10, 20, 15, 5}, 1, now32),
+					types.MakeMetricData("metricE3", []float64{1, 10, 20, 15, 5}, 1, now32),
+				},
+				{"metricF*", 0, 1}: {
+					types.MakeMetricData("metricF1", []float64{4, 4, 8}, 2, now32),
+					types.MakeMetricData("metricF2", []float64{4, 16, 2}, 2, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("asPercent(metricE1,metricF1)",
+				[]float64{25, 500, 125, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+				types.MakeMetricData("asPercent(metricE2,metricF2)",
+					[]float64{25, 62.5, 1000, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+				types.MakeMetricData("asPercent(metricE3,MISSING)",
+					[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 		},
 
 		// Extend tests


### PR DESCRIPTION
In asPercent, if both a series list and a total series list are used as parameters, and the length of the series list is greater than the length of the total series list, then a panic would occur due to trying to access an index of total that did not exist when looping through the series values. This loop has been replaced by a call to getPercentages, so the error will no longer occur. A test was added to verify that no panic occurs, and the correct results are returned.