### PR TITLE
First find filed only graphite metric and fix query tag metric

### DIFF
--- a/zipper/protocols/victoriametrics/fetch.go
+++ b/zipper/protocols/victoriametrics/fetch.go
@@ -75,6 +75,7 @@ func (c *VictoriaMetricsGroup) Fetch(ctx context.Context, request *protov3.Multi
 			// Make local copy
 			stepLocalStr := target.step
 			if strings.HasPrefix(target.name, "seriesByTag") {
+				target.name = strings.ReplaceAll(target.name, "'name=", "'__name__=")
 				stepLocalStr, target.name = helpers.SeriesByTagToPromQL(stepLocalStr, target.name)
 			} else {
 				target.name = fmt.Sprintf("{__graphite__=%q}", target.name)

--- a/zipper/protocols/victoriametrics/find.go
+++ b/zipper/protocols/victoriametrics/find.go
@@ -41,6 +41,11 @@ func (c *VictoriaMetricsGroup) Find(ctx context.Context, request *protov3.MultiG
 	defer c.parserPool.Put(parser)
 
 	for _, query := range request.Metrics {
+		// Find only graphite metric name for first find
+		if query == "*" {
+			query = "*."
+		}
+
 		v := url.Values{
 			"query": []string{query},
 		}


### PR DESCRIPTION
When autocompleting the very first field in the grafana, it displays only metric names with dots (excludes metric names with tags). Tagged metrics are loaded via tag completion.
When autocompleting tags from VictoriaMetrics, the metric name is returned in the name tag, but it cannot be used because it is actually __name__ and it must be used when querying VictoriaMetrics for metrics to work correctly with tags.