### PR TITLE
Fix toUpperCase and toLowerCase to process queries that use correct function names

### DIFF
--- a/expr/functions/toLowerCase/function.go
+++ b/expr/functions/toLowerCase/function.go
@@ -22,7 +22,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &toLowerCase{}
-	functions := []string{"toLowerCase"}
+	functions := []string{"lower", "toLowerCase"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
@@ -68,6 +68,28 @@ func (f *toLowerCase) Do(ctx context.Context, e parser.Expr, from, until int64, 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
 func (f *toLowerCase) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
+		"lower": {
+			Description: "Takes one metric or a wildcard seriesList and lowers the case of each letter. \n Optionally, a letter position to lower case can be specified, in which case only the letter at the specified position gets lower-cased.\n The position parameter may be given multiple times. The position parameter may be negative to define a position relative to the end of the metric name.",
+			Function:    "lower(seriesList, *pos)",
+			Group:       "Alias",
+			Module:      "graphite.render.functions",
+			Name:        "lower",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Multiple: true,
+					Name:     "pos",
+					Type:     types.Node,
+					Required: false,
+				},
+			},
+			NameChange:   true, // name changed
+			ValuesChange: true, // values changed
+		},
 		"toLowerCase": {
 			Description: "Takes one metric or a wildcard seriesList and lowers the case of each letter. \n Optionally, a letter position to lower case can be specified, in which case only the letter at the specified position gets lower-cased.\n The position parameter may be given multiple times. The position parameter may be negative to define a position relative to the end of the metric name.",
 			Function:    "toLowerCase(seriesList, *pos)",

--- a/expr/functions/toLowerCase/function_test.go
+++ b/expr/functions/toLowerCase/function_test.go
@@ -27,7 +27,7 @@ func TestToLowerCaseFunction(t *testing.T) {
 
 	tests := []th.EvalTestItem{
 		{
-			"toLowerCase(METRIC.TEST.FOO)",
+			"lower(METRIC.TEST.FOO)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
@@ -35,7 +35,7 @@ func TestToLowerCaseFunction(t *testing.T) {
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 		{
-			"toLowerCase(METRIC.TEST.FOO,7)",
+			"lower(METRIC.TEST.FOO,7)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
@@ -43,7 +43,7 @@ func TestToLowerCaseFunction(t *testing.T) {
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 		{
-			"toLowerCase(METRIC.TEST.FOO,-3)",
+			"lower(METRIC.TEST.FOO,-3)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
@@ -51,11 +51,19 @@ func TestToLowerCaseFunction(t *testing.T) {
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 		{
-			"toLowerCase(METRIC.TEST.FOO,0,7,12)",
+			"lower(METRIC.TEST.FOO,0,7,12)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("mETRIC.tEST.fOO",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+		{
+			"toLowerCase(METRIC.TEST.FOO)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric.test.foo",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 	}

--- a/expr/functions/toUpperCase/function.go
+++ b/expr/functions/toUpperCase/function.go
@@ -22,7 +22,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &toUpperCase{}
-	functions := []string{"toLowerCase"}
+	functions := []string{"upper", "toUpperCase"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
@@ -67,6 +67,27 @@ func (f *toUpperCase) Do(ctx context.Context, e parser.Expr, from, until int64, 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
 func (f *toUpperCase) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
+		"upper": {
+			Description: "Takes one metric or a wildcard seriesList and uppers the case of each letter. \n Optionally, a letter position to upper case can be specified, in which case only the letter at the specified position gets upper-cased.\n The position parameter may be given multiple times. The position parameter may be negative to define a position relative to the end of the metric name.",
+			Function:    "upper(seriesList, *pos)",
+			Group:       "Alias",
+			Module:      "graphite.render.functions",
+			Name:        "upper",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Multiple: true,
+					Name:     "pos",
+					Type:     types.Node,
+				},
+			},
+			NameChange:   true, // name changed
+			ValuesChange: true, // values changed
+		},
 		"toUpperCase": {
 			Description: "Takes one metric or a wildcard seriesList and uppers the case of each letter. \n Optionally, a letter position to upper case can be specified, in which case only the letter at the specified position gets upper-cased.\n The position parameter may be given multiple times. The position parameter may be negative to define a position relative to the end of the metric name.",
 			Function:    "toUpperCase(seriesList, *pos)",

--- a/expr/functions/toUpperCase/function_test.go
+++ b/expr/functions/toUpperCase/function_test.go
@@ -23,11 +23,11 @@ func init() {
 }
 
 func TestToUpperCaseFunction(t *testing.T) {
-	now32 := int64(time.Now().Unix())
+	now32 := time.Now().Unix()
 
 	tests := []th.EvalTestItem{
 		{
-			"toUpperCase(metric.test.foo)",
+			"upper(metric.test.foo)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
@@ -35,7 +35,7 @@ func TestToUpperCaseFunction(t *testing.T) {
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 		{
-			"toUpperCase(metric.test.foo,7)",
+			"upper(metric.test.foo,7)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
@@ -43,7 +43,7 @@ func TestToUpperCaseFunction(t *testing.T) {
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 		{
-			"toLowerCase(metric.test.foo,-3)",
+			"upper(metric.test.foo,-3)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
@@ -51,11 +51,19 @@ func TestToUpperCaseFunction(t *testing.T) {
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 		{
-			"toUpperCase(metric.test.foo,0,7,12)",
+			"upper(metric.test.foo,0,7,12)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("Metric.Test.Foo",
+				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+		},
+		{
+			"toUpperCase(metric.test.foo)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("METRIC.TEST.FOO",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 	}


### PR DESCRIPTION
The functions toUpperCase and toLowerCase, as described in the  [graphite-web documentation](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.toUpperCase), are using the incorrect function names. The correct function name for toUpperCase is `upper` and the correct function name for toLowerCase is `lower`.  This is shown [here](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L6122-L6123) in the Graphite web code. Using a query with `toUpperCase` or `toLowerCase` also fails in Graphite web.

Because the documentation shows the functions names as toUpperCase and toLowerCase, this PR leaves those as acceptable function names to use in queries.