### PR TITLE
Fix hitcount function handling of intervals and alignToInterval 

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -31,12 +31,12 @@ func (eval evaluator) FetchAndEvalExprs(ctx context.Context, exprs []parser.Expr
 
 	haveFallbackSeries := false
 	for _, exp := range exprs {
-		for _, m := range exp.Metrics() {
+		for _, m := range exp.Metrics(from, until) {
 			fetchRequest := pb.FetchRequest{
 				Name:           m.Metric,
 				PathExpression: m.Metric,
-				StartTime:      m.From + from,
-				StopTime:       m.Until + until,
+				StartTime:      m.From,
+				StopTime:       m.Until,
 				MaxDataPoints:  maxDataPoints,
 			}
 			metricRequest := parser.MetricRequest{
@@ -126,12 +126,12 @@ func (eval evaluator) FetchAndEvalExp(ctx context.Context, exp parser.Expr, from
 	// values related to this particular `target=`
 	targetValues := make(map[parser.MetricRequest][]*types.MetricData)
 
-	for _, m := range exp.Metrics() {
+	for _, m := range exp.Metrics(from, until) {
 		fetchRequest := pb.FetchRequest{
 			Name:           m.Metric,
 			PathExpression: m.Metric,
-			StartTime:      m.From + from,
-			StopTime:       m.Until + until,
+			StartTime:      m.From,
+			StopTime:       m.Until,
 			MaxDataPoints:  maxDataPoints,
 		}
 		metricRequest := parser.MetricRequest{

--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -3,16 +3,14 @@ package hitcount
 import (
 	"context"
 	"fmt"
-	"math"
-	"strconv"
-	"strings"
-	"time"
-
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+	"math"
+	"strconv"
+	"strings"
 )
 
 type hitcount struct {
@@ -105,8 +103,6 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 		buckets := make([][]float64, bucketCount)
 		newStart := stop - bucketCount*interval
 		r.StartTime = newStart
-		newStartDateTime := time.Unix(newStart, 0)
-		fmt.Println("New start time is: ", newStartDateTime)
 
 		for i, v := range arg.Values {
 			if math.IsNaN(v) {

--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -55,8 +55,6 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 	}
 	interval := int64(bucketSizeInt32)
 
-	// Note: the request for the data is adjusted in expr.Metrics() so that the fetched
-	// data is already aligned by interval if this parameter is set to true
 	alignToInterval, err := e.GetBoolNamedOrPosArgDefault("alignToInterval", 2, false)
 	if err != nil {
 		return nil, err
@@ -64,11 +62,13 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 
 	start := args[0].StartTime
 	stop := args[0].StopTime
-	//if alignToInterval {
-	//	start = helper.AlignStartToInterval(start, stop, interval)
-	//	intervalCount := (stop - start) / interval
-	//	stop = start + (intervalCount * interval) + interval
-	//}
+
+	// Note: the start time for the fetch request is adjusted in expr.Metrics() so that the fetched
+	// data is already aligned by interval if this parameter is set to true
+	if alignToInterval {
+		intervalCount := (stop - start) / interval
+		stop = start + (intervalCount * interval) + interval
+	}
 
 	results := make([]*types.MetricData, 0, len(args))
 	for _, arg := range args {

--- a/expr/functions/hitcount/function_test.go
+++ b/expr/functions/hitcount/function_test.go
@@ -45,6 +45,18 @@ func TestHitcount(t *testing.T) {
 
 	tests := []th.SummarizeEvalTestItem{
 		{
+			"hitcount(metric1,\"6m\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
+					2, 4, 6}, 600, 100)},
+			},
+			[]float64{720, 960, 1440, 1920, 2160},
+			"hitcount(metric1,'6m')",
+			360,
+			100,
+			2200,
+		},
+		{
 			"hitcount(metric1,\"30s\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
@@ -102,6 +114,18 @@ func TestHitcount(t *testing.T) {
 			3600,
 			tenFiftyNine - (59 * 60),
 			tenFiftyNine + 25*5,
+		},
+		{
+			"hitcount(metric1,\"6m\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
+					2, 4, 6}, 600, 100)},
+			},
+			[]float64{720, 960, 1440, 1920, 2160},
+			"hitcount(metric1,'6m')",
+			360,
+			100,
+			2200,
 		},
 	}
 

--- a/expr/functions/hitcount/function_test.go
+++ b/expr/functions/hitcount/function_test.go
@@ -45,20 +45,6 @@ func TestHitcount(t *testing.T) {
 
 	tests := []th.SummarizeEvalTestItem{
 		{
-			"hitcount(metric1,\"1h\",true)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
-					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
-					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
-					5}, 5, tenFiftyNine)},
-			},
-			[]float64{105, 270},
-			"hitcount(metric1,'1h',true)",
-			3600,
-			1410343200,
-			1410350400,
-		},
-		{
 			"hitcount(metric1,\"30s\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
@@ -74,7 +60,7 @@ func TestHitcount(t *testing.T) {
 			"hitcount(metric1,'30s')",
 			30,
 			1410344975,
-			now32 + 31*5,
+			1410345155,
 		},
 		{
 			"hitcount(metric1,\"1h\")",
@@ -88,7 +74,7 @@ func TestHitcount(t *testing.T) {
 			"hitcount(metric1,'1h')",
 			3600,
 			1410343265,
-			tenFiftyNine + 25*5,
+			1410346865,
 		},
 		{
 			"hitcount(metric1,\"1h\",true)",
@@ -98,11 +84,11 @@ func TestHitcount(t *testing.T) {
 					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
 					5}, 5, tenFiftyNine)},
 			},
-			[]float64{105, 270},
+			[]float64{375},
 			"hitcount(metric1,'1h',true)",
 			3600,
-			1410343200,
-			tenFiftyNine + 25*5,
+			1410346740,
+			1410350340,
 		},
 		{
 			"hitcount(metric1,\"1h\",alignToInterval=true)",
@@ -112,37 +98,24 @@ func TestHitcount(t *testing.T) {
 					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
 					5}, 5, tenFiftyNine)},
 			},
-			[]float64{105, 270},
+			[]float64{375},
 			"hitcount(metric1,'1h',true)",
 			3600,
-			1410343200,
-			tenFiftyNine + 25*5,
+			1410346740,
+			1410350340,
 		},
 		{
-			"hitcount(metric1,\"6m\")",
+			"hitcount(metric1,\"15s\")", // Test having a smaller interval than the data's step
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
-					2, 4, 6}, 600, 100)},
+					11, 7, 19, 32, 23}, 30, now32)},
 			},
