### PR TITLE
Avoid of alloc for func args copy

### DIFF
--- a/expr/functions/aggregateSeriesLists/function.go
+++ b/expr/functions/aggregateSeriesLists/function.go
@@ -33,11 +33,11 @@ func (f *aggregateSeriesLists) Do(ctx context.Context, e parser.Expr, from, unti
 		return nil, parser.ErrMissingArgument
 	}
 
-	seriesList1, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	seriesList1, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}
-	seriesList2, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
+	seriesList2, err := helper.GetSeriesArg(ctx, e.Arg(1), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/aggregateWithWildcards/function.go
+++ b/expr/functions/aggregateWithWildcards/function.go
@@ -34,7 +34,7 @@ func (f *aggregateWithWildcards) Do(ctx context.Context, e parser.Expr, from, un
 		return nil, parser.ErrMissingArgument
 	}
 
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/averageOutsidePercentile/function.go
+++ b/expr/functions/averageOutsidePercentile/function.go
@@ -33,7 +33,7 @@ func (f *averageOutsidePercentile) Do(ctx context.Context, e parser.Expr, from, 
 		return nil, parser.ErrMissingArgument
 	}
 
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/exp/function.go
+++ b/expr/functions/exp/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *exp) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/exponentialMovingAverage/function_test.go
+++ b/expr/functions/exponentialMovingAverage/function_test.go
@@ -1,6 +1,7 @@
 package exponentialMovingAverage
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -34,6 +35,15 @@ func TestExponentialMovingAverage(t *testing.T) {
 			},
 		},
 		{
+			"exponentialMovingAverage(metric1,'3s')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, startTime)},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("exponentialMovingAverage(metric1,\"3s\")", []float64{4, 6, 9, 11.5, 13.75, 15.875, 17.9375}, 1, 0).SetTag("exponentialMovingAverage", "3"),
+			},
+		},
+		{
 			// if the window is larger than the length of the values, the result should just be the average.
 			// this matches graphiteweb's behavior
 			"exponentialMovingAverage(metric1,100)",
@@ -52,5 +62,49 @@ func TestExponentialMovingAverage(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			th.TestEvalExpr(t, &tt)
 		})
+	}
+}
+
+func BenchmarkExponentialMovingAverage(b *testing.B) {
+	target := "exponentialMovingAverage(metric1,3)"
+	metrics := map[parser.MetricRequest][]*types.MetricData{
+		{"metric[1234]", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, 0)},
+	}
+
+	evaluator := metadata.GetEvaluator()
+	exp, _, err := parser.ParseExpr(target)
+	if err != nil {
+		b.Fatalf("failed to parse %s: %+v", target, err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		g, err := evaluator.Eval(context.Background(), exp, 0, 1, metrics)
+		if err != nil {
+			b.Fatalf("failed to eval %s: %+v", target, err)
+		}
+		_ = g
+	}
+}
+
+func BenchmarkExponentialMovingAverageStr(b *testing.B) {
+	target := "exponentialMovingAverage(metric1,'3s')"
+	metrics := map[parser.MetricRequest][]*types.MetricData{
+		{"metric[1234]", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, 0)},
+	}
+
+	evaluator := metadata.GetEvaluator()
+	exp, _, err := parser.ParseExpr(target)
+	if err != nil {
+		b.Fatalf("failed to parse %s: %+v", target, err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		g, err := evaluator.Eval(context.Background(), exp, 0, 1, metrics)
+		if err != nil {
+			b.Fatalf("failed to eval %s: %+v", target, err)
+		}
+		_ = g
 	}
 }

