### PR TITLE
Fix smartSummarize alignTo interval handling to match Graphite web

### DIFF
--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -70,7 +70,8 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 	start := args[0].StartTime
 	stop := args[0].StopTime
 	if alignToInterval != "" {
-		interval, err := parser.IntervalString(alignToInterval, 1)
+		alignTo := "1" + alignToInterval // Add a 1 before the alignTo interval, so that IntervalString properly parses it
+		interval, err := parser.IntervalString(alignTo, 1)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -70,7 +70,12 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 	start := args[0].StartTime
 	stop := args[0].StopTime
 	if alignToInterval != "" {
-		alignTo := "1" + alignToInterval // Add a 1 before the alignTo interval, so that IntervalString properly parses it
+		var alignTo string
+		if !parser.IsDigit(alignToInterval[0]) {
+			alignTo = "1" + alignToInterval // Add a 1 before the alignTo interval, so that IntervalString properly parses it
+		} else {
+			alignTo = alignToInterval
+		}
 		interval, err := parser.IntervalString(alignTo, 1)
 		if err != nil {
 			return nil, err

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -43,6 +43,17 @@ func TestSummarizeEmptyData(t *testing.T) {
 func TestEvalSummarize(t *testing.T) {
 	tests := []th.SummarizeEvalTestItem{
 		{
+			"smartSummarize(metric1,'1hour','sum','1y')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 1800+3.5*3600, 1), 1, 0)},
+			},
+			[]float64{6478200, 19438200, 32398200, 45358200},
+			"smartSummarize(metric1,'1hour','sum','1y')",
+			3600,
+			0,
+			14400,
+		},
+		{
 			"smartSummarize(metric1,'1hour','sum','y')",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 1800+3.5*3600, 1), 1, 0)},
@@ -60,6 +71,17 @@ func TestEvalSummarize(t *testing.T) {
 			},
 			[]float64{6478200, 19438200, 32398200, 45358200},
 			"smartSummarize(metric1,'1hour','sum','month')",
+			3600,
+			0,
+			14400,
+		},
+		{
+			"smartSummarize(metric1,'1hour','sum','1month')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 1800+3.5*3600, 1), 1, 0)},
+			},
+			[]float64{6478200, 19438200, 32398200, 45358200},
+			"smartSummarize(metric1,'1hour','sum','1month')",
 			3600,
 			0,
 			14400,
@@ -71,6 +93,17 @@ func TestEvalSummarize(t *testing.T) {
 			},
 			[]float64{1770, 5370, 8970, 12570},
 			"smartSummarize(metric1,'1minute','sum','minute')",
+			60,
+			0,
+			240,
+		},
+		{
+			"smartSummarize(metric1,'1minute','sum','1minute')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+			},
+			[]float64{1770, 5370, 8970, 12570},
+			"smartSummarize(metric1,'1minute','sum','1minute')",
 			60,
 			0,
 			240,

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -43,57 +43,56 @@ func TestSummarizeEmptyData(t *testing.T) {
 func TestEvalSummarize(t *testing.T) {
 	tests := []th.SummarizeEvalTestItem{
 		{
-			"smartSummarize(metric1,'1hour','sum','1y')",
+			"smartSummarize(metric1,'1hour','sum','y')",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 1800+3.5*3600, 1), 1, 0)},
 			},
 			[]float64{6478200, 19438200, 32398200, 45358200},
-			"smartSummarize(metric1,'1hour','sum','1y')",
+			"smartSummarize(metric1,'1hour','sum','y')",
 			3600,
 			0,
 			14400,
 		},
 		{
-			"smartSummarize(metric1,'1hour','sum','1month')",
+			"smartSummarize(metric1,'1hour','sum','month')",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 1800+3.5*3600, 1), 1, 0)},
 			},
 			[]float64{6478200, 19438200, 32398200, 45358200},
-			"smartSummarize(metric1,'1hour','sum','1month')",
+			"smartSummarize(metric1,'1hour','sum','month')",
 			3600,
 			0,
 			14400,
 		},
 		{
-			"smartSummarize(metric1,'1minute','sum','1minute')",
+			"smartSummarize(metric1,'1minute','sum','minute')",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			[]float64{1770, 5370, 8970, 12570},
-			"smartSummarize(metric1,'1minute','sum','1minute')",
+			"smartSummarize(metric1,'1minute','sum','minute')",
 			60,
 			0,
 			240,
 		},
 		{
-			"smartSummarize(metric1,'1minute','avg','1minute')",
+			"smartSummarize(metric1,'1minute','avg','minute')",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			[]float64{29.5, 89.5, 149.5, 209.5},
-			"smartSummarize(metric1,'1minute','avg','1minute')",
+			"smartSummarize(metric1,'1minute','avg','minute')",
 			60,
 			0,
 			240,
 		},
-
 		{
-			"smartSummarize(metric1,'1minute','last','1minute')",
+			"smartSummarize(metric1,'1minute','last','minute')",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			[]float64{59, 119, 179, 239},
-			"smartSummarize(metric1,'1minute','last','1minute')",
+			"smartSummarize(metric1,'1minute','last','minute')",
 			60,
 			0,
 			240,

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -574,7 +574,7 @@ func IsNameChar(r byte) bool {
 		r == '@'
 }
 
-func isDigit(r byte) bool {
+func IsDigit(r byte) bool {
 	return '0' <= r && r <= '9'
 }
 
@@ -687,7 +687,7 @@ func parseConst(s string) (float64, string, string, error) {
 	var i int
 	// All valid characters for a floating-point constant
 	// Just slurp them all in and let ParseFloat sort 'em out
-	for i < len(s) && (isDigit(s[i]) || s[i] == '.' || s[i] == '+' || s[i] == '-' || s[i] == 'e' || s[i] == 'E') {
+	for i < len(s) && (IsDigit(s[i]) || s[i] == '.' || s[i] == '+' || s[i] == '-' || s[i] == 'e' || s[i] == 'E') {
 		i++
 	}
 


### PR DESCRIPTION
The smartSummarize function is defined in the [Graphite web documentation](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.smartSummarize) as the following:

```
smartSummarize(seriesList, intervalString, func='sum', alignTo=None)
Smarter version of summarize.

The alignToFrom boolean parameter has been replaced by alignTo and no longer has any effect. **Alignment can be to years, months, weeks, days, hours, and minutes.**

This function can be used with aggregation functions average, median, sum, min, max, diff, stddev, count, range, multiply & last.
```

Note that the alignTo argument accepts values of "years", "months", "weeks", "days", "hours", and "minutes" (or their shortened version, such as "y", "m", "w", etc).  

Currently, CarbonAPI's version of smartSummarize uses the parser.GetIntervalString function, which requires an integer value to be preceding the time units (i.e. "1minute"). However, this does not align with the function's definition, or the [Graphite web implementation](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L5258) (see [here](https://github.com/graphite-project/graphite-web/blob/d6bda76332381a2ff8487efb46f386ad7c6e9bda/webapp/graphite/render/attime.py#L192) for the time parsing function). In order to align with Graphite web's behavior, smartSummarize has been modified to prepend a value of "1" before the interval string, in order to use parser.GetIntervalString without an error being returned because there is no preceding integer.