### PR TITLE
Fix error handling in helper.ForEachSeriesDo

### DIFF
--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -121,8 +121,9 @@ type seriesFunc1 func(*types.MetricData) *types.MetricData
 func ForEachSeriesDo1(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData, function seriesFunc1) ([]*types.MetricData, error) {
 	arg, err := GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
-		return nil, parser.ErrMissingTimeseries
+		return nil, err
 	}
+
 	var results []*types.MetricData
 
 	for _, a := range arg {
@@ -137,8 +138,9 @@ type seriesFunc func(*types.MetricData, *types.MetricData) *types.MetricData
 func ForEachSeriesDo(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData, function seriesFunc) ([]*types.MetricData, error) {
 	arg, err := GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
-		return nil, parser.ErrMissingTimeseries
+		return nil, err
 	}
+
 	var results []*types.MetricData
 
 	for _, a := range arg {


### PR DESCRIPTION
This PR addresses an issue in helper.ForEachSeriesDo and helper.ForEachSeriesDo1 in which an error returned by GetSeriesArg was ignored, and an ErrMissingTimeSeries error was returned in all cases. This can mask the real cause of the error. GetSeriesArg will return an ErrMissingTimeSeries or the appropriate error from evaluating the expression, so ForEachSeriesDo should return the error that GetSeriesArg returns, and not hard-code the error type as ErrMissingTimeSeries. An example of where the true error could be masked is if the argument is a nested function that contains a parameter that is an invalid type. In this case, an ErrBadType should be returned.