-			[]float64{720, 960, 1440, 1920, 2160},
-			"hitcount(metric1,'6m')",
-			360,
-			100,
-			2200,
-		},
-		{
-			"hitcount(metric1,\"30s\")",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
-					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
-					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
-					5}, 60, tenFiftyNine)}, //1410346740
-			},
-			[]float64{30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 150, 150, 150, 150, 150, 150, 150, 150, 150, 150},
-			"hitcount(metric1,'30s')",
-			30,
-			1410343265,
-			tenFiftyNine + 25*60,
+			[]float64{165, 165, 105, 105, 285, 285, 480, 480, 345, 345},
+
+			"hitcount(metric1,'15s')",
+			15,
+			1410345000,
+			1410345150,
 		},
 	}
 

--- a/expr/functions/hitcount/function_test.go
+++ b/expr/functions/hitcount/function_test.go
@@ -60,7 +60,7 @@ func TestHitcount(t *testing.T) {
 			"hitcount(metric1,'30s')",
 			30,
 			1410344975,
-			1410345155,
+			now32 + 31*5,
 		},
 		{
 			"hitcount(metric1,\"1h\")",
@@ -74,7 +74,7 @@ func TestHitcount(t *testing.T) {
 			"hitcount(metric1,'1h')",
 			3600,
 			1410343265,
-			1410346865,
+			tenFiftyNine + 25*5,
 		},
 		{
 			"hitcount(metric1,\"1h\",true)",
@@ -87,8 +87,8 @@ func TestHitcount(t *testing.T) {
 			[]float64{375},
 			"hitcount(metric1,'1h',true)",
 			3600,
-			1410346740,
-			1410350340,
+			tenFiftyNine,
+			tenFiftyNine + (((tenFiftyNine + 25*5) - tenFiftyNine) / 3600) + 3600, // The end time is adjusted because of alignToInterval being set to true
 		},
 		{
 			"hitcount(metric1,\"1h\",alignToInterval=true)",
@@ -101,8 +101,8 @@ func TestHitcount(t *testing.T) {
 			[]float64{375},
 			"hitcount(metric1,'1h',true)",
 			3600,
-			1410346740,
-			1410350340,
+			tenFiftyNine,
+			tenFiftyNine + (((tenFiftyNine + 25*5) - tenFiftyNine) / 3600) + 3600, // The end time is adjusted because of alignToInterval being set to true
 		},
 		{
 			"hitcount(metric1,\"15s\")", // Test having a smaller interval than the data's step
@@ -114,8 +114,8 @@ func TestHitcount(t *testing.T) {
 
 			"hitcount(metric1,'15s')",
 			15,
-			1410345000,
-			1410345150,
+			now32,
+			now32 + 5*30,
 		},
 	}
 

--- a/expr/functions/hitcount/function_test.go
+++ b/expr/functions/hitcount/function_test.go
@@ -45,6 +45,80 @@ func TestHitcount(t *testing.T) {
 
 	tests := []th.SummarizeEvalTestItem{
 		{
+			"hitcount(metric1,\"1h\",true)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
+					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
+					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
+					5}, 5, tenFiftyNine)},
+			},
+			[]float64{105, 270},
+			"hitcount(metric1,'1h',true)",
+			3600,
+			1410343200,
+			1410350400,
+		},
+		{
+			"hitcount(metric1,\"30s\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
+					1, 1, 1, 1, 1, 2,
+					2, 2, 2, 2, 3, 3,
+					3, 3, 3, 4, 4, 4,
+					4, 4, 5, 5, 5, 5,
+					math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+					5}, 5, now32)},
+			},
+			[]float64{5, 40, 75, 110, 120, 25},
+
+			"hitcount(metric1,'30s')",
+			30,
+			1410344975,
+			now32 + 31*5,
+		},
+		{
+			"hitcount(metric1,\"1h\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
+					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
+					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
+					5}, 5, tenFiftyNine)},
+			},
+			[]float64{375},
+			"hitcount(metric1,'1h')",
+			3600,
+			1410343265,
+			tenFiftyNine + 25*5,
+		},
+		{
+			"hitcount(metric1,\"1h\",true)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
+					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
+					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
+					5}, 5, tenFiftyNine)},
+			},
+			[]float64{105, 270},
+			"hitcount(metric1,'1h',true)",
+			3600,
+			1410343200,
+			tenFiftyNine + 25*5,
+		},
+		{
+			"hitcount(metric1,\"1h\",alignToInterval=true)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
+					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
+					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
+					5}, 5, tenFiftyNine)},
+			},
+			[]float64{105, 270},
+			"hitcount(metric1,'1h',true)",
+			3600,
+			1410343200,
+			tenFiftyNine + 25*5,
+		},
+		{
 			"hitcount(metric1,\"6m\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
@@ -60,72 +134,15 @@ func TestHitcount(t *testing.T) {
 			"hitcount(metric1,\"30s\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
-					1, 1, 1, 1, 1, 2,
-					2, 2, 2, 2, 3, 3,
-					3, 3, 3, 4, 4, 4,
-					4, 4, 5, 5, 5, 5,
-					math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
-					5}, 5, now32)},
+					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
+					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
+					5}, 60, tenFiftyNine)}, //1410346740
 			},
