### PR TITLE
Fix consolidateFunc setting and add test for consolidateBy

### DIFF
--- a/cmd/mockbackend/testcases/i584/i584.yaml
+++ b/cmd/mockbackend/testcases/i584/i584.yaml
@@ -28,7 +28,7 @@ test:
                   expectedResults:
                           - metrics:
                                   - target: "diffSeries(time(\"t\", 1), some.metric)"
-                                    datapoints: [[236,120],[356,240],[357,360]]
+                                    datapoints: [[176.5,120],[296.5,240],[357,360]]
 
 listeners:
         - address: ":9070"

--- a/cmd/mockbackend/testcases/i584/i584.yaml
+++ b/cmd/mockbackend/testcases/i584/i584.yaml
@@ -17,7 +17,7 @@ test:
                   expectedResults:
                           - metrics:
                                   - target: "diffSeries(time(\"t\"), some.metric)"
-                                    datapoints: [[177,120],[297,240],[357,360]]
+                                    datapoints: [[147,120],[267,240],[357,360]]
             - endpoint: "http://127.0.0.1:8081"
               delay: 1
               type: "GET"

--- a/expr/functions/cairo/cairo_test.go
+++ b/expr/functions/cairo/cairo_test.go
@@ -1,3 +1,4 @@
+//go:build cairo
 // +build cairo
 
 package cairo
@@ -26,38 +27,38 @@ func TestEvalExpressionGraph(t *testing.T) {
 			"threshold(42.42)",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("42.42",
-				[]float64{42.42, 42.42}, 1, 0)},
+				[]float64{42.42, 42.42}, 1, 0).SetConsolidationFunc("average")},
 		},
 		{
 			"threshold(42.42,\"fourty-two\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two",
-				[]float64{42.42, 42.42}, 1, 0)},
+				[]float64{42.42, 42.42}, 1, 0).SetConsolidationFunc("average")},
 		},
 		{
 			"threshold(42.42,\"fourty-two\",\"blue\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two",
-				[]float64{42.42, 42.42}, 1, 0)},
+				[]float64{42.42, 42.42}, 1, 0).SetConsolidationFunc("average")},
 		},
 		{
 			"threshold(42.42,label=\"fourty-two\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two",
-				[]float64{42.42, 42.42}, 1, 0)},
+				[]float64{42.42, 42.42}, 1, 0).SetConsolidationFunc("average")},
 		},
 		{
 			"threshold(42.42,color=\"blue\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("42.42",
-				[]float64{42.42, 42.42}, 1, 0)},
+				[]float64{42.42, 42.42}, 1, 0).SetConsolidationFunc("average")},
 		},
 		{
 			//TODO(nnuss): test blue is being set rather than just not causing expression to parse/fail
 			"threshold(42.42,label=\"fourty-two-blue\",color=\"blue\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two-blue",
-				[]float64{42.42, 42.42}, 1, 0)},
+				[]float64{42.42, 42.42}, 1, 0).SetConsolidationFunc("average")},
 		},
 		{
 			// BUG(nnuss): This test actually fails with color = "" because of
@@ -67,7 +68,7 @@ func TestEvalExpressionGraph(t *testing.T) {
 			"threshold(42.42,gold,label=\"fourty-two-aurum\")",
 			map[parser.MetricRequest][]*types.MetricData{},
 			[]*types.MetricData{types.MakeMetricData("fourty-two-aurum",
-				[]float64{42.42, 42.42}, 1, 0)},
+				[]float64{42.42, 42.42}, 1, 0).SetConsolidationFunc("average")},
 		},
 	}
 

