### PR TITLE
Reduce allocations on moving functions

### DIFF
--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -114,20 +114,20 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		return arg, nil
 	}
 
-	if len(e.Args()) >= 3 && e.Target() == "movingWindow" {
+	if e.ArgsLen() >= 3 && e.Target() == "movingWindow" {
 		cons, err = e.GetStringArgDefault(2, "average")
 		if err != nil {
 			return nil, err
 		}
 
-		if len(e.Args()) == 4 {
+		if e.ArgsLen() == 4 {
 			xFilesFactor, err = e.GetFloatArgDefault(3, float64(arg[0].XFilesFactor))
 
 			if err != nil {
 				return nil, err
 			}
 		}
-	} else if len(e.Args()) == 3 {
+	} else if e.ArgsLen() == 3 {
 		xFilesFactor, err = e.GetFloatArgDefault(2, float64(arg[0].XFilesFactor))
 
 		if err != nil {


### PR DESCRIPTION
```
carbonapi]$ go test -benchmem -run=^$ -bench ^BenchmarkMoving$ github.com/go-graphite/carbonapi/expr/functions/moving

carbonapi]$ benchcmp moving1.txt moving2.txt 
benchmark                                         old ns/op     new ns/op     delta
BenchmarkMoving/movingAverage(metric1,'5s')-6     668           544           -18.56%
BenchmarkMoving/movingAverage(metric1,4)-6        10490         9962          -5.03%
BenchmarkMoving/movingAverage(metric1,2)-6        10496         9968          -5.03%
BenchmarkMoving/movingSum(metric1,2)-6            14357         13337         -7.10%
BenchmarkMoving/movingMin(metric1,2)-6            16463         16067         -2.41%
BenchmarkMoving/movingMax(metric1,2)-6            15480         15248         -1.50%
BenchmarkMoving/movingAverage(metric1,600)-6      10763         10558         -1.90%
BenchmarkMoving/movingSum(metric1,600)-6          14148         13979         -1.19%
BenchmarkMoving/movingMin(metric1,600)-6          592046        591812        -0.04%
BenchmarkMoving/movingMax(metric1,600)-6          597204        595307        -0.32%

benchmark                                         old allocs     new allocs     delta
BenchmarkMoving/movingAverage(metric1,'5s')-6     9              7              -22.22%
BenchmarkMoving/movingAverage(metric1,4)-6        9              7              -22.22%
BenchmarkMoving/movingAverage(metric1,2)-6        9              7              -22.22%
BenchmarkMoving/movingSum(metric1,2)-6            9              7              -22.22%
BenchmarkMoving/movingMin(metric1,2)-6            9              7              -22.22%
BenchmarkMoving/movingMax(metric1,2)-6            9              7              -22.22%
BenchmarkMoving/movingAverage(metric1,600)-6      10             8              -20.00%
BenchmarkMoving/movingSum(metric1,600)-6          10             8              -20.00%
BenchmarkMoving/movingMin(metric1,600)-6          10             8              -20.00%
BenchmarkMoving/movingMax(metric1,600)-6          10             8              -20.00%

benchmark                                         old bytes     new bytes     delta
BenchmarkMoving/movingAverage(metric1,'5s')-6     660           596           -9.70%
BenchmarkMoving/movingAverage(metric1,4)-6        8848          8784          -0.72%
BenchmarkMoving/movingAverage(metric1,2)-6        8832          8768          -0.72%
BenchmarkMoving/movingSum(metric1,2)-6            8832          8768          -0.72%
BenchmarkMoving/movingMin(metric1,2)-6            8832          8768          -0.72%
BenchmarkMoving/movingMax(metric1,2)-6            8832          8768          -0.72%
BenchmarkMoving/movingAverage(metric1,600)-6      13691         13627         -0.47%
BenchmarkMoving/movingSum(metric1,600)-6          13683         13619         -0.47%
BenchmarkMoving/movingMin(metric1,600)-6          13683         13619         -0.47%
BenchmarkMoving/movingMax(metric1,600)-6          13683         13619         -0.47%

```