-			[]float64{35, 70, 105, 140, math.NaN(), 25},
+			[]float64{30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 150, 150, 150, 150, 150, 150, 150, 150, 150, 150},
 			"hitcount(metric1,'30s')",
 			30,
-			now32,
-			now32 + 31*5,
-		},
-		{
-			"hitcount(metric1,\"1h\")",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
-					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
-					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
-					5}, 5, tenFiftyNine)},
-			},
-			[]float64{375},
-			"hitcount(metric1,'1h')",
-			3600,
-			tenFiftyNine,
-			tenFiftyNine + 25*5,
-		},
-		{
-			"hitcount(metric1,\"1h\",true)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
-					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
-					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
-					5}, 5, tenFiftyNine)},
-			},
-			[]float64{105, 270},
-			"hitcount(metric1,'1h',true)",
-			3600,
-			tenFiftyNine - (59 * 60),
-			tenFiftyNine + 25*5,
-		},
-		{
-			"hitcount(metric1,\"1h\",alignToInterval=true)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
-					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
-					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
-					5}, 5, tenFiftyNine)},
-			},
-			[]float64{105, 270},
-			"hitcount(metric1,'1h',true)",
-			3600,
-			tenFiftyNine - (59 * 60),
-			tenFiftyNine + 25*5,
-		},
-		{
-			"hitcount(metric1,\"6m\")",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
-					2, 4, 6}, 600, 100)},
-			},
-			[]float64{720, 960, 1440, 1920, 2160},
-			"hitcount(metric1,'6m')",
-			360,
-			100,
-			2200,
+			1410343265,
+			tenFiftyNine + 25*60,
 		},
 	}
 

--- a/expr/helper/align.go
+++ b/expr/helper/align.go
@@ -401,3 +401,9 @@ func genNaNs(length int) []float64 {
 	}
 	return nans
 }
