### PR TITLE
Fix delay for negative steps and optimize perfomance

### DIFF
--- a/expr/functions/delay/function_test.go
+++ b/expr/functions/delay/function_test.go
@@ -1,6 +1,7 @@
 package delay
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	th "github.com/go-graphite/carbonapi/tests"
+	"github.com/go-graphite/carbonapi/tests/compare"
 )
 
 func init() {
@@ -29,10 +31,26 @@ func TestDelay(t *testing.T) {
 		{
 			"delay(metric1,3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("delay(metric1,3)",
-				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 3}, 1, now32).SetTag("delay", "3").SetNameTag("delay(metric1,3)")},
+				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 3, math.NaN()}, 1, now32).SetTag("delay", "3").SetNameTag("delay(metric1,3)")},
+		},
+		{
+			"delay(metric1,-3)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 3, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("delay(metric1,-3)",
+				[]float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("delay", "-3").SetNameTag("delay(metric1,-3)")},
+		},
+		{
+			"delay(metric1,0)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("delay(metric1,0)",
+				[]float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("delay", "0").SetNameTag("delay(metric1,0)")},
 		},
 	}
 
@@ -43,4 +61,54 @@ func TestDelay(t *testing.T) {
 		})
 	}
 
+}
+
+func BenchmarkDelay(b *testing.B) {
+	target := "delay(metric*,3)"
+	metrics := map[parser.MetricRequest][]*types.MetricData{
+		{Metric: "metric*", From: 0, Until: 1}: {
+			types.MakeMetricData("metric1", compare.GenerateMetrics(2046, 1, 10, 1), 1, 1),
+			types.MakeMetricData("metric2", compare.GenerateMetrics(2046, 1, 10, 1), 1, 1),
+		},
+	}
+
+	evaluator := metadata.GetEvaluator()
+	exp, _, err := parser.ParseExpr(target)
+	if err != nil {
+		b.Fatalf("failed to parse %s: %+v", target, err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		g, err := evaluator.Eval(context.Background(), exp, 0, 1, metrics)
+		if err != nil {
+			b.Fatalf("failed to eval %s: %+v", target, err)
+		}
+		_ = g
+	}
+}
+
+func BenchmarkDelayReverse(b *testing.B) {
+	target := "delay(metric*,-3)"
+	metrics := map[parser.MetricRequest][]*types.MetricData{
+		{Metric: "metric*", From: 0, Until: 1}: {
+			types.MakeMetricData("metric1", compare.GenerateMetrics(2046, 1, 10, 1), 1, 1),
+			types.MakeMetricData("metric2", compare.GenerateMetrics(2046, 1, 10, 1), 1, 1),
+		},
+	}
+
+	evaluator := metadata.GetEvaluator()
+	exp, _, err := parser.ParseExpr(target)
+	if err != nil {
+		b.Fatalf("failed to parse %s: %+v", target, err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		g, err := evaluator.Eval(context.Background(), exp, 0, 1, metrics)
+		if err != nil {
+			b.Fatalf("failed to eval %s: %+v", target, err)
+		}
+		_ = g
+	}
 }


### PR DESCRIPTION
```
carbonapi]$ benchcmp delay1.txt delay2.txt 
benchmark            old ns/op     new ns/op     delta
BenchmarkDelay-6     68379         5183          -92.42%

benchmark            old allocs     new allocs     delta
BenchmarkDelay-6     2059           11             -99.47%

benchmark            old bytes     new bytes     delta
BenchmarkDelay-6     99328         33872         -65.90%
```