### PR TITLE
Fix various issues with moving* functions

### DIFF
--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -180,7 +180,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		w := &types.Windowed{Data: make([]float64, windowSize)}
 		for i, v := range a.Values {
 			if ridx := i - offset; ridx >= 0 {
-				if helper.XFilesFactorValues(w.Data, xFilesFactor) {
+				if w.IsNonNull() && helper.XFilesFactorValues(w.Data, xFilesFactor) {
 					switch cons {
 					case "average":
 						r.Values[ridx] = w.Mean()

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -105,7 +105,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		}
 		preview = maxStep * int64(n)
 		adjustedStart -= maxStep * int64(n)
-		windowPoints = int(preview)
+		windowPoints = n
 		refetch = true
 	case parser.EtString:
 		var n32 int32
@@ -195,7 +195,12 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			result[j] = r
 			continue
 		}
-		r.Values = make([]float64, len(a.Values)-int(windowPoints))
+
+		size := len(a.Values) - windowPoints
+		if size < 0 {
+			size = 0
+		}
+		r.Values = make([]float64, size)
 		r.StartTime = a.StartTime + preview
 		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
 

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -94,7 +94,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		// and leading `n` values, that used to calculate window, become NaN
 		n, err = e.GetIntArg(1)
 		argstr = strconv.Itoa(n)
-		// Find the maximum step to use for the windowPoints
+		// Find the maximum step to use for determining the altered start time
 		var maxStep int64
 		for _, a := range arg {
 			if a.StepTime > maxStep {
@@ -106,7 +106,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		var n32 int32
 		n32, err = e.GetIntervalArg(1, 1)
 		argstr = "'" + e.Arg(1).StringValue() + "'"
-		n = int(math.Abs(float64(n32)))
+		n = int(math.Abs(float64(n32))) // Absolute is used in order to handle negative string intervals
 		adjustedStart -= int64(n)
 	default:
 		err = parser.ErrBadType
@@ -194,7 +194,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
 
 		w := &types.Windowed{Data: make([]float64, windowSize)}
-		for i := 1; i < len(a.Values); i++ {
+		for i := 1; i < len(a.Values); i++ { // ignoring the first value in the series to avoid shifting of results one step in the future
 			w.Push(a.Values[i])
 
 			if ridx := i - offset; ridx >= 0 {

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -133,6 +133,16 @@ func TestMoving(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("movingMax(metric1,2)",
 				[]float64{math.NaN(), math.NaN(), 2, 3, 3, 2}, 1, 0).SetTag("movingMax", "2").SetNameTag("movingMax(metric1,2)")}, // StartTime = from
 		},
+		{
+			"movingAverage(metric1,'3sec')", // Check that a window that consists only of NaN points returns a value of math.NaN()
+			map[parser.MetricRequest][]*types.MetricData{
+				// These values introduce numerical errors in the sum, making it non-zero when it should be. 
+				// This causes a `0.0000...01/0` division, that results in infinity
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1e20, 0.e-20, 1, math.NaN(), math.NaN(), math.NaN(), 1, 1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, 1, 0}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'3sec')`,
+				[]float64{3.333333333333333e+19, 0, 0, math.NaN(), 0, 0.5, 0.5, 0, math.NaN(), math.NaN(), 1, 1}, 1, 0).SetTag("movingAverage", "'3sec'").SetNameTag(`movingAverage(metric1,'3sec')`)}, // StartTime = from
+		},
 	}
 
 	for n, tt := range tests {

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -26,169 +26,267 @@ func init() {
 }
 
 func TestMoving(t *testing.T) {
-	now32 := int64(time.Now().Unix())
-
-	tests := []th.EvalTestItem{
+	tests := []th.EvalTestItemWithRange{
 		{
-			"movingWindow(metric1,'3sec','average')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+			Target: "movingAverage(metric1,10)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 20, 25}: {types.MakeMetricData("metric1", generateValues(10, 25, 1), 1, 20)},
+				{"metric1", 10, 25}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 10)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
-				[]float64{2, 2, 2}, 1, 0).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,10)`,
+				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 20).SetTag("movingAverage", "10").SetNameTag(`movingAverage(metric1,10)`)},
+			From:  20,
+			Until: 25,
 		},
 		{
-			"movingWindow(metric1,'3sec','avg_zero')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, now32)},
+			Target: "movingAverage(metric1,10)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 20, 30}: {types.MakeMetricData("metric1", generateValues(10, 110, 1), 1, 20)},
+				{"metric1", 10, 30}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, 10)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
-				[]float64{1, 1, 0.3333333333333333}, 1, 0).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,10)`,
+				[]float64{0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5}, 1, 20).SetTag("movingAverage", "10").SetNameTag(`movingAverage(metric1,10)`)},
+			From:  20,
+			Until: 30,
 		},
 		{
-			"movingWindow(metric1,'3sec','count')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, now32)},
+			Target: "movingAverage(metric1,60)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", generateValues(10, 110, 1), 1, 610)},
+				{"metric1", 550, 710}: {types.MakeMetricData("metric1", generateValues(0, 100, 1), 1, 600)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
-				[]float64{2, 2, 1}, 1, 0).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,60)`,
+				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingAverage", "60").SetNameTag(`movingAverage(metric1,60)`)},
+			From:  610,
+			Until: 710,
 		},
 		{
-			"movingWindow(metric1,'3sec','diff')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, now32)},
+			Target: "movingAverage(metric1,'-1min')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", generateValues(10, 110, 1), 1, 610)},
+				{"metric1", 550, 710}: {types.MakeMetricData("metric1", generateValues(0, 100, 1), 1, 600)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
-				[]float64{-4, -1, 3}, 1, 0).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'-1min')`,
+				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingAverage", "'-1min'").SetNameTag(`movingAverage(metric1,'-1min')`)},
+			From:  610,
+			Until: 710,
 		},
 		{
-			"movingWindow(metric1,'3sec','range')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, now32)},
+			Target: "movingMedian(metric1,10)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 20, 30}: {types.MakeMetricData("metric1", generateValues(10, 110, 1), 1, 20)},
+				{"metric1", 10, 30}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, 10)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
-				[]float64{2, 3, 3}, 1, 0).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,10)`,
+				[]float64{0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5}, 1, 20).SetTag("movingMedian", "10").SetNameTag(`movingMedian(metric1,10)`)},
+			From:  20,
+			Until: 30,
 		},
 		{
-			"movingWindow(metric1,'3sec','stddev')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 0, 3, math.NaN(), 5}, 1, now32)},
+			Target: "movingMedian(metric1,10)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 20, 25}: {types.MakeMetricData("metric1", generateValues(10, 25, 1), 1, 20)},
+				{"metric1", 10, 25}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 10)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
-				[]float64{0.8164965809277259, 1.247219128924647, 1.5}, 1, 0).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,10)`,
+				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 20).SetTag("movingMedian", "10").SetNameTag(`movingMedian(metric1,10)`)},
+			From:  20,
+			Until: 25,
 		},
 		{
-			"movingWindow(metric1,'3sec','last')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, now32)},
+			Target: "movingMedian(metric1,60)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", generateValues(10, 110, 1), 1, 610)},
+				{"metric1", 550, 710}: {types.MakeMetricData("metric1", generateValues(0, 100, 1), 1, 600)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
-				[]float64{3, 0, math.NaN()}, 1, 0).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,60)`,
+				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingMedian", "60").SetNameTag(`movingMedian(metric1,60)`)},
+			From:  610,
+			Until: 710,
 		},
 		{
-			"movingAverage(metric1,'3sec')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+			Target: "movingMedian(metric1,'1min')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", generateValues(10, 110, 1), 1, 610)},
+				{"metric1", 550, 710}: {types.MakeMetricData("metric1", generateValues(0, 100, 1), 1, 600)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'3sec')`,
-				[]float64{2, 2, 2}, 1, 0).SetTag("movingAverage", "'3sec'").SetNameTag(`movingAverage(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,'1min')`,
+				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingMedian", "'1min'").SetNameTag(`movingMedian(metric1,'1min')`)},
+			From:  610,
+			Until: 710,
 		},
 		{
-			"movingAverage(metric1,4)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, now32)},
+			Target: "movingMedian(metric1,'-1min')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", generateValues(10, 110, 1), 1, 610)},
+				{"metric1", 550, 710}: {types.MakeMetricData("metric1", generateValues(0, 100, 1), 1, 600)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingAverage(metric1,4)",
-				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1.25, 1.5, 1.75, 2.5, 3.5, 4, 5}, 1, 0).SetTag("movingAverage", "4").SetNameTag("movingAverage(metric1,4)")}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,'-1min')`,
+				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingMedian", "'-1min'").SetNameTag(`movingMedian(metric1,'-1min')`)},
+			From:  610,
+			Until: 710,
 		},
 		{
-			"movingAverage(metric1,'5s')",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -5, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, now32)}, // step > windowSize
+			Target: "movingWindow(metric1,'3sec','average')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 610)},
+				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 607)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'5s')`,
-				[]float64{math.NaN(), math.NaN(), math.NaN()}, 10, now32).SetTag("movingAverage", "'5s'").SetNameTag(`movingAverage(metric1,'5s')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
+				[]float64{2, 2, 2}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
+			From:  610,
+			Until: 710,
 		},
 		{
-			"movingSum(metric1,2)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, 6}, 1, now32)},
+			Target: "movingWindow(metric1,'3sec','avg_zero')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 610)},
+				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 607)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingSum(metric1,2)",
-				[]float64{math.NaN(), math.NaN(), 3, 5, 7, 9}, 1, 0).SetTag("movingSum", "2").SetNameTag("movingSum(metric1,2)")}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
+				[]float64{1.5, 1, 2}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
+			From:  610,
+			Until: 710,
 		},
 		{
-			"movingMin(metric1,2)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 2, 1, 0}, 1, now32)},
+			Target: "movingWindow(metric1,'3sec','count')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 610)},
+				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 607)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMin(metric1,2)",
-				[]float64{math.NaN(), math.NaN(), 1, 2, 2, 1}, 1, 0).SetTag("movingMin", "2").SetNameTag("movingMin(metric1,2)")}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
+				[]float64{2, 1, 2}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
+			From:  610,
+			Until: 710,
 		},
 		{
-			"movingMax(metric1,2)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 2, 1, 0}, 1, now32)},
+			Target: "movingWindow(metric1,'3sec','diff')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
+				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMax(metric1,2)",
-				[]float64{math.NaN(), math.NaN(), 2, 3, 3, 2}, 1, 0).SetTag("movingMax", "2").SetNameTag("movingMax(metric1,2)")}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
+				[]float64{-1, 3, -5}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
+			From:  610,
+			Until: 710,
 		},
 		{
-			"movingAverage(metric1,'3sec')", // Check that a window that consists only of NaN points returns a value of math.NaN()
-			map[parser.MetricRequest][]*types.MetricData{
-				// These values introduce numerical errors in the sum, making it non-zero when it should be. 
-				// This causes a `0.0000...01/0` division, that results in infinity
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1e20, 0.e-20, 1, math.NaN(), math.NaN(), math.NaN(), 1, 1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, 1, 0}, 1, now32)},
+			Target: "movingWindow(metric1,'3sec','range')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
+				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'3sec')`,
-				[]float64{3.333333333333333e+19, 0, 0, math.NaN(), 0, 0.5, 0.5, 0, math.NaN(), math.NaN(), 1, 1}, 1, 0).SetTag("movingAverage", "'3sec'").SetNameTag(`movingAverage(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
+				[]float64{3, 3, 5}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
+			From:  610,
+			Until: 710,
+		},
+		{
+			Target: "movingWindow(metric1,'3sec','stddev')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
+				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
+				[]float64{1.247219128924647, 1.5, 2.5}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			From:  610,
+			Until: 710,
+		},
+		{
+			Target: "movingWindow(metric1,'3sec','last')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
+				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
+				[]float64{0, math.NaN(), 5}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			From:  610,
+			Until: 710,
+		},
+		{
+			Target: "movingWindow(metric1,'3sec')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 610)},
+				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 607)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
+				[]float64{2, 2, 2}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
+			From:  610,
+			Until: 710,
+		},
+		{
+			Target: "movingAverage(metric1,4)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, 610)},
+				{"metric1", 606, 710}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, 606)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,4)`,
+				[]float64{1.25, 1.5, 1.75, 2.5, 3.5, 4.0, 5.0, 6.0}, 1, 610).SetTag("movingAverage", "4").SetNameTag(`movingAverage(metric1,4)`)}, // StartTime = from
+			From:  610,
+			Until: 710,
+		},
+		{
+			Target: "movingAverage(metric1,'5s')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 610)}, // step > windowSize
+				{"metric1", 605, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 605)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'5s')`,
+				[]float64{math.NaN(), math.NaN(), math.NaN()}, 10, 610).SetTag("movingAverage", "'5s'").SetNameTag(`movingAverage(metric1,'5s')`)}, // StartTime = from
+			From:  610,
+			Until: 710,
 		},
 	}
 
 	for n, tt := range tests {
 		testName := tt.Target
 		t.Run(testName+"#"+strconv.Itoa(n), func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprWithRange(t, &tt)
 		})
 	}
 }
 
 func TestMovingXFilesFactor(t *testing.T) {
-	now32 := int64(time.Now().Unix())
-
-	tests := []th.EvalTestItem{
+	tests := []th.EvalTestItemWithRange{
 		{
-			"movingSum(metric1,'3sec',0.5)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, math.NaN(), 2, math.NaN(), 3}, 1, now32)},
+			Target: "movingSum(metric1,'3sec',0.5)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 618}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, math.NaN(), 2, math.NaN(), 3}, 1, 610)},
+				{"metric1", 607, 618}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, math.NaN(), 2, math.NaN(), 3}, 1, 607)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingSum(metric1,'3sec')`,
-				[]float64{6, 6, 4, 3, math.NaN()}, 1, 0).SetTag("movingSum", "'3sec'").SetNameTag(`movingSum(metric1,'3sec')`)}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingSum(metric1,'3sec')`,
+				[]float64{6, 4, 3, math.NaN(), 5}, 1, 610).SetTag("movingSum", "'3sec'").SetNameTag(`movingSum(metric1,'3sec')`)},
+			From:  610,
+			Until: 618,
 		},
 		{
-			"movingAverage(metric1,4,0.6)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, math.NaN(), 2, 4, math.NaN(), 4, 6, 8}, 1, now32)},
+			Target: "movingAverage(metric1,4,0.6)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 622}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, math.NaN(), 2, 4, math.NaN(), 4, 6, 8}, 1, 610)},
+				{"metric1", 606, 622}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, math.NaN(), 2, 4, math.NaN(), 4, 6, 8}, 1, 606)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingAverage(metric1,4)",
-				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1.25,
-					1.3333333333333333, 1.6666666666666667, 2.666666666666666, math.NaN(), 3.3333333333333335, 4.666666666666667}, 1, 0).SetTag(
-				"movingAverage", "4").SetNameTag("movingAverage(metric1,4)")}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,4)`,
+				[]float64{1.25, 1.3333333333333333, 1.6666666666666667, 2.6666666666666665, math.NaN(), 3.3333333333333335, 4.666666666666667, 6}, 1, 610).SetTag("movingAverage", "4").SetNameTag(`movingAverage(metric1,4)`)},
+			From:  610,
+			Until: 622,
 		},
 		{
-			"movingMax(metric1,2,0.5)",
-			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), 0}, 1, now32)},
+			Target: "movingMax(metric1,2,0.5)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 616}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), 0}, 1, 610)},
+				{"metric1", 608, 616}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), 0}, 1, 608)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingMax(metric1,2)",
-				[]float64{math.NaN(), math.NaN(), 2, 3, 3, math.NaN()}, 1, 0).SetTag("movingMax", "2").SetNameTag("movingMax(metric1,2)")}, // StartTime = from
+			Want: []*types.MetricData{types.MakeMetricData(`movingMax(metric1,2)`,
+				[]float64{3, 3, math.NaN(), 0}, 1, 610).SetTag("movingMax", "2").SetNameTag(`movingMax(metric1,2)`)},
+			From:  610,
+			Until: 616,
 		},
 	}
 
-	for _, tt := range tests {
+	for n, tt := range tests {
 		testName := tt.Target
-		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+		t.Run(testName+"#"+strconv.Itoa(n), func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
 		})
 	}
 }
@@ -200,28 +298,28 @@ func TestMovingError(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'','average')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 0)},
 			},
 			Error: parser.ErrBadType,
 		},
 		{
 			Target: "movingWindow(metric1,'-','average')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 0)},
 			},
 			Error: parser.ErrBadType,
 		},
 		{
 			Target: "movingWindow(metric1,'+','average')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 0)},
 			},
 			Error: parser.ErrBadType,
 		},
 		{
 			Target: "movingWindow(metric1,'-s1','average')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
 			},
 			Error: parser.ErrBadType,
 		},
@@ -323,4 +421,11 @@ func BenchmarkMoving(b *testing.B) {
 			}
 		})
 	}
+}
+
+func generateValues(start, stop, step int64) (values []float64) {
+	for i := start; i < stop; i += step {
+		values = append(values, float64(i))
+	}
+	return
 }

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -238,6 +238,17 @@ func TestMoving(t *testing.T) {
 			From:  610,
 			Until: 710,
 		},
+		{
+			Target: "movingAverage(metric1,10)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 700}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 30, 610)}, // step > windowSize
+				{"metric1", 310, 700}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 30, 310)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,10)`,
+				[]float64{}, 30, 610).SetTag("movingAverage", "10").SetNameTag(`movingAverage(metric1,10)`)},
+			From:  610,
+			Until: 700,
+		},
 	}
 
 	for n, tt := range tests {

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -146,7 +146,7 @@ func TestMoving(t *testing.T) {
 				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
-				[]float64{1.5, 1, 2}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
+				[]float64{1, 0.3333333333333333, 1.3333333333333333}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
 			From:  610,
 			Until: 710,
 		},

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -25,6 +25,8 @@ func init() {
 	}
 }
 