+
+func Divmod(numerator, denominator int64) (quotient, remainder int64) {
+	quotient = numerator / denominator // integer division, decimals are truncated
+	remainder = numerator % denominator
+	return
+}

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -108,7 +108,7 @@ type Expr interface {
 	MutateRawArgs(args string) Expr
 
 	// Metrics returns list of metric requests
-	Metrics() []MetricRequest
+	Metrics(from, until int64) []MetricRequest
 
 	// GetIntervalArg returns interval typed argument.
 	GetIntervalArg(n int, defaultSign int) (int32, error)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -231,7 +231,7 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 					// This is done in order to replicate the behavior in Graphite web when alignToInterval is set,
 					// in which new data is fetched with the adjusted start time.
 					for i, _ := range r {
-						start := from
+						start := r[i].From
 						for _, v := range []int64{86400, 3600, 60} {
 							if interval >= v {
 								start -= start % v

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -228,8 +228,9 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 						return nil
 					}
 					interval := int64(bucketSizeInt32)
-					var r2 []MetricRequest
-					for _, v := range r {
+					// This is done in order to replicate the behavior in Graphite web when alignToInterval is set,
+					// in which new data is fetched with the adjusted start time.
+					for i, _ := range r {
 						start := from
 						for _, v := range []int64{86400, 3600, 60} {
 							if interval >= v {
@@ -237,16 +238,9 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 								break
 							}
 						}
-						intervalCount := (until - start) / interval
-						stop := start + (intervalCount * interval) + interval
-						r2 = append(r2, MetricRequest{
-							Metric: v.Metric,
-							From:   start,
-							Until:  stop,
-						})
-					}
 
-					return r2
+						r[i].From = start
+					}
 				}
 			}
 		}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -137,23 +137,23 @@ func (e *expr) NamedArg(name string) (Expr, bool) {
 	return expr, exist
 }
 
