### PR TITLE
fix regression for VictoriaMetrics cluster

### DIFF
--- a/zipper/protocols/victoriametrics/victoriametrics_group.go
+++ b/zipper/protocols/victoriametrics/victoriametrics_group.go
@@ -70,7 +70,7 @@ func NewWithLimiter(logger *zap.Logger, config types.BackendV2, tldCacheDisabled
 
 	step := int64(15)
 	var vmClusterTenantID string = ""
-	vmClusterTenantIDI, ok := config.BackendOptions["vmClusterTenantID"]
+	vmClusterTenantIDI, ok := config.BackendOptions["vmclustertenantid"]
 	if ok {
 		vmClusterTenantID = vmClusterTenantIDI.(string)
 	}


### PR DESCRIPTION
There is regression for cluster version of VictoriaMetrics "find" API call - carbonapi ignores configured vmClusterTenantID.