### PR TITLE
Fix inconsistencies in timeSlice function and add test

### DIFF
--- a/expr/functions/timeSlice/function.go
+++ b/expr/functions/timeSlice/function.go
@@ -2,14 +2,12 @@ package timeSlice
 
 import (
 	"context"
-	"math"
-	"strconv"
-	"time"
-
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
+	"math"
+	"strconv"
 )
 
 type timeSlice struct {
@@ -35,19 +33,16 @@ func (f *timeSlice) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		return nil, parser.ErrMissingArgument
 	}
 
-	start32, err := e.GetIntervalArg(1, -1)
+	start32, err := e.GetIntervalArg(1, 1)
 	if err != nil {
 		return nil, err
 	}
 	start := int64(start32)
 
-	end, err := e.GetIntervalNamedOrPosArgDefault("endSliceAt", 2, -1, 0)
+	end, err := e.GetIntervalNamedOrPosArgDefault("endSliceAt", 2, 1, 0)
 	if err != nil {
 		return nil, err
 	}
-	now := time.Now().Unix()
-	start += now
-	end += now
 
 	startStr := strconv.FormatInt(start, 10)
 	endStr := strconv.FormatInt(end, 10)

--- a/expr/functions/timeSlice/function_test.go
+++ b/expr/functions/timeSlice/function_test.go
@@ -1,0 +1,46 @@
+package timeSlice
+
+import (
+	"math"
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestTimeSlice(t *testing.T) {
+	var startTime int64 = 0
+
+	tests := []th.EvalTestItemWithRange{
+		{
+			Target: `timeSlice(metric1, "3m", "8m")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: startTime, Until: startTime + 11*60}: {types.MakeMetricData("metric1", []float64{math.NaN(), 1, 2, 3, math.NaN(), 5, 6, math.NaN(), 7, 8, 9}, 60, startTime)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("timeSlice(metric1,180,480)",
+				[]float64{math.NaN(), math.NaN(), math.NaN(), 3, math.NaN(), 5, 6, math.NaN(), 7, math.NaN(), math.NaN()}, 60, startTime).SetTags(map[string]string{"name": "metric1", "timeSliceStart": "180", "timeSliceEnd": "480"})},
+			From:  startTime,
+			Until: startTime + 11*60,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes some discrepancies between CarbonAPI's  and Graphite web's implementation of the timeSlice function.

Graphite web's timeSlice function is defined in the [documentation](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.timeSlice) as:

```
timeSlice(seriesList, startSliceAt, endSliceAt='now')
Takes one metric or a wildcard metric, followed by a quoted string with the time to start the line and another quoted string with the time to end the line. The start and end times are inclusive. See from / until in the [Render API](https://graphite.readthedocs.io/en/latest/render_api.html) for examples of time formats.

Useful for filtering out a part of a series of data from a wider range of data.

Example:

&target=timeSlice(network.core.port1,"00:00 20140101","11:59 20140630")
&target=timeSlice(network.core.port1,"12:00 20140630","now")
```

Graphite web's implementation can be found [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L4571).

The previous implementation of this function involved some bugs, including the use of time.Now() to calculate start and end times, and the default sign for the interval arguments being set to negative. These are inconsistent with the Graphite web implementation. Additionally, a test was missing. A test matching the one[ in Graphite web](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/tests/test_functions.py#L4229) has been added. 