### PR TITLE
Fix ConsolidationFunc setting

### DIFF
--- a/expr/functions/consolidateBy/function.go
+++ b/expr/functions/consolidateBy/function.go
@@ -48,7 +48,7 @@ func (f *consolidateBy) Do(ctx context.Context, e parser.Expr, from, until int64
 	for i, a := range arg {
 		r := a.CopyLink()
 
-		r.AggregateFunction = consolidations.ConsolidationToFunc[name]
+		r.ConsolidationFunc = name
 		r.Tags["consolidateBy"] = name
 		results[i] = r
 	}

--- a/expr/functions/cumulative/function.go
+++ b/expr/functions/cumulative/function.go
@@ -3,7 +3,6 @@ package cumulative
 import (
 	"context"
 
-	"github.com/go-graphite/carbonapi/expr/consolidations"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
@@ -38,7 +37,7 @@ func (f *cumulative) Do(ctx context.Context, e parser.Expr, from, until int64, v
 
 	for i, a := range arg {
 		r := a.CopyLinkTags()
-		r.AggregateFunction = consolidations.AggSum
+		r.ConsolidationFunc = "sum"
 		results[i] = r
 	}
 	return results, nil


### PR DESCRIPTION
We noticed some functions were setting the `r.AggregateFunction` directly instead of the string `r.ConsolidationFunc` that is then used in the `GetAggregateFunction` helper:

https://github.com/go-graphite/carbonapi/blob/30a090756e199c9d588499972268c4ebbb22a4e9/expr/types/types.go#L299-L310

This was leading to inconsistencies between `ConsolidationFunc` and `AggregateFunction` that were causing issues for our use case.