### PR TITLE
Render marshalSJON/Raw/CSV preallocated bytes buffer

### DIFF
--- a/expr/types/metricdata_test.go
+++ b/expr/types/metricdata_test.go
@@ -25,7 +25,7 @@ func TestJSONResponse(t *testing.T) {
 	for _, tt := range tests {
 		b := MarshalJSON(tt.results, 1.0, false)
 		if !bytes.Equal(b, tt.out) {
-			t.Errorf("marshalJSON(%+v):\n    got %+v\n    want %+v", tt.results, string(b), string(tt.out))
+			t.Errorf("marshalJSON(%+v): got\n%+v\nwant\n%+v", tt.results, string(b), string(tt.out))
 		}
 	}
 }
@@ -50,7 +50,7 @@ func TestJSONResponseNoNullPoints(t *testing.T) {
 	for _, tt := range tests {
 		b := MarshalJSON(tt.results, 1.0, true)
 		if !bytes.Equal(b, tt.out) {
-			t.Errorf("marshalJSON(%+v):\n    got %+v\n    want %+v", tt.results, string(b), string(tt.out))
+			t.Errorf("marshalJSON(%+v): got\n%+v\nwant\n%+v", tt.results, string(b), string(tt.out))
 		}
 	}
 }
@@ -73,7 +73,39 @@ func TestRawResponse(t *testing.T) {
 	for _, tt := range tests {
 		b := MarshalRaw(tt.results)
 		if !bytes.Equal(b, tt.out) {
-			t.Errorf("marshalRaw(%+v)=%+v, want %+v", tt.results, string(b), string(tt.out))
+			t.Errorf("marshalRaw(%+v): got\n%+v\nwant\n%+v", tt.results, string(b), string(tt.out))
+		}
+	}
+}
+
+func TestCSVResponse(t *testing.T) {
+
+	tests := []struct {
+		results []*MetricData
+		out     []byte
+	}{
+		{
+			[]*MetricData{
+				MakeMetricData("metric1", []float64{1, 1.5, 2.25, math.NaN()}, 100, 100),
+				MakeMetricData("metric2", []float64{2, 2.5, 3.25, 4, 5}, 100, 100),
+			},
+			[]byte(`"metric1",1970-01-01 00:01:40,1` + "\n" +
+				`"metric1",1970-01-01 00:03:20,1.5` + "\n" +
+				`"metric1",1970-01-01 00:05:00,2.25` + "\n" +
+				`"metric1",1970-01-01 00:06:40,` + "\n" +
+				`"metric2",1970-01-01 00:01:40,2` + "\n" +
+				`"metric2",1970-01-01 00:03:20,2.5` + "\n" +
+				`"metric2",1970-01-01 00:05:00,3.25` + "\n" +
+				`"metric2",1970-01-01 00:06:40,4` + "\n" +
+				`"metric2",1970-01-01 00:08:20,5` + "\n",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		b := MarshalCSV(tt.results)
+		if !bytes.Equal(b, tt.out) {
+			t.Errorf("marshalCSV(%+v): \n%+v\nwant\n%+v", tt.results, string(b), string(tt.out))
 		}
 	}
 }
@@ -97,5 +129,119 @@ func BenchmarkMarshalJSON(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = MarshalJSON(data, 1.0, false)
+	}
+}
+
+func BenchmarkMarshalJSONLong(b *testing.B) {
+	data := []*MetricData{
+		MakeMetricData("metric1", getData(10000), 100, 100),
+		MakeMetricData("metric2", getData(100000), 100, 100),
+		MakeMetricData("metric3", getData(100000), 100, 100),
+		MakeMetricData("metric4", getData(100000), 100, 100),
+		MakeMetricData("metric5", getData(100000), 100, 100),
+		MakeMetricData("metric6", getData(100000), 100, 100),
+		MakeMetricData("metric7", getData(100000), 100, 100),
+		MakeMetricData("metric8", getData(100000), 100, 100),
+		MakeMetricData("metric9", getData(100000), 100, 100),
+		MakeMetricData("metric10", getData(100000), 100, 100),
+		MakeMetricData("metric11", getData(10000), 100, 100),
+		MakeMetricData("metric12", getData(100000), 100, 100),
+		MakeMetricData("metric13", getData(100000), 100, 100),
+		MakeMetricData("metric14", getData(100000), 100, 100),
+		MakeMetricData("metric15", getData(100000), 100, 100),
+		MakeMetricData("metric16", getData(100000), 100, 100),
+		MakeMetricData("metric17", getData(100000), 100, 100),
+		MakeMetricData("metric18", getData(100000), 100, 100),
+		MakeMetricData("metric19", getData(100000), 100, 100),
+		MakeMetricData("metric20", getData(100000), 100, 100),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = MarshalJSON(data, 1.0, false)
+	}
+}
+
+func BenchmarkMarshalRaw(b *testing.B) {
+	data := []*MetricData{
+		MakeMetricData("metric1", getData(10000), 100, 100),
+		MakeMetricData("metric2", getData(100000), 100, 100),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = MarshalRaw(data)
+	}
+}
+
+func BenchmarkMarshalRawLong(b *testing.B) {
+	data := []*MetricData{
+		MakeMetricData("metric1", getData(10000), 100, 100),
+		MakeMetricData("metric2", getData(100000), 100, 100),
+		MakeMetricData("metric3", getData(100000), 100, 100),
+		MakeMetricData("metric4", getData(100000), 100, 100),
+		MakeMetricData("metric5", getData(100000), 100, 100),
+		MakeMetricData("metric6", getData(100000), 100, 100),
+		MakeMetricData("metric7", getData(100000), 100, 100),
+		MakeMetricData("metric8", getData(100000), 100, 100),
+		MakeMetricData("metric9", getData(100000), 100, 100),
+		MakeMetricData("metric10", getData(100000), 100, 100),
+		MakeMetricData("metric11", getData(10000), 100, 100),
+		MakeMetricData("metric12", getData(100000), 100, 100),
+		MakeMetricData("metric13", getData(100000), 100, 100),
+		MakeMetricData("metric14", getData(100000), 100, 100),
+		MakeMetricData("metric15", getData(100000), 100, 100),
+		MakeMetricData("metric16", getData(100000), 100, 100),
+		MakeMetricData("metric17", getData(100000), 100, 100),
+		MakeMetricData("metric18", getData(100000), 100, 100),
+		MakeMetricData("metric19", getData(100000), 100, 100),
+		MakeMetricData("metric20", getData(100000), 100, 100),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = MarshalRaw(data)
+	}
+}
+
+func BenchmarkMarshalCSV(b *testing.B) {
+	data := []*MetricData{
+		MakeMetricData("metric1", getData(10000), 100, 100),
+		MakeMetricData("metric2", getData(100000), 100, 100),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = MarshalCSV(data)
+	}
+}
+
+func BenchmarkMarshalCSVLong(b *testing.B) {
+	data := []*MetricData{
+		MakeMetricData("metric1", getData(10000), 100, 100),
+		MakeMetricData("metric2", getData(100000), 100, 100),
+		MakeMetricData("metric3", getData(100000), 100, 100),
+		MakeMetricData("metric4", getData(100000), 100, 100),
+		MakeMetricData("metric5", getData(100000), 100, 100),
+		MakeMetricData("metric6", getData(100000), 100, 100),
+		MakeMetricData("metric7", getData(100000), 100, 100),
+		MakeMetricData("metric8", getData(100000), 100, 100),
+		MakeMetricData("metric9", getData(100000), 100, 100),
+		MakeMetricData("metric10", getData(100000), 100, 100),
+		MakeMetricData("metric11", getData(10000), 100, 100),
+		MakeMetricData("metric12", getData(100000), 100, 100),
+		MakeMetricData("metric13", getData(100000), 100, 100),
+		MakeMetricData("metric14", getData(100000), 100, 100),
+		MakeMetricData("metric15", getData(100000), 100, 100),
+		MakeMetricData("metric16", getData(100000), 100, 100),
+		MakeMetricData("metric17", getData(100000), 100, 100),
+		MakeMetricData("metric18", getData(100000), 100, 100),
+		MakeMetricData("metric19", getData(100000), 100, 100),
+		MakeMetricData("metric20", getData(100000), 100, 100),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = MarshalCSV(data)
 	}
 }


### PR DESCRIPTION
```
$ go test -benchmem -run=^$ -bench ^Benchmark github.com/go-graphite/carbonapi/expr/types | tee marshalJSON2.txt 

$ benchcmp marshalJSON1.txt marshalJSON2.txt 
benchmark                      old ns/op     new ns/op     delta
BenchmarkMarshalJSON-6         9297315       7406833       -20.33%
BenchmarkMarshalJSONLong-6     135895934     121057103     -10.92%
BenchmarkMarshalRaw-6          5717379       5622104       -1.67%
BenchmarkMarshalRawLong-6      94664746      90235233      -4.68%
BenchmarkMarshalCSV-6          38516100      19187483      -50.18%
BenchmarkMarshalCSVLong-6      587776864     320056366     -45.55%

benchmark                      old allocs     new allocs     delta
BenchmarkMarshalJSON-6         39             5              -87.18%
BenchmarkMarshalJSONLong-6     89             43             -51.69%
BenchmarkMarshalRaw-6          29             1              -96.55%
BenchmarkMarshalRawLong-6      42             1              -97.62%
BenchmarkMarshalCSV-6          110037         3              -100.00%
BenchmarkMarshalCSVLong-6      1820049        6              -100.00%

benchmark                      old bytes     new bytes     delta
BenchmarkMarshalJSON-6         8401270       2569729       -69.41%
BenchmarkMarshalJSONLong-6     130283752     27232828      -79.10%
BenchmarkMarshalRaw-6          1981197       2564105       +29.42%
BenchmarkMarshalRawLong-6      41704200      25608206      -38.60%
BenchmarkMarshalCSV-6          23749513      9773060       -58.85%
BenchmarkMarshalCSVLong-6      358308832     288342088     -19.53%

```