### PR TITLE
Support 'step' argument in randomWalk

### DIFF
--- a/expr/functions/randomWalk/function.go
+++ b/expr/functions/randomWalk/function.go
@@ -34,14 +34,20 @@ func (f *randomWalk) Do(ctx context.Context, e parser.Expr, from, until int64, v
 	if err != nil {
 		name = "randomWalk"
 	}
+	stepInt, err := e.GetIntNamedOrPosArgDefault("step", 1, 60)
+	if err != nil {
+		return nil, err
+	}
+	step := int64(stepInt)
 
-	size := until - from
+	size := (until - from) / step
+	until = from + step*size // Re-compute 'until' in case 'size' is a not a divisor of the range
 
 	r := types.MetricData{
 		FetchResponse: pb.FetchResponse{
 			Name:              name,
 			Values:            make([]float64, size),
-			StepTime:          1,
+			StepTime:          step,
 			StartTime:         from,
 			StopTime:          until,
 			ConsolidationFunc: "average",

--- a/expr/functions/randomWalk/function_test.go
+++ b/expr/functions/randomWalk/function_test.go
@@ -1,0 +1,87 @@
+package randomWalk
+
+import (
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestRandomWalk(t *testing.T) {
+	tests := []th.EvalTestItemWithCustomValidation{
+		{
+			Target: "randomWalk('foo')",
+			M:      map[parser.MetricRequest][]*types.MetricData{},
+			From:   0,
+			Until:  120,
+			Validator: func(t *testing.T, md []*types.MetricData) {
+				assert.Equal(t, 1, len(md))
+				m := md[0]
+				assert.Equal(t, "foo", m.Name)
+				assert.Equal(t, int64(60), m.StepTime)
+				assert.Equal(t, 2, len(m.Values))
+			},
+		},
+		{
+			Target: "randomWalk('foo', step=3)",
+			M:      map[parser.MetricRequest][]*types.MetricData{},
+			From:   0,
+			Until:  120,
+			Validator: func(t *testing.T, md []*types.MetricData) {
+				assert.Equal(t, 1, len(md))
+				m := md[0]
+				assert.Equal(t, "foo", m.Name)
+				assert.Equal(t, int64(3), m.StepTime)
+				assert.Equal(t, 40, len(m.Values))
+			},
+		},
+		{
+			Target: "randomWalk('foo', 4)",
+			M:      map[parser.MetricRequest][]*types.MetricData{},
+			From:   0,
+			Until:  120,
+			Validator: func(t *testing.T, md []*types.MetricData) {
+				assert.Equal(t, 1, len(md))
+				m := md[0]
+				assert.Equal(t, "foo", m.Name)
+				assert.Equal(t, int64(4), m.StepTime)
+				assert.Equal(t, 30, len(m.Values))
+			},
+		},
+		{
+			Target: "randomWalk('foo', 5)",
+			M:      map[parser.MetricRequest][]*types.MetricData{},
+			From:   0,
+			Until:  121, // Should be rounded to 120
+			Validator: func(t *testing.T, md []*types.MetricData) {
+				assert.Equal(t, 1, len(md))
+				m := md[0]
+				assert.Equal(t, "foo", m.Name)
+				assert.Equal(t, int64(5), m.StepTime)
+				assert.Equal(t, 24, len(m.Values))
+				assert.Equal(t, int64(120), m.StopTime)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithCustomValidation(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
Title says it all. Here's `randomWalk`'s docs: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.randomWalkFunction

```

randomWalkFunction(name, step=60)

    Short Alias: randomWalk()

    Returns a random walk starting at 0. This is great for testing when there is no real data in whisper.

    Example:

    &target=randomWalk("The.time.series")

    This would create a series named “The.time.series” that contains points where x(t) == x(t-1)+random()-0.5, and x(0) == 0. Accepts optional second argument as ‘step’ parameter (default step is 60 sec)

```