### PR TITLE
Add test for cumulative function

### DIFF
--- a/expr/functions/cumulative/function.go
+++ b/expr/functions/cumulative/function.go
@@ -36,8 +36,10 @@ func (f *cumulative) Do(ctx context.Context, e parser.Expr, from, until int64, v
 	results := make([]*types.MetricData, len(arg))
 
 	for i, a := range arg {
-		r := a.CopyLinkTags()
+		r := a.CopyLink()
 		r.ConsolidationFunc = "sum"
+		r.Name = "consolidateBy(" + a.Name + ",\"sum\")"
+		r.Tags["consolidateBy"] = "sum"
 		results[i] = r
 	}
 	return results, nil

--- a/expr/functions/cumulative/function_test.go
+++ b/expr/functions/cumulative/function_test.go
@@ -1,0 +1,44 @@
+package cumulative
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestCumulative(t *testing.T) {
+	now32 := time.Now().Unix()
+
+	tests := []th.EvalTestItem{
+		{
+			"cumulative(metric1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"sum\")",
+				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "sum").SetConsolidationFunc("sum")},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a test for the Graphite web cumulative function. It also updates the cumulative function's setting of the results name and tags to match that of Graphite webs (note that in Graphite web, the cumulative function calls the 'consolidateBy' function. See [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L2069) and [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L2078)).