### PR TITLE
Update functions that were modifying original input

### DIFF
--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -689,9 +689,9 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 		results := make([]*types.MetricData, len(arg))
 
 		for i, a := range arg {
-			r := *a
+			r := a.CopyLinkTags()
 			r.Color = color
-			results[i] = &r
+			results[i] = r
 		}
 
 		return results, nil
@@ -764,10 +764,10 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 		results := make([]*types.MetricData, len(arg))
 
 		for i, a := range arg {
-			r := *a
+			r := a.CopyLinkTags()
 			r.Alpha = alpha
 			r.HasAlpha = true
-			results[i] = &r
+			results[i] = r
 		}
 
 		return results, nil
@@ -824,10 +824,10 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 		results := make([]*types.MetricData, len(arg))
 
 		for i, a := range arg {
-			r := *a
+			r := a.CopyLinkTags()
 			r.LineWidth = width
 			r.HasLineWidth = true
-			results[i] = &r
+			results[i] = r
 		}
 
 		return results, nil

--- a/expr/functions/cumulative/function.go
+++ b/expr/functions/cumulative/function.go
@@ -37,9 +37,9 @@ func (f *cumulative) Do(ctx context.Context, e parser.Expr, from, until int64, v
 	results := make([]*types.MetricData, len(arg))
 
 	for i, a := range arg {
-		r := *a
+		r := a.CopyLinkTags()
 		r.AggregateFunction = consolidations.AggSum
-		results[i] = &r
+		results[i] = r
 	}
 	return results, nil
 }

--- a/expr/functions/ifft/function.go
+++ b/expr/functions/ifft/function.go
@@ -47,7 +47,7 @@ func (f *ifft) Do(ctx context.Context, e parser.Expr, from, until int64, values 
 
 	results := make([]*types.MetricData, len(absSeriesList))
 	for j, a := range absSeriesList {
-		r := *a
+		r := a.CopyLinkTags()
 		r.Values = make([]float64, len(a.Values))
 		if len(phaseSeriesList) > j {
 			p := phaseSeriesList[j]
@@ -73,7 +73,7 @@ func (f *ifft) Do(ctx context.Context, e parser.Expr, from, until int64, values 
 			}
 		}
 
-		results[j] = &r
+		results[j] = r
 	}
 	return results, nil
 }

--- a/expr/functions/integralWithReset/function.go
+++ b/expr/functions/integralWithReset/function.go
@@ -53,7 +53,7 @@ func (f *integralWithReset) Do(ctx context.Context, e parser.Expr, from, until i
 
 	results := make([]*types.MetricData, len(arg))
 	for i, a := range arg {
-		r := *a
+		r := a.CopyLinkTags()
 		r.Name = "integralWithReset(" + a.Name + "," + resettingSeries.Name + ")"
 		r.Values = make([]float64, len(a.Values))
 
@@ -70,7 +70,7 @@ func (f *integralWithReset) Do(ctx context.Context, e parser.Expr, from, until i
 			}
 			r.Values[i] = current
 		}
-		results[i] = &r
+		results[i] = r
 	}
 	return results, nil
 }

--- a/expr/functions/interpolate/function.go
+++ b/expr/functions/interpolate/function.go
@@ -39,7 +39,7 @@ func (f *interpolate) Do(ctx context.Context, e parser.Expr, from, until int64, 
 	resultSeriesList := make([]*types.MetricData, 0, len(seriesList))
 	for _, series := range seriesList {
 		pointsQty := len(series.Values)
-		resultSeries := *series
+		resultSeries := series.CopyLinkTags()
 		resultSeries.Name = "interpolate(" + series.Name + ")"
 
 		resultSeries.Values = make([]float64, pointsQty)
@@ -85,7 +85,7 @@ func (f *interpolate) Do(ctx context.Context, e parser.Expr, from, until int64, 
 			}
 		}
 
-		resultSeriesList = append(resultSeriesList, &resultSeries)
+		resultSeriesList = append(resultSeriesList, resultSeries)
 	}
 
 	return resultSeriesList, nil

--- a/expr/functions/keepLastValue/function.go
+++ b/expr/functions/keepLastValue/function.go
@@ -60,7 +60,7 @@ func (f *keepLastValue) Do(ctx context.Context, e parser.Expr, from, until int64
 			name = "keepLastValue(" + a.Name + "," + keepStr + ")"
 		}
 
-		r := *a
+		r := a.CopyLinkTags()
 		r.Name = name
 		r.Values = make([]float64, len(a.Values))
 
@@ -83,7 +83,7 @@ func (f *keepLastValue) Do(ctx context.Context, e parser.Expr, from, until int64
 			prev = v
 			r.Values[i] = v
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, err
 }