+// Note: some of these tests are influenced by the testcases for moving* functions
+// in Graphite-web. See: https://github.com/graphite-project/graphite-web/blob/master/webapp/tests/test_functions.py
 func TestMoving(t *testing.T) {
 	tests := []th.EvalTestItemWithRange{
 		{

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -175,3 +175,12 @@ func (w *Windowed) Last() float64 {
 
 	return w.Data[w.head-1]
 }
+
+// IsNonNull checks if the window's data contains only NaN values
+// This is to prevent returning -Inf when the window's data contains only NaN values
+func (w *Windowed) IsNonNull() bool {
+	if len(w.Data) == w.nans {
+		return false
+	}
+	return true
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -232,7 +232,7 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 				}
 				r = append(r, adjustedReq)
 			}
-		case "movingAverage", "movingMedian", "movingMin", "movingMax", "movingSum", "exponentialMovingAverage":
+		case "exponentialMovingAverage":
 			if len(e.args) < 2 {
 				return nil
 			}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -232,7 +232,7 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 				}
 				r = append(r, adjustedReq)
 			}
-		case "exponentialMovingAverage":
+		case "movingAverage", "movingMedian", "movingMin", "movingMax", "movingSum", "exponentialMovingAverage":
 			if len(e.args) < 2 {
 				return nil
 			}


