### PR TITLE
metrics/find, tags autocomplete: return detailed (non-internal server) error

### DIFF
--- a/cmd/carbonapi/http/find_handlers.go
+++ b/cmd/carbonapi/http/find_handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-graphite/carbonapi/date"
 	"github.com/go-graphite/carbonapi/intervalset"
 	utilctx "github.com/go-graphite/carbonapi/util/ctx"
+	"github.com/go-graphite/carbonapi/zipper/helper"
 )
 
 // Find handler and it's helper functions
@@ -175,6 +176,7 @@ func findList(multiGlobs *pbv3.MultiGlobResponse) ([]byte, error) {
 func findHandler(w http.ResponseWriter, r *http.Request) {
 	t0 := time.Now()
 	uid := uuid.NewV4()
+	carbonapiUUID := uid.String()
 	// TODO: Migrate to context.WithTimeout
 	// ctx, _ := context.WithTimeout(context.TODO(), config.Config.ZipperTimeout)
 	ctx := utilctx.SetUUID(r.Context(), uid.String())
@@ -197,7 +199,7 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 	var accessLogDetails = carbonapipb.AccessLogDetails{
 		Handler:        "find",
 		Username:       username,
-		CarbonapiUUID:  uid.String(),
+		CarbonapiUUID:  carbonapiUUID,
 		URL:            r.URL.RequestURI(),
 		PeerIP:         srcIP,
 		PeerPort:       srcPort,
@@ -214,10 +216,9 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if !ok || !format.ValidFindFormat() {
-		http.Error(w, "unsupported format: "+formatRaw, http.StatusBadRequest)
 		accessLogDetails.HTTPCode = http.StatusBadRequest
 		accessLogDetails.Reason = "unsupported format: " + formatRaw
-		logAsError = true
+		writeErrorResponse(w, int(accessLogDetails.HTTPCode), accessLogDetails.Reason, carbonapiUUID)
 		return
 	}
 
@@ -240,15 +241,16 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			accessLogDetails.HTTPCode = http.StatusBadRequest
 			accessLogDetails.Reason = "failed to parse message body: " + err.Error()
-			http.Error(w, "bad request (failed to parse format): "+err.Error(), http.StatusBadRequest)
+			writeErrorResponse(w, http.StatusBadRequest, accessLogDetails.Reason, carbonapiUUID)
 			return
 		}
 
 		err = pv3Request.Unmarshal(body)
 		if err != nil {
+			w.Header().Set(ctxHeaderUUID, carbonapiUUID)
 			accessLogDetails.HTTPCode = http.StatusBadRequest
 			accessLogDetails.Reason = "failed to parse message body: " + err.Error()
-			http.Error(w, "bad request (failed to parse format): "+err.Error(), http.StatusBadRequest)
+			writeErrorResponse(w, http.StatusBadRequest, accessLogDetails.Reason, carbonapiUUID)
 			return
 		}
 	} else {
@@ -258,10 +260,9 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(pv3Request.Metrics) == 0 {
-		http.Error(w, "missing parameter `query`", http.StatusBadRequest)
 		accessLogDetails.HTTPCode = http.StatusBadRequest
 		accessLogDetails.Reason = "missing parameter `query`"
-		logAsError = true
+		writeErrorResponse(w, http.StatusBadRequest, accessLogDetails.Reason, carbonapiUUID)
 		return
 	}
 
@@ -273,7 +274,7 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 		accessLogDetails.TotalMetricsCount += stats.TotalMetricsCount
 	}
 	if err != nil {
-		returnCode := merry.HTTPCode(err)
+		returnCode := merry.HTTPCode(helper.HttpErrorByCode(err))
 		if returnCode != http.StatusOK || multiGlobs == nil {
 			// Allow override status code for 404-not-found replies.
 			if returnCode == http.StatusNotFound {
@@ -283,9 +284,9 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 			if returnCode < 300 {
 				multiGlobs = &pbv3.MultiGlobResponse{Metrics: []pbv3.GlobResponse{}}
 			} else {
-				http.Error(w, http.StatusText(returnCode), returnCode)
 				accessLogDetails.HTTPCode = int32(returnCode)
 				accessLogDetails.Reason = err.Error()
+				writeErrorResponse(w, returnCode, accessLogDetails.Reason, carbonapiUUID)
 				// We don't want to log this as an error if it's something normal
 				// Normal is everything that is >= 500. So if config.Config.NotFoundStatusCode is 500 - this will be
 				// logged as error
@@ -365,12 +366,13 @@ func findHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		accessLogDetails.HTTPCode = http.StatusInternalServerError
 		accessLogDetails.Reason = err.Error()
+		writeErrorResponse(w, http.StatusInternalServerError, accessLogDetails.Reason, carbonapiUUID)
+
 		logAsError = true
 		return
 	}
 
-	writeResponse(w, http.StatusOK, b, format, jsonp, uid.String())
+	writeResponse(w, http.StatusOK, b, format, jsonp, carbonapiUUID)
 }

--- a/cmd/carbonapi/http/helper.go
+++ b/cmd/carbonapi/http/helper.go
@@ -158,6 +158,11 @@ func getFormat(r *http.Request, defaultFormat responseFormat) (responseFormat, b
 	return f, ok, format
 }
 
+func writeErrorResponse(w http.ResponseWriter, returnCode int, err, carbonapiUUID string) {
+	w.Header().Set(ctxHeaderUUID, carbonapiUUID)
+	http.Error(w, err, returnCode)
+}
+
 func writeResponse(w http.ResponseWriter, returnCode int, b []byte, format responseFormat, jsonp, carbonapiUUID string) {
 	//TODO: Simplify that switch
 	w.Header().Set(ctxHeaderUUID, carbonapiUUID)

--- a/cmd/carbonapi/http/tags_handler.go
+++ b/cmd/carbonapi/http/tags_handler.go
@@ -20,15 +20,16 @@ import (
 
 func tagHandler(w http.ResponseWriter, r *http.Request) {
 	t0 := time.Now()
-	uuid := uuid.NewV4()
+	uid := uuid.NewV4()
+	carbonapiUUID := uid.String()
 
 	// TODO: Migrate to context.WithTimeout
-	ctx := utilctx.SetUUID(r.Context(), uuid.String())
+	ctx := utilctx.SetUUID(r.Context(), uid.String())
 	requestHeaders := utilctx.GetLogHeaders(ctx)
 	username, _, _ := r.BasicAuth()
 
 	logger := zapwriter.Logger("tag").With(
-		zap.String("carbonapi_uuid", uuid.String()),
+		zap.String("carbonapi_uuid", uid.String()),
 		zap.String("username", username),
 		zap.Any("request_headers", requestHeaders),
 	)
@@ -39,7 +40,7 @@ func tagHandler(w http.ResponseWriter, r *http.Request) {
 	var accessLogDetails = &carbonapipb.AccessLogDetails{
 		Handler:        "tags",
 		Username:       username,
-		CarbonapiUUID:  uuid.String(),
+		CarbonapiUUID:  carbonapiUUID,
 		URL:            r.URL.Path,
 		PeerIP:         srcIP,
 		PeerPort:       srcPort,
@@ -57,8 +58,8 @@ func tagHandler(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
 	if err != nil {
 		logAsError = true
-		w.Header().Set("Content-Type", contentTypeJSON)
-		_, _ = w.Write([]byte{'[', ']'})
+		accessLogDetails.HTTPCode = int32(http.StatusBadRequest)
+		writeErrorResponse(w, http.StatusBadRequest, accessLogDetails.Reason, carbonapiUUID)
 		return
 	}
 
@@ -87,15 +88,16 @@ func tagHandler(w http.ResponseWriter, r *http.Request) {
 	} else if strings.HasSuffix(r.URL.Path, "values") || strings.HasSuffix(r.URL.Path, "values/") {
 		res, err = config.Config.ZipperInstance.TagValues(ctx, rawQuery, limit)
 	} else {
-		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		writeErrorResponse(w, http.StatusNotFound, http.StatusText(http.StatusNotFound), carbonapiUUID)
 		accessLogDetails.HTTPCode = http.StatusNotFound
 		return
 	}
 
 	// TODO(civil): Implement stats
 	if err != nil && !merry.Is(err, types.ErrNoMetricsFetched) && !merry.Is(err, types.ErrNonFatalErrors) {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		accessLogDetails.HTTPCode = http.StatusInternalServerError
+		code := merry.HTTPCode(err)
+		writeErrorResponse(w, code, http.StatusText(code), carbonapiUUID)
+		accessLogDetails.HTTPCode = int32(code)
 		accessLogDetails.Reason = err.Error()
 		logAsError = true
 		return
@@ -109,7 +111,7 @@ func tagHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		writeErrorResponse(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), carbonapiUUID)
 		accessLogDetails.HTTPCode = http.StatusInternalServerError
 		accessLogDetails.Reason = err.Error()
 		logAsError = true
@@ -117,7 +119,7 @@ func tagHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", contentTypeJSON)
-	w.Header().Set(ctxHeaderUUID, uuid.String())
+	w.Header().Set(ctxHeaderUUID, uid.String())
 	_, _ = w.Write(b)
 	accessLogDetails.Runtime = time.Since(t0).Seconds()
 	accessLogDetails.HTTPCode = http.StatusOK

--- a/zipper/broadcast/broadcast_group.go
+++ b/zipper/broadcast/broadcast_group.go
@@ -607,7 +607,8 @@ func (bg *BroadcastGroup) Find(ctx context.Context, request *protov3.MultiGlobRe
 	if len(result.Response.Metrics) == 0 {
 		nonNotFoundErrors := types.ReturnNonNotFoundError(result.Err)
 		if nonNotFoundErrors != nil {
-			err := types.ErrFailedToFetch.WithHTTPCode(500)
+			code := helper.MergeHttpErrorsCode(result.Err)
+			err := types.ErrFailedToFetch.WithHTTPCode(code)
 			for _, e := range nonNotFoundErrors {
 				err = err.WithCause(e)
 			}
@@ -818,10 +819,8 @@ func (bg *BroadcastGroup) tagEverything(ctx context.Context, isTagName bool, que
 
 	var err merry.Error
 	if result.Err != nil {
-		err = types.ErrNonFatalErrors
-		for _, e := range result.Err {
-			err = err.WithCause(e)
-		}
+		code := helper.MergeHttpErrorsCode(result.Err)
+		err = types.ErrFailedToFetch.WithHTTPCode(code)
 	}
 
 	return result.Response, err

--- a/zipper/zipper.go
+++ b/zipper/zipper.go
@@ -161,7 +161,6 @@ func NewZipper(sender func(*types.Stats), cfg *config.Config, logger *zap.Logger
 		)
 	}
 
-
 	logger.Error("DEBUG ERROR LOGGGGG", zap.Any("cfg", cfg))
 	broadcastGroup, err := broadcast.New(
 		broadcast.WithLogger(logger),


### PR DESCRIPTION
Try to return detailed error (non InternalServerError, if possible). Also fix for issue #657

Fixes #657 