### PR TITLE
Add test for setXFilesFactor function

### DIFF
--- a/expr/functions/setXFilesFactor/function.go
+++ b/expr/functions/setXFilesFactor/function.go
@@ -2,6 +2,7 @@ package setXFilesFactor
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
@@ -43,10 +44,14 @@ func (f *setXFilesFactor) Do(ctx context.Context, e parser.Expr, from, until int
 		return nil, err
 	}
 
+	results := make([]*types.MetricData, 0, len(args))
 	for _, a := range args {
-		a.XFilesFactor = float32(xFilesFactor)
+		r := a.CopyLink()
+		r.XFilesFactor = float32(xFilesFactor)
+		r.Tags["xFilesFactor"] = strconv.FormatFloat(xFilesFactor, 'g', -1, 64)
+		results = append(results, r)
 	}
-	return args, nil
+	return results, nil
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/setXFilesFactor/function_test.go
+++ b/expr/functions/setXFilesFactor/function_test.go
@@ -1,0 +1,44 @@
+package setXFilesFactor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestSetXFilesFactor(t *testing.T) {
+	now64 := time.Now().Unix()
+
+	tests := []th.EvalTestItem{
+		{
+			"setXFilesFactor(metric1,0.6)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now64)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1",
+				[]float64{1, 2, 3, 4, 5}, 1, now64).SetXFilesFactor(0.6).SetTag("xFilesFactor", "0.6")},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a test for the setXFilesFactor function, as there previously were no tests to verify functionality. See Graphite web's test [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/tests/test_functions.py#L1570)