--- a/expr/functions/holtWintersConfidenceArea/function_cairo.go
+++ b/expr/functions/holtWintersConfidenceArea/function_cairo.go
@@ -39,7 +39,7 @@ func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from,
 		return nil, err
 	}
 
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from-bootstrapInterval, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from-bootstrapInterval, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/linearRegression/function.go
+++ b/expr/functions/linearRegression/function.go
@@ -44,9 +44,9 @@ func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until in
 
 	for _, a := range arg {
 		r := a.CopyLink()
-		if len(e.Args()) > 2 {
+		if e.ArgsLen() > 2 {
 			r.Name = "linearRegression(" + a.GetName() + ",'" + e.Arg(1).StringValue() + "','" + e.Arg(2).StringValue() + "')"
-		} else if len(e.Args()) > 1 {
+		} else if e.ArgsLen() > 1 {
 			r.Name = "linearRegression(" + a.GetName() + ",'" + e.Arg(1).StringValue() + "')"
 		} else {
 			r.Name = "linearRegression(" + a.Name + ")"
@@ -56,7 +56,7 @@ func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until in
 		r.StopTime = a.GetStopTime()
 
 		// Removing absent values from original dataset
-		nonNulls := make([]float64, 0)
+		nonNulls := make([]float64, 0, len(a.Values))
 		for i, v := range a.Values {
 			if !math.IsNaN(v) {
 				nonNulls = append(nonNulls, a.Values[i])

--- a/expr/functions/logit/function.go
+++ b/expr/functions/logit/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // logarithm(seriesList, base=10)
 // Alias: log
 func (f *logit) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/minMax/function.go
+++ b/expr/functions/minMax/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // highestAverage(seriesList, n) , highestCurrent(seriesList, n), highestMax(seriesList, n)
 func (f *minMax) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/removeBetweenPercentile/function.go
+++ b/expr/functions/removeBetweenPercentile/function.go
@@ -36,7 +36,7 @@ func (f *removeBetweenPercentile) Do(ctx context.Context, e parser.Expr, from, u
 		return nil, parser.ErrMissingArgument
 	}
 
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -41,7 +41,7 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 		return []*types.MetricData{}, nil
 	}
 
-	if len(e.Args()) == 2 {
+	if e.ArgsLen() == 2 {
 		xFilesFactor, err = e.GetFloatArgDefault(1, float64(args[0].XFilesFactor)) // If set by setXFilesFactor, all series in a list will have the same value
 		if err != nil {
 			return nil, err

--- a/expr/functions/round/function.go
+++ b/expr/functions/round/function.go
@@ -30,7 +30,7 @@ func New(_ string) []interfaces.FunctionMetadata {
 
 // round(seriesList,precision)
 func (f *round) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/scaleToSeconds/function.go
+++ b/expr/functions/scaleToSeconds/function.go
@@ -33,8 +33,8 @@ func (f *scaleToSeconds) Do(ctx context.Context, e parser.Expr, from, until int6
 	if e.ArgsLen() < 2 {
 		return nil, parser.ErrMissingArgument
 	}
-	
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/setXFilesFactor/function.go
+++ b/expr/functions/setXFilesFactor/function.go
@@ -33,7 +33,7 @@ func (f *setXFilesFactor) Do(ctx context.Context, e parser.Expr, from, until int
 		return nil, parser.ErrMissingArgument
 	}
 
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/sigmoid/function.go
+++ b/expr/functions/sigmoid/function.go
@@ -30,7 +30,7 @@ func New(_ string) []interfaces.FunctionMetadata {
 
 // sigmoid(seriesList)
 func (f *sigmoid) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/sinFunction/function.go
+++ b/expr/functions/sinFunction/function.go
@@ -37,13 +37,13 @@ func (f *sinFunction) Do(ctx context.Context, e parser.Expr, from, until int64, 
 
 	var amplitude = 1.0
 	var stepInt = 60
-	if len(e.Args()) >= 2 {
+	if e.ArgsLen() >= 2 {
 		amplitude, err = e.GetFloatArgDefault(1, 1.0)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if len(e.Args()) == 3 {
+	if e.ArgsLen() == 3 {
 		stepInt, err = e.GetIntArgDefault(2, 60)
 		if err != nil {
 			return nil, err

--- a/expr/functions/slo/function.go
+++ b/expr/functions/slo/function.go
@@ -38,7 +38,7 @@ func (f *slo) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 	)
 
 	// requested data points' window
-	argsWindowed, err = helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	argsWindowed, err = helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if len(argsWindowed) == 0 || err != nil {
 		return nil, err
 	}
@@ -48,6 +48,7 @@ func (f *slo) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 		return nil, err
 	}
 	bucketSize := int64(bucketSize32)
+	intervalStringValue := e.Arg(1).StringValue()
 
 	// there is an opportunity that requested data points' window is smaller than slo interval
 	// e.g.: requesting slo(some.data.series, '30days', above, 0) with window of 6 hours
@@ -58,7 +59,7 @@ func (f *slo) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 	windowSize = until - from
 	if bucketSize > windowSize && !(from == 0 && until == 1) {
 		delta = bucketSize - windowSize
-		argsExtended, err = helper.GetSeriesArg(ctx, e.Args()[0], from-delta, until, values)
+		argsExtended, err = helper.GetSeriesArg(ctx, e.Arg(0), from-delta, until, values)
 
 		if err != nil {
 			return nil, err
@@ -101,7 +102,6 @@ func (f *slo) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 		objectiveStr = e.Arg(4).StringValue()
 	}
 
-	intervalStringValue := e.Args()[1].StringValue()
 	results := make([]*types.MetricData, 0, len(argsWindowed))
 
 	for i, argWnd := range argsWindowed {

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -38,7 +38,7 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 		return nil, parser.ErrMissingArgument
 	}
 
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/sortBy/function.go
+++ b/expr/functions/sortBy/function.go
@@ -32,7 +32,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // sortByMaxima(seriesList), sortByMinima(seriesList), sortByTotal(seriesList)
 func (f *sortBy) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	original, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	original, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/sortByName/function.go
+++ b/expr/functions/sortByName/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // sortByName(seriesList, natural=false)
 func (f *sortByName) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	original, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	original, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/squareRoot/function.go
+++ b/expr/functions/squareRoot/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // squareRoot(seriesList)
 func (f *squareRoot) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/stdev/function.go
+++ b/expr/functions/stdev/function.go
@@ -33,7 +33,7 @@ func (f *stdev) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		return nil, parser.ErrMissingArgument
 	}
 
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // summarize(seriesList, intervalString, func='sum', alignToFrom=False)
 func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	results := make([]*types.MetricData, 0, len(args))
 	for _, arg := range args {
 
-		name := fmt.Sprintf("summarize(%s,'%s'", arg.Name, e.Args()[1].StringValue())
+		name := fmt.Sprintf("summarize(%s,'%s'", arg.Name, e.Arg(1).StringValue())
 		if funcOk || alignOk {
 			// we include the "func" argument in the presence of
 			// "alignToFrom", even if the former was omitted
@@ -127,7 +127,7 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			},
 			Tags: helper.CopyTags(arg),
 		}
-		r.Tags["summarize"] = e.Args()[1].StringValue()
+		r.Tags["summarize"] = e.Arg(1).StringValue()
 		r.Tags["summarizeFunction"] = summarizeFunction
 
 		t := arg.StartTime // unadjusted

--- a/expr/functions/timeSlice/function.go
+++ b/expr/functions/timeSlice/function.go
@@ -2,12 +2,13 @@ package timeSlice
 
 import (
 	"context"
+	"math"
+	"strconv"
+
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
-	"math"
-	"strconv"
 )
 
 type timeSlice struct {
@@ -47,7 +48,7 @@ func (f *timeSlice) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	startStr := strconv.FormatInt(start, 10)
 	endStr := strconv.FormatInt(end, 10)
 
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/timeStack/function.go
+++ b/expr/functions/timeStack/function.go
@@ -52,7 +52,7 @@ func (f *timeStack) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		offs := i * int64(unit)
 		fromNew := from + offs
 		untilNew := until + offs
-		arg, err := helper.GetSeriesArg(ctx, e.Args()[0], fromNew, untilNew, values)
+		arg, err := helper.GetSeriesArg(ctx, e.Arg(0), fromNew, untilNew, values)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/toLowerCase/function.go
+++ b/expr/functions/toLowerCase/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // toLowerCase(seriesList, *pos)
 func (f *toLowerCase) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/toUpperCase/function.go
+++ b/expr/functions/toUpperCase/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // toUpperCase(seriesList, *pos)
 func (f *toUpperCase) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/transformNull/function.go
+++ b/expr/functions/transformNull/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // transformNull(seriesList, default=0)
 func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/unique/function.go
+++ b/expr/functions/unique/function.go
@@ -29,7 +29,7 @@ func New(_ string) []interfaces.FunctionMetadata {
 
 // unique(seriesList)
 func (f *unique) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/rewrite/aboveSeries/function.go
+++ b/expr/rewrite/aboveSeries/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.RewriteFunctionMetadata {
 }
 
 func (f *aboveSeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error) {
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return false, nil, err
 	}

--- a/expr/rewrite/applyByNode/function.go
+++ b/expr/rewrite/applyByNode/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.RewriteFunctionMetadata {
 }
 
 func (f *applyByNode) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (bool, []string, error) {
-	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return false, nil, err
 	}


### PR DESCRIPTION
Cleanup of use e.Args()[N] and len(e.Args())

For example
```
$ go test -benchmem -run=^$ -bench ^BenchmarkExponentialMovingAverage github.com/go-graphite/carbonapi/expr/functions/exponentialMovingAverage

$ benchcmp exponentialMovingAverage1.txt exponentialMovingAverage2.txt 

benchmark                                  old ns/op     new ns/op     delta
BenchmarkExponentialMovingAverage-6        216           48.5          -77.58%
BenchmarkExponentialMovingAverageStr-6     436           134           -69.30%

benchmark                                  old allocs     new allocs     delta
BenchmarkExponentialMovingAverage-6        3              0              -100.00%
BenchmarkExponentialMovingAverageStr-6     6              2              -66.67%

benchmark                                  old bytes     new bytes     delta
BenchmarkExponentialMovingAverage-6        96            0             -100.00%
BenchmarkExponentialMovingAverageStr-6     148           16            -89.19%


```