--- a/expr/functions/consolidateBy/function.go
+++ b/expr/functions/consolidateBy/function.go
@@ -47,7 +47,7 @@ func (f *consolidateBy) Do(ctx context.Context, e parser.Expr, from, until int64
 
 	for i, a := range arg {
 		r := a.CopyLink()
-
+		r.Name = "consolidateBy(" + a.Name + ",\"" + name + "\")"
 		r.ConsolidationFunc = name
 		r.Tags["consolidateBy"] = name
 		results[i] = r

--- a/expr/functions/consolidateBy/function_test.go
+++ b/expr/functions/consolidateBy/function_test.go
@@ -1,0 +1,83 @@
+package consolidateBy
+
+import (
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+	"testing"
+	"time"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestConsolidateBy(t *testing.T) {
+	now32 := time.Now().Unix()
+
+	tests := []th.EvalTestItem{
+		{
+			"consolidateBy(metric1,\"sum\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"sum\")",
+				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "sum").SetConsolidationFunc("sum")},
+		},
+		{
+			"consolidateBy(metric1,\"avg\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"avg\")",
+				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "avg").SetConsolidationFunc("avg")},
+		},
+		{
+			"consolidateBy(metric1,\"min\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"min\")",
+				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "min").SetConsolidationFunc("min")},
+		},
+		{
+			"consolidateBy(metric1,\"max\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"max\")",
+				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "max").SetConsolidationFunc("max")},
+		},
+		{
+			"consolidateBy(metric1,\"first\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"first\")",
+				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "first").SetConsolidationFunc("first")},
+		},
+		{
+			"consolidateBy(metric1,\"last\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"last\")",
+				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "last").SetConsolidationFunc("last")},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}

--- a/expr/functions/constantLine/function.go
+++ b/expr/functions/constantLine/function.go
@@ -40,12 +40,11 @@ func (f *constantLine) Do(ctx context.Context, e parser.Expr, from, until int64,
 	name := strconv.FormatFloat(value, 'g', -1, 64)
 	p := &types.MetricData{
 		FetchResponse: pb.FetchResponse{
-			Name:              name,
-			StartTime:         from,
-			StopTime:          stopTime,
-			StepTime:          stepTime,
-			Values:            newValues,
-			ConsolidationFunc: "max",
+			Name:      name,
+			StartTime: from,
+			StopTime:  stopTime,
+			StepTime:  stepTime,
+			Values:    newValues,
 		},
 		Tags: map[string]string{"name": name},
 	}

--- a/expr/functions/identity/function.go
+++ b/expr/functions/identity/function.go
@@ -45,12 +45,11 @@ func (f *identity) Do(ctx context.Context, e parser.Expr, from, until int64, val
 
 	p := types.MetricData{
 		FetchResponse: pb.FetchResponse{
-			Name:              "identity(" + name + ")",
-			StartTime:         from,
-			StopTime:          until,
-			StepTime:          step,
-			Values:            newValues,
-			ConsolidationFunc: "max",
+			Name:      "identity(" + name + ")",
+			StartTime: from,
+			StopTime:  until,
+			StepTime:  step,
+			Values:    newValues,
 		},
 		Tags: map[string]string{"name": name},
 	}

--- a/expr/functions/timeFunction/function.go
+++ b/expr/functions/timeFunction/function.go
@@ -57,12 +57,11 @@ func (f *timeFunction) Do(ctx context.Context, e parser.Expr, from, until int64,
 
 	p := types.MetricData{
 		FetchResponse: pb.FetchResponse{
-			Name:              name,
-			StartTime:         from,
-			StopTime:          until,
-			StepTime:          step,
-			Values:            newValues,
-			ConsolidationFunc: "max",
+			Name:      name,
+			StartTime: from,
+			StopTime:  until,
+			StepTime:  step,
+			Values:    newValues,
 		},
 		Tags: map[string]string{"name": name},
 	}

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -443,6 +443,9 @@ func TestEvalExprModifiedOrigin(t *testing.T, tt *EvalTestItem, from, until int6
 		if actual.Name != want.Name {
 			t.Errorf("bad Name for %s metric[%d]: got %s, Want %s", testName, i, actual.Name, want.Name)
 		}
+		if actual.ConsolidationFunc != want.ConsolidationFunc {
+			t.Errorf("different ConsolidationFunc for %s metric[%d] %s: got %v, Want %v", testName, i, actual.Name, actual.ConsolidationFunc, want.ConsolidationFunc)
+		}
 		if !compare.NearlyEqualMetrics(actual, want) {
 			t.Errorf("different values for %s metric[%d] %s: got %v, Want %v", testName, i, actual.Name, actual.Values, want.Values)
 		}


### PR DESCRIPTION
This PR adds tests for the consolidateBy function, as there previously were no tests. It also updates the Name field of the results to match how Graphite web's consolidateBy function assigns Name to the results (see [Graphite web's implementation](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L2101)).

Additionally, it appeared that several functions, such as constantLine, time, and identity, had a consolidationFunc setting that was not aligned with Graphite web, so this was fixed.