### PR DESCRIPTION
This PR addresses multiple issues that were found with the moving* functions. These issues included:

1. Moving* functions are intended to support two different types for the windowSize parameter: either a string containing an interval such as “1min” or “1h”, or an integer which represents a fixed number of points to be considered for the window. The CarbonAPI implementation contained a bug for the integer windowSize parameter in which the windowSize was not properly taken into consideration, and extraneous NaN values were added. 
2. The start time of the fetch request  was being altered in the parser.Metrics() function, before the data was fetched, in order to take into consideration the specified time interval. However, it was only doing this if a string interval was supplied for the windowSize parameter; it ignored the case of an integer interval being specified, which corresponds to a specific number of points. In the case of a specific number of points being used for the window, the step time of the data has to be factored in, and this is not possible to know the step time before the data is fetched. Therefore, the moving* functions must re-fetch data to accommodate this
 3. Graphite-web ignores the first point of the re-fetched data.  [This issue](https://github.com/graphite-project/graphite-web/issues/2632) in Graphite-web addresses why. CarbonAPI was not doing this, so the results were shifted.
4. MovingMedian was not mapped to a consolidation function, so a query including the movingMedian function would fail.
5. A window containing only NaN values could result in a window's sum can become negative, and when Mean() was called on the window, the negative sum being divided by w.Len() (with a value of 0, since this function returns the result of subtracting the number of NaN values from the length of the window's data) resulted in -Inf being returned. Graphite-web checks if there are any non-null values, and if there are none, a value of None is returned for that window. CarbonAPI will now return NaN in this case to match Graphite-web's behavior

There were also several issues with the start and end time not being properly altered. 

See [documentation](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.movingWindow) for the moving* functions and the [implementation](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L1290) in Graphite-web.