### PR TITLE
holtWinters: fix panic on small season lengths

### DIFF
--- a/expr/functions/holtWintersConfidenceBands/function_test.go
+++ b/expr/functions/holtWintersConfidenceBands/function_test.go
@@ -1,0 +1,39 @@
+package holtWintersConfidenceBands
+
+import (
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestNoPanicOnBigStep(t *testing.T) {
+
+	// NOTE: the expected values of this test are not meaningful, its purpose is to reproduce a panic
+	test := th.EvalTestItem{
+		"holtWintersConfidenceBands(metric1,3)",
+		map[parser.MetricRequest][]*types.MetricData{
+			{"metric1", -604800, 1}: {types.MakeMetricData("metric1", []float64{1}, 604800, -604800)},
+		},
+		[]*types.MetricData{
+			types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{}, 604800, 0).SetTag("holtWintersConfidenceLower", "1"),
+			types.MakeMetricData("holtWintersConfidenceUpper(metric1)", []float64{}, 604800, 0).SetTag("holtWintersConfidenceUpper", "1"),
+		},
+	}
+
+	th.TestEvalExpr(t, &test)
+
+}

--- a/expr/holtwinters/hw.go
+++ b/expr/holtwinters/hw.go
@@ -37,6 +37,12 @@ func HoltWintersAnalysis(series []float64, step int64) ([]float64, []float64) {
 	// season is currently one day
 	seasonLength := 24 * 60 * 60 / int(step)
 
+	// seasonLength needs to be at least 2, so we force it
+	// GraphiteWeb has the same problem, still needs fixing https://github.com/graphite-project/graphite-web/issues/2780
+	if seasonLength < 2 {
+		seasonLength = 2
+	}
+
 	var (
 		intercepts  []float64
 		slopes      []float64
@@ -125,7 +131,7 @@ func HoltWintersConfidenceBands(series []float64, step int64, delta float64, day
 
 	var (
 		predictionsOfInterest []float64
-		deviationsOfInterest []float64
+		deviationsOfInterest  []float64
 	)
 	if len(predictions) < windowPoints || len(deviations) < windowPoints {
 		predictionsOfInterest = predictions


### PR DESCRIPTION
We found this panic in `HoltWintersAnalysis`

```
runtime error: index out of range [0] with length 0\", stack='\"goroutine .. [running]
```

after some debugging I found where it was coming from: a big step in a series was causing a very small `seasonLength`, which was invalid for the `HoltWintersAnalysis` function.  I also noted GraphiteWeb has this bug too, so I filed an issue there https://github.com/graphite-project/graphite-web/issues/2780 (I left more details about the problem there).

The fix I propose here is to force `seasonLength` to be at least `2`, but we can see what GraphiteWeb's maintainers propose and match their decision later.



