### PR TITLE
Add test for timeStack function

### DIFF
--- a/expr/functions/timeStack/function.go
+++ b/expr/functions/timeStack/function.go
@@ -60,7 +60,7 @@ func (f *timeStack) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		offsStr := strconv.FormatInt(offs, 10)
 		for _, a := range arg {
 			r := a.CopyLink()
-			r.Name = fmt.Sprintf("timeShift(%s,%d)", a.Name, offs)
+			r.Name = fmt.Sprintf("timeShift(%s,%s,%d)", a.Name, unitStr, offs)
 			r.StartTime = a.StartTime - offs
 			r.StopTime = a.StopTime - offs
 			r.Tags["timeShiftUnit"] = unitStr

--- a/expr/functions/timeStack/function_test.go
+++ b/expr/functions/timeStack/function_test.go
@@ -1,0 +1,47 @@
+package timeStack
+
+import (
+	"math"
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestTimeStack(t *testing.T) {
+	var startTime int64 = 86400
+
+	tests := []th.EvalTestItemWithRange{
+		// TODO(civil): Do not pass `true` resetEnd parameter in 0.15
+		{
+			Target: `timeStack(metric1, "10m", 0)`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: startTime, Until: startTime + 6}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), 3, math.NaN(), 5, 6, math.NaN(), 7, math.NaN(), math.NaN()}, 60, startTime)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,10m,0)",
+				[]float64{math.NaN(), math.NaN(), math.NaN(), 3, math.NaN(), 5, 6, math.NaN(), 7, math.NaN(), math.NaN()}, 60, startTime).SetTags(map[string]string{"timeShift": "0", "timeShiftUnit": "10m"}).SetNameTag("metric1")},
+			From:  startTime,
+			Until: startTime + 6,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a test for verifying functionality of the the timeStack function, as it was previously missing. Also included in this PR is a fix for the name of the results generated by timeStack, in order to match [Graphite web](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L4426)