### PR TITLE
Various fixes for `exponentialMovingAverage`

### DIFF
--- a/expr/functions/exponentialMovingAverage/function_test.go
+++ b/expr/functions/exponentialMovingAverage/function_test.go
@@ -2,6 +2,7 @@ package exponentialMovingAverage
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -22,37 +23,73 @@ func init() {
 }
 
 func TestExponentialMovingAverage(t *testing.T) {
-	startTime := int64(0)
+	const from = 100
+	const step = 10
 
-	tests := []th.EvalTestItem{
+	tests := []th.EvalTestItemWithRange{
 		{
-			"exponentialMovingAverage(metric1,3)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, startTime)},
+			Target: "exponentialMovingAverage(metric1,'30s')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", from - 30, from + step*6}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, step, from-30)},
 			},
-			[]*types.MetricData{
-				types.MakeMetricData("exponentialMovingAverage(metric1,3)", []float64{4, 6, 9, 11.5, 13.75, 15.875, 17.9375}, 1, 0).SetTag("exponentialMovingAverage", "3"),
+			Want: []*types.MetricData{
+				types.MakeMetricData("exponentialMovingAverage(metric1,\"30s\")", []float64{4, 4.258065, 4.757544, 5.353832, 6.040681, 6.81225, 7.663073}, step, from).SetTag("exponentialMovingAverage", `"30s"`),
 			},
+			From:  from,
+			Until: from + step*6,
 		},
 		{
-			"exponentialMovingAverage(metric1,'3s')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, startTime)},
+			Target: "exponentialMovingAverage(empty,3)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				// When the window is an integer, the original from-until range is used to get the step.
+				// That's why two requests are made.
+				{"empty", from, from + step*4}:          {},
+				{"empty", from - step*3, from + step*4}: {},
 			},
-			[]*types.MetricData{
-				types.MakeMetricData("exponentialMovingAverage(metric1,\"3s\")", []float64{4, 6, 9, 11.5, 13.75, 15.875, 17.9375}, 1, 0).SetTag("exponentialMovingAverage", "3"),
-			},
+			Want:  []*types.MetricData{},
+			From:  from,
+			Until: from + step*4,
 		},
 		{
-			// if the window is larger than the length of the values, the result should just be the average.
-			// this matches graphiteweb's behavior
-			"exponentialMovingAverage(metric1,100)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, startTime)},
+			Target: "exponentialMovingAverage(metric_changes_rollup,4)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric_changes_rollup", from, from + step*6}: {types.MakeMetricData("metric_changes_rollup", []float64{8, 12, 14, 16, 18, 20}, step, from)},
+				// when querying for the preview window, the store changes the rollup and the step changes
+				{"metric_changes_rollup", from - step*4, from + step*6}: {types.MakeMetricData("metric_changes_rollup", []float64{10, 20}, step*10, from-step*4)},
 			},
-			[]*types.MetricData{
-				types.MakeMetricData("exponentialMovingAverage(metric1,100)", []float64{2}, 1, 0).SetTag("exponentialMovingAverage", "100"),
+			Want: []*types.MetricData{
+				// since the input is shorter than the window, the result should be just the average
+				types.MakeMetricData("exponentialMovingAverage(metric_changes_rollup,4)", []float64{15}, step*10, from).SetTag("exponentialMovingAverage", "4"),
 			},
+			From:  from,
+			Until: from + step*6,
+		},
+		{
+			// copied from Graphite Web
+			Target: "exponentialMovingAverage(halfNone,10)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"halfNone", from, from + 10}:      {types.MakeMetricData("halfNone", append(append(append(nans(10), rangeFloats(0, 5, 1)...), math.NaN()), rangeFloats(5, 9, 1)...), 1, from)},
+				{"halfNone", from - 10, from + 10}: {types.MakeMetricData("halfNone", append(append(append(nans(10), rangeFloats(0, 5, 1)...), math.NaN()), rangeFloats(5, 9, 1)...), 1, from-10)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("exponentialMovingAverage(halfNone,10)", []float64{0, 0.0, 0.181818, 0.512397, 0.964688, 1.516563, math.NaN(), 2.149915, 2.849931, 3.604489, 4.403673}, 1, from).SetTag("exponentialMovingAverage", `10`),
+			},
+			From:  from,
+			Until: from + 10,
+		},
+		// copied from Graphite Web
+		{
+			Target: `exponentialMovingAverage(collectd.test-db0.load.value,"-30s")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"collectd.test-db0.load.value", from - 30, from + 30}: {types.MakeMetricData("collectd.test-db0.load.value", rangeFloats(0, 60, 1), 1, from-30)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("exponentialMovingAverage(collectd.test-db0.load.value,\"-30s\")", []float64{
+					14.5, 15.5, 16.5, 17.5, 18.5, 19.5, 20.5, 21.5, 22.5, 23.5, 24.5, 25.5, 26.5, 27.5, 28.5, 29.5, 30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5,
+				}, 1, from).SetTag("exponentialMovingAverage", `"-30s"`),
+			},
+			From:  from,
+			Until: from + 30,
 		},
 	}
 
@@ -60,9 +97,25 @@ func TestExponentialMovingAverage(t *testing.T) {
 		tt := tt
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprWithRange(t, &tt)
 		})
 	}
+}
+
+func nans(n int) []float64 {
+	res := make([]float64, n)
+	for i := range res {
+		res[i] = math.NaN()
+	}
+	return res
+}
+
+func rangeFloats(start, end, step float64) []float64 {
+	res := make([]float64, 0, int((end-start)/step))
+	for i := start; i < end; i += step {
+		res = append(res, i)
+	}
+	return res
 }
 
 func BenchmarkExponentialMovingAverage(b *testing.B) {


### PR DESCRIPTION
Multiple fixes for `exponentialMovingAverage`:

- Adjust the `from` to take the preview window of the series when getting the argument. This bug was previously producing empty results in some scenarios.
- Correctly calculate the `previewSeconds` when the window size is an integer, and refetch the data as necessary
- Correctly calculate the `constant` used for the window, which is calculated differently depending on whether the window is an integer or a string interval. See [graphite web](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L1408-L1411)
- Default to zero when the preview average (of the window) is NaN. See [Graphite Web](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L1432).
- Set Start Time [like Graphite Web does](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L1430).