### PR TITLE
Fix for panic on empty interval string

### DIFF
--- a/pkg/parser/interval.go
+++ b/pkg/parser/interval.go
@@ -6,6 +6,13 @@ import (
 
 // IntervalString converts a sign and string into a number of seconds
 func IntervalString(s string, defaultSign int) (int32, error) {
+	if len(s) == 0 {
+		return 0, ErrUnknownTimeUnits
+	}
+
+	if s == "-" || s == "+" {
+		return 0, ErrUnknownTimeUnits
+	}
 
 	sign := defaultSign
 

--- a/pkg/parser/interval_test.go
+++ b/pkg/parser/interval_test.go
@@ -38,6 +38,9 @@ func TestInterval(t *testing.T) {
 		err     string
 		sign    int
 	}{
+		{"", 0, "unknown time units", 1},
+		{"-", 0, "unknown time units", 1},
+		{"+", 0, "unknown time units", 1},
 		{"10x10s", 0, "unknown time units", 1},
 		{"10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000y", 0, "value out of range", 1},
 	}


### PR DESCRIPTION
Fix for panic in moving function like `movingAverage(seriesList, '')`
graphite-web return `nan` on this, but may be not required.