### PR TITLE
Handle default arguments and number of arguments to avoid errors

### DIFF
--- a/expr/functions/aggregateLine/function.go
+++ b/expr/functions/aggregateLine/function.go
@@ -41,12 +41,12 @@ func (f *aggregateLine) Do(ctx context.Context, e parser.Expr, from, until int64
 	keepStep := false
 	switch e.ArgsLen() {
 	case 2:
-		callback, err = e.GetStringArg(1)
+		callback, err = e.GetStringArgDefault(1, "average")
 		if err != nil {
 			return nil, err
 		}
 	case 3:
-		callback, err = e.GetStringArg(1)
+		callback, err = e.GetStringArgDefault(1, "average")
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/aggregateSeriesLists/function.go
+++ b/expr/functions/aggregateSeriesLists/function.go
@@ -29,6 +29,10 @@ func New(_ string) []interfaces.FunctionMetadata {
 }
 
 func (f *aggregateSeriesLists) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 3 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	seriesList1, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/aggregateWithWildcards/function.go
+++ b/expr/functions/aggregateWithWildcards/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aggregateWithWildcards) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 3 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/aggregateWithWildcards/function.go
+++ b/expr/functions/aggregateWithWildcards/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aggregateWithWildcards) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	if e.ArgsLen() < 3 {
+	if e.ArgsLen() < 2 {
 		return nil, parser.ErrMissingArgument
 	}
 

--- a/expr/functions/alias/function.go
+++ b/expr/functions/alias/function.go
@@ -28,6 +28,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *alias) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/aliasByNode/function.go
+++ b/expr/functions/aliasByNode/function.go
@@ -27,6 +27,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aliasByNode) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/aliasByPostgres/function.go
+++ b/expr/functions/aliasByPostgres/function.go
@@ -150,6 +150,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aliasByPostgres) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 4 {
+		return nil, parser.ErrMissingTimeseries
+	}
+
 	logger := zapwriter.Logger("functionInit").With(zap.String("function", "aliasByPostgres"))
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {

--- a/expr/functions/aliasSub/function.go
+++ b/expr/functions/aliasSub/function.go
@@ -29,6 +29,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aliasSub) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 3 {
+		return nil, parser.ErrMissingTimeseries
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/averageOutsidePercentile/function.go
+++ b/expr/functions/averageOutsidePercentile/function.go
@@ -29,6 +29,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // averageOutsidePercentile(seriesList, n)
 func (f *averageOutsidePercentile) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/below/function.go
+++ b/expr/functions/below/function.go
@@ -31,6 +31,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // averageAbove(seriesList, n), averageBelow(seriesList, n), currentAbove(seriesList, n), currentBelow(seriesList, n), maximumAbove(seriesList, n), maximumBelow(seriesList, n), minimumAbove(seriesList, n), minimumBelow
 func (f *below) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/consolidateBy/function.go
+++ b/expr/functions/consolidateBy/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // consolidateBy(seriesList, aggregationMethod)
 func (f *consolidateBy) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/delay/function.go
+++ b/expr/functions/delay/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // delay(seriesList, steps)
 func (f *delay) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	seriesList, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/ewma/function.go
+++ b/expr/functions/ewma/function.go
@@ -31,6 +31,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // ewma(seriesList, alpha)
 func (f *ewma) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/exclude/function.go
+++ b/expr/functions/exclude/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // exclude(seriesList, pattern)
 func (f *exclude) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/filter/function.go
+++ b/expr/functions/filter/function.go
@@ -39,6 +39,10 @@ var supportedOperators = map[string]struct{}{
 
 // filterSeries(*seriesLists)
 func (f *filterSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 4 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/grep/function.go
+++ b/expr/functions/grep/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // grep(seriesList, pattern)
 func (f *grep) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/groupByNode/function.go
+++ b/expr/functions/groupByNode/function.go
@@ -32,6 +32,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // groupByNode(seriesList, nodeNum, callback)
 // groupByNodes(seriesList, callback, *nodes)
 func (f *groupByNode) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/groupByTags/function.go
+++ b/expr/functions/groupByTags/function.go
@@ -32,6 +32,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // seriesByTag("name=cpu")|groupByTags("average","dc","os")
 func (f *groupByTags) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 3 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/highestLowest/function.go
+++ b/expr/functions/highestLowest/function.go
@@ -68,7 +68,7 @@ func (f *highest) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 			if err != nil {
 				// We need to support case where only function specified
 				n = 1
-				consolidation, err = e.GetStringArg(1)
+				consolidation, err = e.GetStringArgDefault(1, "average")
 				if err != nil {
 					return nil, err
 				}
@@ -79,7 +79,7 @@ func (f *highest) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 			if err != nil {
 				return nil, err
 			}
-			consolidation, err = e.GetStringArg(2)
+			consolidation, err = e.GetStringArgDefault(2, "average")
 
 			if err != nil {
 				return nil, err

--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -35,6 +35,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // hitcount(seriesList, intervalString, alignToInterval=False)
 func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/integralByInterval/function.go
+++ b/expr/functions/integralByInterval/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // integralByInterval(seriesList, intervalString)
 func (f *integralByInterval) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/legendValue/function.go
+++ b/expr/functions/legendValue/function.go
@@ -33,6 +33,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // legendValue(seriesList, newName)
 func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/limit/function.go
+++ b/expr/functions/limit/function.go
@@ -29,6 +29,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // limit(seriesList, n)
 func (f *limit) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/mapSeries/function.go
+++ b/expr/functions/mapSeries/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // mapSeries(seriesList, *mapNodes)
 // Alias: map
 func (f *mapSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/mostDeviant/function.go
+++ b/expr/functions/mostDeviant/function.go
@@ -32,6 +32,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // mostDeviant(seriesList, n) -or- mostDeviant(n, seriesList)
 func (f *mostDeviant) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	var nArg int
 	if !e.Arg(0).IsConst() {
 		// mostDeviant(seriesList, n)

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -67,6 +67,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // movingMedian(seriesList, windowSize)
 func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	var n int
 	var err error
 

--- a/expr/functions/nPercentile/function.go
+++ b/expr/functions/nPercentile/function.go
@@ -32,6 +32,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // nPercentile(seriesList, n)
 func (f *nPercentile) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/offset/function.go
+++ b/expr/functions/offset/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // offset(seriesList,factor)
 func (f *offset) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/percentileOfSeries/function.go
+++ b/expr/functions/percentileOfSeries/function.go
@@ -38,6 +38,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // percentileOfSeries(seriesList, n, interpolate=False)
 func (f *percentileOfSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/pow/function.go
+++ b/expr/functions/pow/function.go
@@ -31,6 +31,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // pow(seriesList,factor)
 func (f *pow) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+	
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/randomWalk/function.go
+++ b/expr/functions/randomWalk/function.go
@@ -28,7 +28,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 	return res
 }
 
-// squareRoot(seriesList)
+// randomWalk(name, step=60)
 func (f *randomWalk) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	name, err := e.GetStringArg(0)
 	if err != nil {

--- a/expr/functions/removeBetweenPercentile/function.go
+++ b/expr/functions/removeBetweenPercentile/function.go
@@ -32,6 +32,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // removeBetweenPercentile(seriesLists, percent)
 func (f *removeBetweenPercentile) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/scale/function.go
+++ b/expr/functions/scale/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // scale(seriesList, factor)
 func (f *scale) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/scaleToSeconds/function.go
+++ b/expr/functions/scaleToSeconds/function.go
@@ -30,6 +30,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // scaleToSeconds(seriesList, seconds)
 func (f *scaleToSeconds) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+	
 	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/setXFilesFactor/function.go
+++ b/expr/functions/setXFilesFactor/function.go
@@ -29,6 +29,10 @@ func New(_ string) []interfaces.FunctionMetadata {
 
 // setXFilesFactor(seriesList, xFilesFactor)
 func (f *setXFilesFactor) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -34,6 +34,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // smartSummarize(seriesList, intervalString, alignToInterval=False)
 func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/stdev/function.go
+++ b/expr/functions/stdev/function.go
@@ -29,6 +29,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // stdev(seriesList, points, missingThreshold=0.1)
 // Alias: stddev
 func (f *stdev) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err

--- a/expr/functions/timeShift/function.go
+++ b/expr/functions/timeShift/function.go
@@ -75,6 +75,9 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // timeShift(seriesList, timeShift, resetEnd=True)
 func (f *timeShift) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// FIXME(civil): support alignDst
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
 
 	offs, err := e.GetIntervalArg(1, -1)
 	if err != nil {

--- a/expr/functions/timeSlice/function.go
+++ b/expr/functions/timeSlice/function.go
@@ -31,6 +31,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *timeSlice) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	start32, err := e.GetIntervalArg(1, -1)
 	if err != nil {
 		return nil, err

--- a/expr/functions/timeStack/function.go
+++ b/expr/functions/timeStack/function.go
@@ -37,12 +37,12 @@ func (f *timeStack) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	}
 	unitStr := e.Arg(1).StringValue()
 
-	start, err := e.GetIntArg(2)
+	start, err := e.GetIntArgDefault(2, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	end, err := e.GetIntArg(3)
+	end, err := e.GetIntArgDefault(3, 7)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/weightedAverage/function.go
+++ b/expr/functions/weightedAverage/function.go
@@ -31,6 +31,10 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // weightedAverage(seriesListAvg, seriesListWeight, *nodes)
 func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
 	aggKeyPairs := make(map[string]map[string]*types.MetricData)
 	var productList []*types.MetricData
 


### PR DESCRIPTION
This PR adds checks for the number of arguments passed into a function, verifying that it meets the minimal number that the function can accept, and adds default arguments for functions that have those. This was based off of the function definitions defined in the [Graphite web documentation](https://graphite.readthedocs.io/en/latest/functions.html#). This should help prevent errors with indices, and properly handle default arguments in functions that have them.