### PR TITLE
Improve support for constant series

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -240,10 +240,13 @@ func EvalExpr(ctx context.Context, e parser.Expr, from, until int64, values map[
 	} else if e.IsConst() {
 		p := types.MetricData{
 			FetchResponse: pb.FetchResponse{
-				Name:   e.Target(),
-				Values: []float64{e.FloatValue()},
+				Name:      e.ToString(),
+				Values:    []float64{e.FloatValue()},
+				StartTime: from,
+				StopTime:  until,
+				StepTime:  until - from,
 			},
-			Tags: map[string]string{"name": e.Target()},
+			Tags: map[string]string{"name": e.ToString()},
 		}
 		return []*types.MetricData{&p}, nil
 	}

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -226,6 +226,11 @@ func TestEvalExpression(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("metric", []float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
 		{
+			"42",
+			map[parser.MetricRequest][]*types.MetricData{},
+			[]*types.MetricData{types.MakeMetricData("42", []float64{42}, 1, 0)},
+		},
+		{
 			"metric*",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric*", 0, 1}: {


### PR DESCRIPTION
Small change to populate the missing fields of a series created from a const. This should improve the support when querying for constants, which are useful to draw horizontal lines with requests like `target=10`.