--- a/expr/functions/kolmogorovSmirnovTest2/function.go
+++ b/expr/functions/kolmogorovSmirnovTest2/function.go
@@ -58,7 +58,7 @@ func (f *kolmogorovSmirnovTest2) Do(ctx context.Context, e parser.Expr, from, un
 	w1 := &types.Windowed{Data: make([]float64, windowSize)}
 	w2 := &types.Windowed{Data: make([]float64, windowSize)}
 
-	r := *a1
+	r := a1.CopyLinkTags()
 	r.Name = "kolmogorovSmirnovTest2(" + a1.Name + "," + a2.Name + "," + windowSizeStr + ")"
 	r.Values = make([]float64, len(a1.Values))
 	r.StartTime = from
@@ -81,7 +81,7 @@ func (f *kolmogorovSmirnovTest2) Do(ctx context.Context, e parser.Expr, from, un
 			r.Values[i] = math.NaN()
 		}
 	}
-	return []*types.MetricData{&r}, nil
+	return []*types.MetricData{r}, nil
 }
 
 // TODO: Implement normal description

--- a/expr/functions/lowPass/function.go
+++ b/expr/functions/lowPass/function.go
@@ -44,7 +44,7 @@ func (f *lowPass) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 
 	results := make([]*types.MetricData, len(arg))
 	for j, a := range arg {
-		r := *a
+		r := a.CopyLinkTags()
 		r.Name = "lowPass(" + a.Name + "," + cutPercentStr + ")"
 		r.Values = make([]float64, len(a.Values))
 		lowCut := int((cutPercent / 200) * float64(len(a.Values)))
@@ -57,7 +57,7 @@ func (f *lowPass) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 			}
 		}
 
-		results[j] = &r
+		results[j] = r
 	}
 	return results, nil
 }

--- a/expr/functions/minMax/function.go
+++ b/expr/functions/minMax/function.go
@@ -40,7 +40,7 @@ func (f *minMax) Do(ctx context.Context, e parser.Expr, from, until int64, value
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLinkTags()
 		r.Name = fmt.Sprintf("minMax(%s)", a.Name)
 		r.Values = make([]float64, len(a.Values))
 
@@ -64,7 +64,7 @@ func (f *minMax) Do(ctx context.Context, e parser.Expr, from, until int64, value
 				r.Values[i] = math.NaN()
 			}
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 
 	return results, nil

--- a/expr/functions/pearson/function.go
+++ b/expr/functions/pearson/function.go
@@ -56,7 +56,7 @@ func (f *pearson) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 	w1 := &types.Windowed{Data: make([]float64, windowSize)}
 	w2 := &types.Windowed{Data: make([]float64, windowSize)}
 
-	r := *a1
+	r := a1.CopyLinkTags()
 	r.Name = "pearson(" + a1.Name + "," + a2.Name + "," + e.Arg(2).StringValue() + ")"
 	r.Values = make([]float64, len(a1.Values))
 	r.StartTime = from
@@ -74,7 +74,7 @@ func (f *pearson) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 		}
 	}
 
-	return []*types.MetricData{&r}, nil
+	return []*types.MetricData{r}, nil
 }
 
 func (f *pearson) Description() map[string]types.FunctionDescription {

--- a/expr/functions/polyfit/function.go
+++ b/expr/functions/polyfit/function.go
@@ -61,7 +61,7 @@ func (f *polyfit) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 
 	results := make([]*types.MetricData, 0, len(arg))
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLinkTags()
 		if e.ArgsLen() > 2 {
 			r.Name = "polyfit(" + a.Name + "," + degreeStr + ",'" + offsStr + "')"
 		} else if e.ArgsLen() > 1 {
@@ -84,7 +84,7 @@ func (f *polyfit) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 			for i := range r.Values {
 				r.Values[i] = math.NaN()
 			}
-			results = append(results, &r)
+			results = append(results, r)
 			continue
 		}
 
@@ -106,7 +106,7 @@ func (f *polyfit) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 		for i := range r.Values {
 			r.Values[i] = consolidations.Poly(float64(i), c.RawMatrix().Data...)
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -103,7 +103,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 		}
 		results := make([]*types.MetricData, len(single))
 		for n, s := range single {
-			r := *s
+			r := s.CopyLinkTags()
 			r.Name = functionName + "(" + s.Name + "," + s.Name + ")"
 			r.Values = make([]float64, len(s.Values))
 			for i, v := range s.Values {
@@ -125,7 +125,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 				}
 
 			}
-			results[n] = &r
+			results[n] = r
 		}
 		return results, nil
 	}

--- a/expr/functions/timeShiftByMetric/function.go
+++ b/expr/functions/timeShiftByMetric/function.go
@@ -82,12 +82,12 @@ func (f *timeShiftByMetric) applyShift(params *callParams, offsets offsetByVersi
 
 		// checking if it is some version after all, otherwise this series will be omitted
 		if offsetIsSet {
-			r := *metric
+			r := metric.CopyLinkTags()
 			r.Name = "timeShiftByMetric(" + r.Name + ")"
 			r.StopTime += offset
 			r.StartTime += offset
 
-			result = append(result, &r)
+			result = append(result, r)
 		}
 	}
 


### PR DESCRIPTION
Several functions were still modifying the original series input, instead of making a copy before processing the data. This can lead to no-copy-on write bugs. This PR updates the remaining functions that were using `r := *a`, instead using `r := a.CopyLinkTags()`. 