### PR TITLE
Add tests for Graphite web stdev function

### DIFF
--- a/expr/functions/stdev/function.go
+++ b/expr/functions/stdev/function.go
@@ -63,7 +63,11 @@ func (f *stdev) Do(ctx context.Context, e parser.Expr, from, until int64, values
 
 		for i, v := range a.Values {
 			w.Push(v)
-			r.Values[i] = w.Stdev()
+			if !math.IsNaN(v) {
+				r.Values[i] = w.Stdev()
+			} else {
+				r.Values[i] = math.NaN()
+			}
 			if math.IsNaN(r.Values[i]) || (i >= minLen && w.Len() < minLen) {
 				r.Values[i] = math.NaN()
 			}

--- a/expr/functions/stdev/function_test.go
+++ b/expr/functions/stdev/function_test.go
@@ -1,0 +1,52 @@
+package stdev
+
+import (
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+	"math"
+	"testing"
+	"time"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestStdev(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"stdev(metric1, 2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("stdev(metric1,2)",
+				[]float64{0.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5}, 1, now32).SetTag("stdev", "2")},
+		},
+		{
+			"stdev(metric1, 2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("stdev(metric1,2)",
+				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("stdev", "2")},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds tests for the Graphite web stdev function, matching the tests implemented for stdev in [Graphite web](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/tests/test_functions.py#L2435). Note that after implementing [this test found in Graphite web's code](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/tests/test_functions.py#L2459), an issue was found with the stdev function, where a value of 0 was calculated for the standard deviation if the first value in the series was math.NaN(). This PR also includes a fix that should handle this scenario.