### PR TITLE
Add support for Graphite web holtWintersConfidenceArea

### DIFF
--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -46,6 +46,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/functions/highestLowest"
 	"github.com/go-graphite/carbonapi/expr/functions/hitcount"
 	"github.com/go-graphite/carbonapi/expr/functions/holtWintersAberration"
+	"github.com/go-graphite/carbonapi/expr/functions/holtWintersConfidenceArea"
 	"github.com/go-graphite/carbonapi/expr/functions/holtWintersConfidenceBands"
 	"github.com/go-graphite/carbonapi/expr/functions/holtWintersForecast"
 	"github.com/go-graphite/carbonapi/expr/functions/identity"
@@ -170,6 +171,7 @@ func New(configs map[string]string) {
 		{name: "highestLowest", filename: "highestLowest", order: highestLowest.GetOrder(), f: highestLowest.New},
 		{name: "hitcount", filename: "hitcount", order: hitcount.GetOrder(), f: hitcount.New},
 		{name: "holtWintersAberration", filename: "holtWintersAberration", order: holtWintersAberration.GetOrder(), f: holtWintersAberration.New},
+		{name: "holtWintersConfidenceArea", filename: "holtWintersConfidenceArea", order: holtWintersConfidenceArea.GetOrder(), f: holtWintersConfidenceArea.New},
 		{name: "holtWintersConfidenceBands", filename: "holtWintersConfidenceBands", order: holtWintersConfidenceBands.GetOrder(), f: holtWintersConfidenceBands.New},
 		{name: "holtWintersForecast", filename: "holtWintersForecast", order: holtWintersForecast.GetOrder(), f: holtWintersForecast.New},
 		{name: "identity", filename: "identity", order: identity.GetOrder(), f: identity.New},

--- a/expr/functions/holtWintersConfidenceArea/function.go
+++ b/expr/functions/holtWintersConfidenceArea/function.go
@@ -1,0 +1,73 @@
+//go:build !cairo
+// +build !cairo
+
+package holtWintersConfidenceArea
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+)
+
+var UnsupportedError = fmt.Errorf("must build w/ cairo support")
+
+type holtWintersConfidenceArea struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(_ string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+
+	f := &holtWintersConfidenceArea{}
+	functions := []string{"holtWintersConfidenceArea"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+
+	return res
+}
+
+func (f *holtWintersConfidenceArea) Do(_ context.Context, _ parser.Expr, _, _ int64, _ map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	return nil, UnsupportedError
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *holtWintersConfidenceArea) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"holtWintersConfidenceArea": {
+			Description: "Performs a Holt-Winters forecast using the series as input data and plots\n the area between the upper and lower bands of the predicted forecast deviations.",
+			Function:    "holtWintersConfidenceArea(seriesList, delta=3, bootstrapInterval='7d')",
+			Group:       "Calculate",
+			Module:      "graphite.render.functions",
+			Name:        "holtWintersConfidenceArea",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Default: types.NewSuggestion(3),
+					Name:    "delta",
+					Type:    types.Integer,
+				},
+				{
+					Default: types.NewSuggestion("7d"),
+					Name:    "bootstrapInterval",
+					Suggestions: types.NewSuggestions(
+						"7d",
+						"30d",
+					),
+					Type: types.Interval,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/holtWintersConfidenceArea/function_cairo.go
+++ b/expr/functions/holtWintersConfidenceArea/function_cairo.go
@@ -1,0 +1,135 @@
+//go:build cairo
+// +build cairo
+
+package holtWintersConfidenceArea
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/holtwinters"
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+)
+
+type holtWintersConfidenceArea struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &holtWintersConfidenceArea{}
+	functions := []string{"holtWintersConfidenceArea"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, 7*86400)
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from-bootstrapInterval, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	delta, err := e.GetFloatNamedOrPosArgDefault("delta", 1, 3)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]*types.MetricData, 0, len(args)*2)
+	for _, arg := range args {
+		stepTime := arg.StepTime
+
+		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(arg.Values, stepTime, delta, bootstrapInterval/86400)
+
+		lowerSeries := types.MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:              fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
+				Values:            lowerBand,
+				StepTime:          arg.StepTime,
+				StartTime:         arg.StartTime + bootstrapInterval,
+				StopTime:          arg.StopTime,
+				ConsolidationFunc: arg.ConsolidationFunc,
+				XFilesFactor:      arg.XFilesFactor,
+				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
+			},
+			Tags: helper.CopyTags(arg),
+			GraphOptions: types.GraphOptions{
+				Stacked:   true,
+				StackName: types.DefaultStackName,
+				Invisible: true,
+			},
+		}
+		lowerSeries.Tags["holtWintersConfidenceArea"] = "1"
+
+		upperSeries := types.MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:              fmt.Sprintf("holtWintersConfidenceUpper(%s)", arg.Name),
+				Values:            upperBand,
+				StepTime:          arg.StepTime,
+				StartTime:         arg.StartTime + bootstrapInterval,
+				StopTime:          arg.StopTime,
+				ConsolidationFunc: arg.ConsolidationFunc,
+				XFilesFactor:      arg.XFilesFactor,
+				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
+			},
+			Tags: helper.CopyTags(arg),
+			GraphOptions: types.GraphOptions{
+				Stacked:   true,
+				StackName: types.DefaultStackName,
+			},
+		}
+
+		upperSeries.Tags["holtWintersConfidenceArea"] = "1"
+
+		results = append(results, &lowerSeries, &upperSeries)
+	}
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *holtWintersConfidenceArea) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"holtWintersConfidenceArea": {
+			Description: "Performs a Holt-Winters forecast using the series as input data and plots\n the area between the upper and lower bands of the predicted forecast deviations.",
+			Function:    "holtWintersConfidenceArea(seriesList, delta=3, bootstrapInterval='7d')",
+			Group:       "Calculate",
+			Module:      "graphite.render.functions",
+			Name:        "holtWintersConfidenceArea",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Default: types.NewSuggestion(3),
+					Name:    "delta",
+					Type:    types.Integer,
+				},
+				{
+					Default: types.NewSuggestion("7d"),
+					Name:    "bootstrapInterval",
+					Suggestions: types.NewSuggestions(
+						"7d",
+						"30d",
+					),
+					Type: types.Interval,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/holtWintersConfidenceArea/function_test.go
+++ b/expr/functions/holtWintersConfidenceArea/function_test.go
@@ -1,0 +1,65 @@
+//go:build cairo
+// +build cairo
+
+package holtWintersConfidenceArea
+
+import (
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestHoltWintersConfidenceArea(t *testing.T) {
+	var startTime int64 = 2678400
+	var step int64 = 600
+	var points int64 = 10
+	var weekSeconds int64 = 7 * 86400
+
+	seriesValues := generateHwRange(0, ((weekSeconds/step)+points)*step, step)
+
+	tests := []th.EvalTestItemWithRange{
+		{
+			Target: "holtWintersConfidenceArea(metric1)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", startTime - weekSeconds, startTime + step*points}: {types.MakeMetricData("metric1", seriesValues, step, startTime-weekSeconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{0.2841206166091448, 1.0581027098774411, 0.3338172102994683, 0.5116859493263242, -0.18199175514936972, 0.2366173792019426, -1.2941554508809152, -0.513426806531049, -0.7970905542723132, 0.09868900726536012}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
+				types.MakeMetricData("holtWintersConfidenceUpper(metric1)", []float64{8.424944558327624, 9.409422251880809, 10.607070189221787, 10.288439865038768, 9.491556863132963, 9.474595784593738, 8.572310478053845, 8.897670449095346, 8.941566968508148, 9.409728797779282}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
+		})
+	}
+}
+
+func generateHwRange(x, y, jump int64) []float64 {
+	var valuesList []float64
+	for x < y {
+		val := float64((x / jump) % 10)
+		valuesList = append(valuesList, val)
+		x += jump
+	}
+	return valuesList
+}


### PR DESCRIPTION
This PR adds support for the Graphite web holtWintersConfidenceArea function. This function is defined in the [Graphite web documentation](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.holtWintersConfidenceArea) as:

```
holtWintersConfidenceArea(seriesList, delta=3, bootstrapInterval='7d', seasonality='1d')
Performs a Holt-Winters forecast using the series as input data and plots the area between the upper and lower bands of the predicted forecast deviations.
```

For reference, this function is implemented in Graphite web [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L4242).

This PR also adds a test matching the holtWintersConfidenceArea test in [Graphite web.](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/tests/test_functions.py#L5442)