### PR TITLE
response/backend cache short duration tune

### DIFF
--- a/cmd/carbonapi/config/config.go
+++ b/cmd/carbonapi/config/config.go
@@ -23,11 +23,13 @@ var DefaultLoggerConfig = zapwriter.Config{
 }
 
 type CacheConfig struct {
-	Type              string   `mapstructure:"type"`
-	Size              int      `mapstructure:"size_mb"`
-	MemcachedServers  []string `mapstructure:"memcachedServers"`
-	DefaultTimeoutSec int32    `mapstructure:"defaultTimeoutSec"`
-	ShortTimeoutSec   int32    `mapstructure:"shortTimeoutSec"`
+	Type                string        `mapstructure:"type"`
+	Size                int           `mapstructure:"size_mb"`
+	MemcachedServers    []string      `mapstructure:"memcachedServers"`
+	DefaultTimeoutSec   int32         `mapstructure:"defaultTimeoutSec"`
+	ShortTimeoutSec     int32         `mapstructure:"shortTimeoutSec"`
+	ShortDuration       time.Duration `mapstructure:"shortDuration"`
+	ShortUntilOffsetSec int64         `mapstructure:"shortUntilOffsetSec"`
 }
 
 type GraphiteConfig struct {
@@ -129,7 +131,8 @@ var Config = ConfigType{
 	ResponseCacheConfig: CacheConfig{
 		Type:              "mem",
 		DefaultTimeoutSec: 60,
-		ShortTimeoutSec:   60,
+		ShortTimeoutSec:   0,
+		ShortDuration:     0,
 	},
 	BackendCacheConfig: CacheConfig{
 		Type:              "null",

--- a/cmd/carbonapi/config/init.go
+++ b/cmd/carbonapi/config/init.go
@@ -287,12 +287,23 @@ func SetUpConfig(logger *zap.Logger, BuildVersion string) {
 }
 
 func createCache(logger *zap.Logger, cacheName string, cacheConfig *CacheConfig) cache.BytesCache {
-	if cacheConfig.DefaultTimeoutSec <= 0 {
+	if cacheConfig.DefaultTimeoutSec <= 0 && cacheConfig.ShortTimeoutSec <= 0 {
 		return cache.NullCache{}
 	}
-	if cacheConfig.DefaultTimeoutSec < cacheConfig.ShortTimeoutSec || cacheConfig.ShortTimeoutSec <= 0 {
-		cacheConfig.ShortTimeoutSec = cacheConfig.DefaultTimeoutSec
+	if cacheConfig.ShortTimeoutSec < 0 || cacheConfig.DefaultTimeoutSec == cacheConfig.ShortTimeoutSec {
+		// broken value or short timeout not need due to equal
+		cacheConfig.ShortTimeoutSec = 0
 	}
+	if cacheConfig.DefaultTimeoutSec < cacheConfig.ShortTimeoutSec {
+		cacheConfig.DefaultTimeoutSec = cacheConfig.ShortTimeoutSec
+	}
+	if cacheConfig.ShortDuration == 0 {
+		cacheConfig.ShortDuration = 3 * time.Hour
+	}
+	if cacheConfig.ShortUntilOffsetSec == 0 {
+		cacheConfig.ShortUntilOffsetSec = 120
+	}
+
 	switch cacheConfig.Type {
 	case "memcache":
 		if len(cacheConfig.MemcachedServers) == 0 {

--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -48,7 +48,7 @@ func setError(w http.ResponseWriter, accessLogDetails *carbonapipb.AccessLogDeta
 	accessLogDetails.HTTPCode = int32(status)
 }
 
-func getCacheTimeout(logger *zap.Logger, r *http.Request, defaultTimeout int32) int32 {
+func getCacheTimeout(logger *zap.Logger, r *http.Request, now32, until32 int64, duration time.Duration, cacheConfig *config.CacheConfig) int32 {
 	if tstr := r.FormValue("cacheTimeout"); tstr != "" {
 		t, err := strconv.Atoi(tstr)
 		if err != nil {
@@ -60,8 +60,14 @@ func getCacheTimeout(logger *zap.Logger, r *http.Request, defaultTimeout int32) 
 			return int32(t)
 		}
 	}
-
-	return defaultTimeout
+	if now32 == 0 || cacheConfig.ShortTimeoutSec == 0 || cacheConfig.ShortDuration == 0 {
+		return cacheConfig.DefaultTimeoutSec
+	}
+	if duration > cacheConfig.ShortDuration || now32-until32 > cacheConfig.ShortUntilOffsetSec {
+		return cacheConfig.DefaultTimeoutSec
+	}
+	// short cache ttl
+	return cacheConfig.ShortTimeoutSec
 }
 
 func renderHandler(w http.ResponseWriter, r *http.Request) {
@@ -147,32 +153,39 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	responseCacheTimeout := getCacheTimeout(logger, r, config.Config.ResponseCacheConfig.DefaultTimeoutSec)
-	backendCacheTimeout := getCacheTimeout(logger, r, config.Config.BackendCacheConfig.DefaultTimeoutSec)
+	now := timeNow()
+	now32 := now.Unix()
 
 	cleanupParams(r)
 
 	// normalize from and until values
-	now := timeNow()
-	now32 := now.Unix()
 	qtz := r.FormValue("tz")
 	from32 := date.DateParamToEpoch(from, qtz, now.Add(-24*time.Hour).Unix(), config.Config.DefaultTimeZone)
 	until32 := date.DateParamToEpoch(until, qtz, now.Unix(), config.Config.DefaultTimeZone)
 
-	var responseCacheKey string
+	var (
+		responseCacheKey     string
+		responseCacheTimeout int32
+		backendCacheTimeout  int32
+	)
 
+	duration := time.Second * time.Duration(until32-from32)
 	if len(config.Config.TruncateTime) > 0 {
-		duration := time.Second * time.Duration(until32-from32)
 		from32 = timestampTruncate(from32, duration, config.Config.TruncateTime)
 		until32 = timestampTruncate(until32, duration, config.Config.TruncateTime)
+		// recalc duration
+		duration = time.Second * time.Duration(until32-from32)
 		responseCacheKey = responseCacheComputeKey(from32, until32, targets, formatRaw, maxDataPoints, noNullPoints, template)
-		if duration <= time.Hour && now32-until32 < 60 {
-			// short cache ttl
-			responseCacheTimeout = config.Config.ResponseCacheConfig.ShortTimeoutSec
-			backendCacheTimeout = config.Config.BackendCacheConfig.ShortTimeoutSec
+		if useCache {
+			responseCacheTimeout = getCacheTimeout(logger, r, now32, until32, duration, &config.Config.ResponseCacheConfig)
+			backendCacheTimeout = getCacheTimeout(logger, r, now32, until32, duration, &config.Config.BackendCacheConfig)
 		}
 	} else {
 		responseCacheKey = r.Form.Encode()
+		if useCache {
+			responseCacheTimeout = getCacheTimeout(logger, r, now32, until32, duration, &config.Config.ResponseCacheConfig)
+			backendCacheTimeout = getCacheTimeout(logger, r, now32, until32, duration, &config.Config.BackendCacheConfig)
+		}
 	}
 
 	accessLogDetails.UseCache = useCache
@@ -265,9 +278,9 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 
 	var backendCacheKey string
 	if len(config.Config.TruncateTime) > 0 {
-		backendCacheKey = backendCacheComputeKeyAbs(from32, until32, targets)
+		backendCacheKey = backendCacheComputeKeyAbs(from32, until32, targets, maxDataPoints, noNullPoints)
 	} else {
-		backendCacheKey = backendCacheComputeKey(from, until, targets)
+		backendCacheKey = backendCacheComputeKey(from, until, targets, maxDataPoints, noNullPoints)
 	}
 
 	results, err := backendCacheFetchResults(logger, useCache, backendCacheKey, accessLogDetails)
@@ -409,18 +422,25 @@ func responseCacheComputeKey(from, until int64, targets []string, format string,
 	return responseCacheKey.String()
 }
 
-func backendCacheComputeKey(from, until string, targets []string) string {
-	var backendCacheKey bytes.Buffer
+func backendCacheComputeKey(from, until string, targets []string, maxDataPoints int64, noNullPoints bool) string {
+	var backendCacheKey stringutils.Builder
 	backendCacheKey.WriteString("from:")
 	backendCacheKey.WriteString(from)
 	backendCacheKey.WriteString(" until:")
 	backendCacheKey.WriteString(until)
 	backendCacheKey.WriteString(" targets:")
 	backendCacheKey.WriteString(strings.Join(targets, ","))
+	if maxDataPoints > 0 {
+		backendCacheKey.WriteString(" maxDataPoints:")
+		backendCacheKey.WriteInt(maxDataPoints, 10)
+	}
+	if noNullPoints {
+		backendCacheKey.WriteString(" noNullPoints")
+	}
 	return backendCacheKey.String()
 }
 
-func backendCacheComputeKeyAbs(from, until int64, targets []string) string {
+func backendCacheComputeKeyAbs(from, until int64, targets []string, maxDataPoints int64, noNullPoints bool) string {
 	var backendCacheKey stringutils.Builder
 	backendCacheKey.Grow(128)
 	backendCacheKey.WriteString("from:")
@@ -429,6 +449,13 @@ func backendCacheComputeKeyAbs(from, until int64, targets []string) string {
 	backendCacheKey.WriteInt(until, 10)
 	backendCacheKey.WriteString(" targets:")
 	backendCacheKey.WriteString(strings.Join(targets, ","))
+	if maxDataPoints > 0 {
+		backendCacheKey.WriteString(" maxDataPoints:")
+		backendCacheKey.WriteInt(maxDataPoints, 10)
+	}
+	if noNullPoints {
+		backendCacheKey.WriteString(" noNullPoints")
+	}
 	return backendCacheKey.String()
 }
 

--- a/cmd/carbonapi/http/render_handler_test.go
+++ b/cmd/carbonapi/http/render_handler_test.go
@@ -1,7 +1,12 @@
 package http
 
 import (
+	"net/http"
 	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/cmd/carbonapi/config"
+	"github.com/lomik/zapwriter"
 )
 
 func BenchmarkResponseCacheComputeKey(b *testing.B) {
@@ -30,7 +35,7 @@ func BenchmarkBackendCacheComputeKey(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		_ = backendCacheComputeKey(from, until, targets)
+		_ = backendCacheComputeKey(from, until, targets, 0, true)
 	}
 }
 
@@ -43,6 +48,78 @@ func BenchmarkBackendCacheComputeKeyAbs(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		_ = backendCacheComputeKeyAbs(from, until, targets)
+		_ = backendCacheComputeKeyAbs(from, until, targets, 0, true)
+	}
+}
+
+func Test_getCacheTimeout(t *testing.T) {
+	cacheConfig := config.CacheConfig{
+		ShortTimeoutSec:     60,
+		DefaultTimeoutSec:   300,
+		ShortDuration:       3 * time.Hour,
+		ShortUntilOffsetSec: 120,
+	}
+
+	now := int64(1636985018)
+
+	tests := []struct {
+		name  string
+		now   time.Time
+		from  int64
+		until int64
+		want  int32
+	}{
+		{
+			name:  "short: from = now - 600, until = now - 120",
+			now:   time.Unix(now, 0),
+			from:  now - 600,
+			until: now - 120,
+			want:  60,
+		},
+		{
+			name:  "short: from = now - 10800",
+			now:   time.Unix(now, 0),
+			from:  now - 10800,
+			until: now,
+			want:  60,
+		},
+		{
+			name:  "short: from = now - 10810, until = now - 120",
+			now:   time.Unix(now, 0),
+			from:  now - 10800,
+			until: now - 120,
+			want:  60,
+		},
+		{
+			name:  "short: from = now - 10800, until now - 121",
+			now:   time.Unix(now, 0),
+			from:  now - 10800,
+			until: now - 121,
+			want:  300,
+		},
+		{
+			name:  "default: from = now - 10801",
+			now:   time.Unix(now, 0),
+			from:  now - 10801,
+			until: now,
+			want:  300,
+		},
+		{
+			name:  "short: from = now - 122, until = now - 121",
+			now:   time.Unix(now, 0),
+			from:  now - 122,
+			until: now - 121,
+			want:  300,
+		},
+	}
+	logger := zapwriter.Logger("test")
+	r, _ := http.NewRequest("GET", "http://127.0.0.1/render", nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			duration := time.Second * time.Duration(tt.until-tt.from)
+			if got := getCacheTimeout(logger, r, tt.now.Unix(), tt.until, duration, &cacheConfig); got != tt.want {
+				t.Errorf("getCacheTimeout() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -246,7 +246,7 @@ Supported cache types:
  - `mem` - will use integrated in-memory cache. Not distributed. Fast.
  - `memcache` - will use specified memcache servers. Could be shared. Slow.
  - `null` - disable cache
- 
+
 Extra options:
  - `size_mb` - specify max size of cache, in MiB
  - `defaultTimeoutSec` - specify default cache duration. Identical to `DEFAULT_CACHE_DURATION` in graphite-web
@@ -280,18 +280,23 @@ backendCache:
        - "127.0.0.2:1235"
 ```
 
+In many cases two-level cache is useful. Additional parameters for configuration:
+- `shortDuration` until-from duration (by default "3h")
+- `shortUntilOffsetSec` now-until duration seconds (by default 120)
+- `shortTimeoutSec`  - short duration, disabled by default, used when `(from-until<=shortDuration) && (now-until<shortUntilOffsetSec)`
+
 ### Example for 2-level cache lifetime (short timeout on 1-hour window and long timeout for other) and round timestamps for tune cache efficience
 ```yaml
 cache:
    type: "mem"
    size_mb: 0
    defaultTimeoutSec: 10800 # Default cache timeout
-   shortTimeoutSec: 60 # if until - from <= 1hour && now-until < 1min, by default is equal to defaultTimeoutSec
+   shortTimeoutSec: 60 # if until - from <= 3hour && now-until < 2min
 backendCache:
    type: "mem"
    size_mb: 0
    defaultTimeoutSec: 10800 # Default cache timeout
-   shortTimeoutSec: 60 # if until - from <= 1hour && now-until < 1min, by default is equal to defaultTimeoutSec
+   shortTimeoutSec: 60 # if until - from <= 3hour && now-until < 2min
 
 truncateTime: # truncate from/until for identifical results between carbonapi instances. Also reduce load on long-range queries
   "8760h": "1h"     # Timestamp will be truncated to 1 hour round if (until - from) > 365 days


### PR DESCRIPTION
- Change long cache duration to 3 hours and 2 minute until offset by default, also make until offset tunable.
- Recalc duration on from/until timestamps truncate.
