### PR TITLE
Allow quoted numeric arguments for asPercent and keepLastValue

### DIFF
--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -364,7 +364,7 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			a.Name = "asPercent(" + a.Name + ")"
 		}
 		return arg, nil
-	} else if e.ArgsLen() == 2 && e.Arg(1).IsConst() {
+	} else if e.ArgsLen() == 2 && (e.Arg(1).IsConst() || e.Arg(1).IsString()) {
 		// asPercent(seriesList, N)
 
 		total, err := e.GetFloatArg(1)

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -29,6 +29,57 @@ func TestAsPercent(t *testing.T) {
 
 	tests := []th.EvalTestItem{
 		{
+			"asPercent(metric1,metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 12}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, NaN, 3, NaN, 0, 6}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("asPercent(metric1,metric2)",
+				[]float64{50, NaN, NaN, NaN, NaN, 200}, 1, now32)},
+		},
+		{
+			"asPercent(metric1,'5')", // Ensure quoted numeric values are handled
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 12}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("asPercent(metric1,5)",
+				[]float64{20, NaN, NaN, 60, 80, 240}, 1, now32)},
+		},
+		{
+			"asPercent(metricA*,metricB*)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metricA*", 0, 1}: {
+					types.MakeMetricData("metricA1", []float64{1, 20, 10}, 1, now32),
+					types.MakeMetricData("metricA2", []float64{1, 10, 20}, 1, now32),
+				},
+				{"metricB*", 0, 1}: {
+					types.MakeMetricData("metricB1", []float64{4, 4, 8}, 1, now32),
+					types.MakeMetricData("metricB2", []float64{4, 16, 2}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("asPercent(metricA1,metricB1)",
+				[]float64{25, 500, 125}, 1, now32),
+				types.MakeMetricData("asPercent(metricA2,metricB2)",
+					[]float64{25, 62.5, 1000}, 1, now32)},
+		},
+		{
+			"asPercent(Server{1,2}.memory.used,Server{1,3}.memory.total)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"Server{1,2}.memory.used", 0, 1}: {
+					types.MakeMetricData("Server1.memory.used", []float64{1, 20, 10}, 1, now32),
+					types.MakeMetricData("Server2.memory.used", []float64{1, 10, 20}, 1, now32),
+				},
+				{"Server{1,3}.memory.total", 0, 1}: {
+					types.MakeMetricData("Server1.memory.total", []float64{4, 4, 8}, 1, now32),
+					types.MakeMetricData("Server3.memory.total", []float64{4, 16, 2}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("asPercent(Server1.memory.used,Server1.memory.total)", []float64{25, 500, 125}, 1, now32),
+				types.MakeMetricData("asPercent(Server2.memory.used,Server3.memory.total)", []float64{25, 62.5, 1000}, 1, now32),
+			},
+		},
+		{
 			"asPercent(metricC*,metricD*)", // This test is to verify that passing in metrics with different number of values and different step values for the series and the totalSeries does not throw an error
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metricC*", 0, 1}: {

--- a/expr/functions/keepLastValue/function_test.go
+++ b/expr/functions/keepLastValue/function_test.go
@@ -50,6 +50,14 @@ func TestFunction(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("keepLastValue(metric1,inf)", []float64{math.NaN(), 2, 2, 2, 2, 2, 4, 5}, 1, now32)},
 		},
 		{
+			"keepLastValue(metric1,'INF')",
+
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("keepLastValue(metric1,inf)", []float64{math.NaN(), 2, 2, 2, 2, 2, 4, 5}, 1, now32)},
+		},
+		{
 			"keepLastValue(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric*", 0, 1}: {

--- a/pkg/parser/internal.go
+++ b/pkg/parser/internal.go
@@ -2,7 +2,9 @@ package parser
 
 import (
 	"fmt"
+	"math"
 	"strconv"
+	"strings"
 
 	"runtime/debug"
 )
@@ -32,6 +34,8 @@ func (e *expr) doGetFloatArg() (float64, error) {
 		if e.etype == EtString {
 			f, err := strconv.ParseFloat(e.valStr, 64)
 			return f, err
+		} else if e.etype == EtName && strings.ToLower(e.Target()) == "inf" {
+			return math.Inf(1), nil
 		}
 		return 0, ErrBadType
 	}


### PR DESCRIPTION
The asPercent function and the keepLastValue function were not allowing singly quoted input for their total and limit parameters respectively. Users will sometimes pass in numeric values within single quotes, and doing so was resulting in errors. Since we previously added ability to parse quoted floats and ints (see https://github.com/go-graphite/carbonapi/pull/694), it should be extended to asPercent and keepLastValue as well.