-func (e *expr) Metrics() []MetricRequest {
+func (e *expr) Metrics(from, until int64) []MetricRequest {
 	switch e.etype {
 	case EtName:
-		return []MetricRequest{{Metric: e.target}}
+		return []MetricRequest{{Metric: e.target, From: from, Until: until}}
 	case EtConst, EtString:
 		return nil
 	case EtFunc:
 		var r []MetricRequest
 		for _, a := range e.args {
-			r = append(r, a.Metrics()...)
+			r = append(r, a.Metrics(from, until)...)
 		}
 
 		switch e.target {
 		case "transformNull":
 			referenceSeriesExpr := e.GetNamedArg("referenceSeries")
 			if !referenceSeriesExpr.IsInterfaceNil() {
-				r = append(r, referenceSeriesExpr.Metrics()...)
+				r = append(r, referenceSeriesExpr.Metrics(from, until)...)
 			}
 		case "timeShift":
 			offs, err := e.GetIntervalArg(1, -1)
@@ -210,6 +210,43 @@ func (e *expr) Metrics() []MetricRequest {
 				for i := range r {
 					fromNew := r[i].From - int64(offs)
 					r[i].From = fromNew
+				}
+			}
+		case "hitcount":
+			if len(e.args) < 2 {
+				return nil
+			}
+
+			if len(e.args) == 3 {
+				alignToInterval, err := e.GetBoolNamedOrPosArgDefault("alignToInterval", 2, false)
+				if err != nil {
+					return nil
+				}
+				if alignToInterval {
+					bucketSizeInt32, err := e.GetIntervalArg(1, 1)
+					if err != nil {
+						return nil
+					}
+					interval := int64(bucketSizeInt32)
+					var r2 []MetricRequest
+					for _, v := range r {
+						start := from
+						for _, v := range []int64{86400, 3600, 60} {
+							if interval >= v {
+								start -= start % v
+								break
+							}
+						}
+						intervalCount := (until - start) / interval
+						stop := start + (intervalCount * interval) + interval
+						r2 = append(r2, MetricRequest{
+							Metric: v.Metric,
+							From:   start,
+							Until:  stop,
+						})
+					}
+
+					return r2
 				}
 			}
 		}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -217,30 +217,29 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 				return nil
 			}
 
-			if len(e.args) == 3 {
-				alignToInterval, err := e.GetBoolNamedOrPosArgDefault("alignToInterval", 2, false)
+			alignToInterval, err := e.GetBoolNamedOrPosArgDefault("alignToInterval", 2, false)
+			if err != nil {
+				return nil
+			}
+			if alignToInterval {
+				bucketSizeInt32, err := e.GetIntervalArg(1, 1)
 				if err != nil {
 					return nil
 				}
-				if alignToInterval {
-					bucketSizeInt32, err := e.GetIntervalArg(1, 1)
-					if err != nil {
-						return nil
-					}
-					interval := int64(bucketSizeInt32)
-					// This is done in order to replicate the behavior in Graphite web when alignToInterval is set,
-					// in which new data is fetched with the adjusted start time.
-					for i, _ := range r {
-						start := r[i].From
-						for _, v := range []int64{86400, 3600, 60} {
-							if interval >= v {
-								start -= start % v
-								break
-							}
-						}
 
-						r[i].From = start
+				interval := int64(bucketSizeInt32)
+				// This is done in order to replicate the behavior in Graphite web when alignToInterval is set,
+				// in which new data is fetched with the adjusted start time.
+				for i, _ := range r {
+					start := r[i].From
+					for _, v := range []int64{86400, 3600, 60} {
+						if interval >= v {
+							start -= start % v
+							break
+						}
 					}
+
+					r[i].From = start
 				}
 			}
 		}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -522,6 +522,34 @@ func TestMetrics(t *testing.T) {
 			},
 		},
 		{
+			"hitcount(metric1, '1h', alignToInterval=True)",
+			&expr{
+				target: "hitcount",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+				},
+				namedArgs: map[string]*expr{
+					"alignToInterval": {
+						target: "true",
+						etype:  EtBool,
+						valStr: "true",
+					},
+				},
+				argString: "metric1, '1h', alignToInterval=True",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410343200,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
 			"hitcount(metric1, '1h')",
 			&expr{
 				target: "hitcount",

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -542,6 +542,36 @@ func TestMetrics(t *testing.T) {
 				},
 			},
 		},
+		{
+			"hitcount(timeShift(metric1, '-1h'),'1h')",
+			&expr{
+				target: "hitcount",
+				etype:  EtFunc,
+				args: []*expr{
+					{
+						target: "timeShift",
+						etype:  EtFunc,
+						args: []*expr{
+							{target: "metric1"},
+							{valStr: "-1h", etype: EtString},
+						},
+						argString: "metric1, '-1h'",
+					},
+					{valStr: "1h", etype: EtString},
+					{valStr: "true", etype: EtBool},
+				},
+				argString: "timeShift(metric1, '-1h'),'1h'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410339600,
+					Until:  1410343265,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.s, func(t *testing.T) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -490,3 +490,64 @@ func TestDoGetIntArg(t *testing.T) {
 		})
 	}
 }
+
+func TestMetrics(t *testing.T) {
+	tests := []struct {
+		s        string
+		e        *expr
+		from     int64
+		to       int64
+		expected []MetricRequest
+	}{
+		{
+			"hitcount(metric1, '1h', true)",
+			&expr{
+				target: "hitcount",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+					{valStr: "true", etype: EtBool},
+				},
+				argString: "metric1, '1h', true",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410343200,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
+			"hitcount(metric1, '1h')",
+			&expr{
+				target: "hitcount",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+				},
+				argString: "metric1, '1h'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410346740,
+					Until:  1410346865,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+
+			r := tt.e.Metrics(tt.from, tt.to)
+			assert.Equal(t, tt.expected, r)
+		})
+	}
+}


### PR DESCRIPTION
This PR is a rewrite of the hitcount function in order to match Graphite web's behavior. There are two major issues that were discovered: 

1) When the `interval` parameter was set to a value smaller than the fetched data's step between data points, it results were incorrectly shifted left, such that all of the hit counts were concentrated towards the left buckets, and there were empty buckets on the right. For example:

hitcount(metric1, "6m")
[]*types.MetricData{{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6}, 600, 100)},} // 10m step

The result will be []float64{1200, 2400, 3600, 0, 0, 0}. The hit values are all concentrated on the left half of the buckets.

2) Upon looking at Graphite web's implementation of hitcount, when the `alignToInterval` parameter is set to true, the start time is adjusted and the data is re-fetched. In CarbonAPI, the start time was adjusted, but data was not re-fetched. 

**Major changes in this PR:**
- The hitcount function was completely rewritten to match the behavior of Graphite web. This helps address the issue with intervals smaller than the data's step, as well as fixes discrepancies in results that were occurring with CarbonAPI tests that were tested in Graphite web. 
- The Metrics() function in pkg/parser.go was updated to pass in the from/to of the request, and code was added to determine the correct start time for the data being fetched for the hitcount function when `alignToInterval ` is set to true. The new start time is determined based on the request's from value and the interval specified. This is intended to prevent needing to re-fetch the data as is done in Graphite web. 
