### PR TITLE
groupByNodes: allow zero nodes to be passed

### DIFF
--- a/expr/functions/groupByNode/function_test.go
+++ b/expr/functions/groupByNode/function_test.go
@@ -169,6 +169,20 @@ func TestGroupByNode(t *testing.T) {
 			},
 		},
 		{
+			Name:   "groupByNodes_no_nodes",
+			Target: `groupByNodes(metric1.foo.*.*,"sum")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				mr: {
+					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric1.foo.bar1.bla", []float64{1, 2, 3, 4, 5}, 1, now32),
+				},
+			},
+			// If no nodes are specified, all metrics are combined to the empty string
+			Results: map[string][]*types.MetricData{
+				"": {types.MakeMetricData("", []float64{2, 4, 6, 8, 10}, 1, now32)},
+			},
+		},
+		{
 			Target: "groupByNode(metric1.foo.*.*,2,\"sum\")",
 			M: map[parser.MetricRequest][]*types.MetricData{
 				mr: {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -410,7 +410,8 @@ func (e *expr) GetBoolArgDefault(n int, b bool) (bool, error) {
 }
 
 func (e *expr) GetNodeOrTagArgs(n int, single bool) ([]NodeOrTag, error) {
-	if len(e.args) <= n {
+	// if single==false, zero nodes is OK
+	if single && len(e.args) <= n || len(e.args) < n {
 		return nil, ErrMissingArgument
 	}
 


### PR DESCRIPTION
Passing zero nodes to `groupByNodes` is allowed by GraphiteWeb, its aggregation is the empty string, see: https://github.com/graphite-project/graphite-web/blob/e7d08e6af65c47c5a5dd6421c5b352d7ac3d381c/webapp/graphite/render/functions.py#L111

Also here is a test that shows that from GraphiteWeb:

https://github.com/graphite-project/graphite-web/blob/e7d08e6af65c47c5a5dd6421c5b352d7ac3d381c/webapp/tests/test_functions.py#L3168-L3171