### PR TITLE
`aliasByNode`/`Tags` should not discard tags

### DIFF
--- a/expr/functions/aliasByNode/function.go
+++ b/expr/functions/aliasByNode/function.go
@@ -45,7 +45,7 @@ func (f *aliasByNode) Do(ctx context.Context, e parser.Expr, from, until int64, 
 
 	for i, a := range args {
 		name := helper.AggKey(a, nodesOrTags)
-		r := a.CopyTag(name, map[string]string{"name": name})
+		r := a.CopyName(name)
 		results[i] = r
 	}
 

--- a/expr/functions/aliasByNode/function_test.go
+++ b/expr/functions/aliasByNode/function_test.go
@@ -71,7 +71,7 @@ func TestAliasByNode(t *testing.T) {
 			M: map[parser.MetricRequest][]*types.MetricData{
 				{Metric: "metric1.foo.bar.ba*", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("bar.word", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			Want: []*types.MetricData{types.MakeMetricData("bar.word", []float64{1, 2, 3, 4, 5}, 1, now32).SetTag("transformNull", "0")},
 		},
 		{
 			Target: "aliasByNode(metric1.foo.bar.baz,1)",
@@ -101,35 +101,35 @@ func TestAliasByNode(t *testing.T) {
 			M: map[parser.MetricRequest][]*types.MetricData{
 				{Metric: "*", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz;foo=bar;baz=bam", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("bar", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			Want: []*types.MetricData{types.MakeMetricData("bar", []float64{1, 2, 3, 4, 5}, 1, now32).SetTag("foo", "bar").SetTag("baz", "bam")},
 		},
 		{
 			Target: `aliasByTags(*, "foo", "name")`,
 			M: map[parser.MetricRequest][]*types.MetricData{
 				{Metric: "*", From: 0, Until: 1}: {types.MakeMetricData("metric1;foo=bar", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("bar.metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			Want: []*types.MetricData{types.MakeMetricData("bar.metric1", []float64{1, 2, 3, 4, 5}, 1, now32).SetTag("foo", "bar")},
 		},
 		{
 			Target: `aliasByTags(*, 2, "blah", "foo", 1)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
 				{Metric: "*", From: 0, Until: 1}: {types.MakeMetricData("base.metric1;foo=bar;baz=bam", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData(".bar.metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			Want: []*types.MetricData{types.MakeMetricData(".bar.metric1", []float64{1, 2, 3, 4, 5}, 1, now32).SetTag("foo", "bar").SetTag("baz", "bam")},
 		},
 		{
 			Target: `aliasByTags(*, 2, "baz", "foo", 1)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
 				{Metric: "*", From: 0, Until: 1}: {types.MakeMetricData("base.metric1;foo=bar;baz=bam", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("bam.bar.metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			Want: []*types.MetricData{types.MakeMetricData("bam.bar.metric1", []float64{1, 2, 3, 4, 5}, 1, now32).SetTag("foo", "bar").SetTag("baz", "bam")},
 		},
 		{
 			Target: `aliasByTags(perSecond(*), 'name')`,
 			M: map[parser.MetricRequest][]*types.MetricData{
 				{Metric: "*", From: 0, Until: 1}: {types.MakeMetricData("base.metric1;foo=bar;baz=bam", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("base.metric1", []float64{math.NaN(), 1, 1, 1, 1}, 1, now32)},
+			Want: []*types.MetricData{types.MakeMetricData("base.metric1", []float64{math.NaN(), 1, 1, 1, 1}, 1, now32).SetTag("foo", "bar").SetTag("baz", "bam").SetTag("perSecond", "1")},
 		},
 		{
 			Target: "aliasByNode(metric1.fo*.bar.baz,1,3)",
@@ -144,7 +144,7 @@ func TestAliasByNode(t *testing.T) {
 			M: map[parser.MetricRequest][]*types.MetricData{
 				{Metric: "*", From: 0, Until: 1}: {types.MakeMetricData("base.metric1;foo=bar=;baz=bam==", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("bam==.bar=.metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			Want: []*types.MetricData{types.MakeMetricData("bam==.bar=.metric1", []float64{1, 2, 3, 4, 5}, 1, now32).SetTag("foo", "bar=").SetTag("baz", "bam==")},
 		},
 		// extract nodes with sumSeries
 		{
@@ -156,7 +156,7 @@ func TestAliasByNode(t *testing.T) {
 					types.MakeMetricData("metric.c2.b", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
 				},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("{a,b}*.b", []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
+			Want: []*types.MetricData{types.MakeMetricData("{a,b}*.b", []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32).SetTag("aggregatedBy", "sum")},
 		},
 		// extract tags from seriesByTag
 		{
@@ -170,7 +170,8 @@ func TestAliasByNode(t *testing.T) {
 				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
 			},
 			// Want: []*types.MetricData{types.MakeMetricData("value____.metric", []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
-			Want: []*types.MetricData{types.MakeMetricData("value21.metric", []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
+			Want: []*types.MetricData{
+				types.MakeMetricData("value21.metric", []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32).SetTag("aggregatedBy", "sum").SetTag("tag2", "value21")},
 		},
 		// TODO msaf1980: tests with extractTagsFromArgs = true
 	}


### PR DESCRIPTION
`aliasByNode`/`Tag` should keep the argument's tags instead of discarding them. This is consistent with what graphite web does: https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/functions.py#L2760


Should close https://github.com/go-graphite/carbonapi/issues/755 


