### PR TITLE
Fix groupByNode/groupByNodes returning more results than expected

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -293,6 +293,65 @@ func TestEvalExpression(t *testing.T) {
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1.baz", []float64{22, 48, 78, 112, 150}, 1, now32).SetTag("aggregatedBy", "multiply").SetNameTag("metric1.foo.*.*")},
 		},
+		{
+			"groupByNode(metric1foo.*,0,\"asPercent\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1foo.*", 0, 1}: {
+					types.MakeMetricData("metric1foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric1foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, now32),
+					types.MakeMetricData("metric1foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, now32),
+					types.MakeMetricData("metric1foo.bar2.qux", []float64{7, 8, 9, 10, 11}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1foo", []float64{4, 6.896551724137931, 9.09090909090909, 10.81081081081081, 12.195121951219512}, 1, now32)},
+		},
+		{
+			"groupByNodes(test.metric*.foo*,\"keepLastValue\",1,0)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"test.metric*.foo*", 0, 1}: {
+					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo2", []float64{0}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1.test", []float64{0}, 1, now32),
+				types.MakeMetricData("metric2.test", []float64{0}, 1, now32),
+			},
+		},
+		{
+			"groupByNodes(test.metric*.foo*,\"keepLastValue\",1,2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"test.metric*.foo*", 0, 1}: {
+					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo2", []float64{0}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1.foo1", []float64{0}, 1, now32),
+				types.MakeMetricData("metric1.foo2", []float64{0}, 1, now32),
+				types.MakeMetricData("metric2.foo1", []float64{0}, 1, now32),
+				types.MakeMetricData("metric2.foo2", []float64{0}, 1, now32),
+			},
+		},
+		{
+			"groupByNodes(test.metric*.foo*,\"keepLastValue\",1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"test.metric*.foo*", 0, 1}: {
+					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo2", []float64{0}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{0}, 1, now32),
+				types.MakeMetricData("metric2", []float64{0}, 1, now32),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/functions/groupByNode/function.go
+++ b/expr/functions/groupByNode/function.go
@@ -110,8 +110,16 @@ func (f *groupByNode) Do(ctx context.Context, e parser.Expr, from, until int64, 
 
 		r, _ := f.Evaluator.Eval(ctx, nexpr, from, until, nvalues)
 		if r != nil {
+			var res []*types.MetricData
+			if len(r) > 0 {
+				// Only the first result is used. See implementation in Graphite-web:
+				// https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/functions.py
+				res = []*types.MetricData{r[0]}
+			} else {
+				res = r
+			}
 			// avoid overwriting, do copy-on-write
-			rg := types.CopyMetricDataSliceWithName([]*types.MetricData{r[0]}, k) // Only the first result is used. See implementation in Graphite-web: https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/functions.py
+			rg := types.CopyMetricDataSliceWithName(res, k)
 			results = append(results, rg...)
 		}
 	}

--- a/expr/functions/groupByNode/function.go
+++ b/expr/functions/groupByNode/function.go
@@ -111,7 +111,7 @@ func (f *groupByNode) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		r, _ := f.Evaluator.Eval(ctx, nexpr, from, until, nvalues)
 		if r != nil {
 			// avoid overwriting, do copy-on-write
-			rg := types.CopyMetricDataSliceWithName(r, k)
+			rg := types.CopyMetricDataSliceWithName([]*types.MetricData{r[0]}, k) // Only the first result is used. See implementation in Graphite-web: https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/functions.py
 			results = append(results, rg...)
 		}
 	}

--- a/expr/functions/groupByNode/function_test.go
+++ b/expr/functions/groupByNode/function_test.go
@@ -28,6 +28,8 @@ func init() {
 	helper.SetEvaluator(evaluator)
 }
 
+// Note: some of these tests are influenced by the testcases for groupByNode and groupByNodes functions
+// in Graphite-web. See: https://github.com/graphite-project/graphite-web/blob/master/webapp/tests/test_functions.py
 func TestGroupByNode(t *testing.T) {
 	now32 := int64(time.Now().Unix())
 
@@ -210,6 +212,37 @@ func TestGroupByNode(t *testing.T) {
 			Results: map[string][]*types.MetricData{
 				"lag":  {types.MakeMetricData("lag", []float64{1, 2, 3, 4, 5}, 1, now32).SetTag("aggregatedBy", "sum")},
 				"lag=": {types.MakeMetricData("lag=", []float64{1, 0, 3, 4, 5}, 1, now32).SetTag("aggregatedBy", "sum")},
+			},
+		},
+		{
+			Name:   "groupByNodes_range",
+			Target: `groupByNodes(test.metric*.foo*,"range",1,0)`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"test.metric*.foo*", 0, 1}: {
+					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo2", []float64{0}, 1, now32),
+				},
+			},
+			Results: map[string][]*types.MetricData{
+				"metric1.test": {types.MakeMetricData("metric1.test", []float64{0}, 1, now32).SetTag("aggregatedBy", "range")},
+				"metric2.test": {types.MakeMetricData("metric2.test", []float64{0}, 1, now32).SetTag("aggregatedBy", "range")},
+			},
+		},
+		{
+			Name:   "groupByNodes_average_no_nodes",
+			Target: `groupByNodes(test.metric*.foo*,"average")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"test.metric*.foo*", 0, 1}: {
+					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),
+					types.MakeMetricData("test.metric2.foo2", []float64{0}, 1, now32),
+				},
+			},
+			Results: map[string][]*types.MetricData{
+				"": {types.MakeMetricData("", []float64{0}, 1, now32).SetTag("aggregatedBy", "average")},
 			},
 		},
 	}


### PR DESCRIPTION
This PR fixes an issue in which groupByNode/groupByNodes functions were returning more series than expected (based on issuing the same query in Graphite-web). The [Graphite-web implementation](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L5163)  returns only the first result of the series that are returned from the callback function. In order to match the expected behavior, these functions have been updated to do the same.