### PR TITLE
Small fixes to function aliases and descriptions

### DIFF
--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -23,7 +23,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &asPercent{}
-	for _, n := range []string{"asPercent"} {
+	for _, n := range []string{"asPercent", "pct"} {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
 	return res
@@ -439,6 +439,33 @@ func (f *asPercent) Description() map[string]types.FunctionDescription {
 			Group:       "Combine",
 			Module:      "graphite.render.functions",
 			Name:        "asPercent",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name: "total",
+					Type: types.SeriesList,
+				},
+				{
+					Multiple: true,
+					Name:     "nodes",
+					Type:     types.NodeOrTag,
+				},
+			},
+			SeriesChange: true, // function aggregate metrics or change series items count
+			NameChange:   true, // name changed
+			TagsChange:   true, // name tag changed
+			ValuesChange: true, // values changed
+		},
+		"pct": {
+			Description: "Calculates a percentage of the total of a wildcard series. If `total` is specified,\neach series will be calculated as a percentage of that total. If `total` is not specified,\nthe sum of all points in the wildcard series will be used instead.\n\nA list of nodes can optionally be provided, if so they will be used to match series with their\ncorresponding totals following the same logic as :py:func:`groupByNodes <groupByNodes>`.\n\nWhen passing `nodes` the `total` parameter may be a series list or `None`.  If it is `None` then\nfor each series in `seriesList` the percentage of the sum of series in that group will be returned.\n\nWhen not passing `nodes`, the `total` parameter may be a single series, reference the same number\nof series as `seriesList` or be a numeric value.\n\nExample:\n\n.. code-block:: none\n\n  # Server01 connections failed and succeeded as a percentage of Server01 connections attempted\n  &target=asPercent(Server01.connections.{failed,succeeded}, Server01.connections.attempted)\n\n  # For each server, its connections failed as a percentage of its connections attempted\n  &target=asPercent(Server*.connections.failed, Server*.connections.attempted)\n\n  # For each server, its connections failed and succeeded as a percentage of its connections attemped\n  &target=asPercent(Server*.connections.{failed,succeeded}, Server*.connections.attempted, 0)\n\n  # apache01.threads.busy as a percentage of 1500\n  &target=asPercent(apache01.threads.busy,1500)\n\n  # Server01 cpu stats as a percentage of its total\n  &target=asPercent(Server01.cpu.*.jiffies)\n\n  # cpu stats for each server as a percentage of its total\n  &target=asPercent(Server*.cpu.*.jiffies, None, 0)\n\nWhen using `nodes`, any series or totals that can't be matched will create output series with\nnames like ``asPercent(someSeries,MISSING)`` or ``asPercent(MISSING,someTotalSeries)`` and all\nvalues set to None. If desired these series can be filtered out by piping the result through\n``|exclude(\"MISSING\")`` as shown below:\n\n.. code-block:: none\n\n  &target=asPercent(Server{1,2}.memory.used,Server{1,3}.memory.total,0)\n\n  # will produce 3 output series:\n  # asPercent(Server1.memory.used,Server1.memory.total) [values will be as expected}\n  # asPercent(Server2.memory.used,MISSING) [all values will be None}\n  # asPercent(MISSING,Server3.memory.total) [all values will be None}\n\n  &target=asPercent(Server{1,2}.memory.used,Server{1,3}.memory.total,0)|exclude(\"MISSING\")\n\n  # will produce 1 output series:\n  # asPercent(Server1.memory.used,Server1.memory.total) [values will be as expected}\n\nEach node may be an integer referencing a node in the series name or a string identifying a tag.\n\n.. note::\n\n  When `total` is a seriesList, specifying `nodes` to match series with the corresponding total\n  series will increase reliability.",
+			Function:    "pct(seriesList, total=None, *nodes)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "pct",
 			Params: []types.FunctionParam{
 				{
 					Name:     "seriesList",

--- a/expr/functions/exp/function.go
+++ b/expr/functions/exp/function.go
@@ -56,7 +56,7 @@ func (f *exp) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
 func (f *exp) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
-		"add": {
+		"exp": {
 			Description: "Raise e to the power of the datapoint, where e = 2.718281… is the base of natural logarithms.\n\nExample:\n\n.. code-block:: none\n\n  &target=exp(Server.instance01.threads.busy)",
 			Function:    "exp(seriesList)",
 			Group:       "Transform",

--- a/expr/functions/scale/function.go
+++ b/expr/functions/scale/function.go
@@ -113,10 +113,10 @@ func (f *scale) Description() map[string]types.FunctionDescription {
 				"by the constant provided at each point.\n" +
 				"carbonapi extends this function by optional 3-rd parameter that accepts unix-timestamp. If provided, only values with timestamp newer than it will be scaled\n\n" +
 				"Example:\n\n.. code-block:: none\n\n  &target=scale(Server.instance01.threads.busy,10)\n  &target=scale(Server.instance*.threads.busy,10)",
-			Function: "scale(seriesList, factor)",
+			Function: "scaleAfterTimestamp(seriesList, factor)",
 			Group:    "Transform",
 			Module:   "graphite.render.functions",
-			Name:     "scale",
+			Name:     "scaleAfterTimestamp",
 			Params: []types.FunctionParam{
 				{
 					Name:     "seriesList",

--- a/expr/functions/setXFilesFactor/function.go
+++ b/expr/functions/setXFilesFactor/function.go
@@ -76,5 +76,24 @@ func (f *setXFilesFactor) Description() map[string]types.FunctionDescription {
 				},
 			},
 		},
+		"xFilesFactor": {
+			Description: "Takes one metric or a wildcard seriesList and an xFilesFactor value between 0 and 1. When a series needs to be consolidated, this sets the fraction of values in an interval that must\nnot be null for the consolidation to be considered valid. If there are not enough values then None will be returned for that interval.\n\nExample:\n\n.. code-block:: none\n\n  &target=xFilesFactor(Sales.widgets.largeBlue, 0.5)\n  &target=Servers.web01.sda1.free_space|consolidateBy('max')|xFilesFactor(0.5)",
+			Function:    "xFilesFactor(seriesList, xFilesFactor)",
+			Group:       "Transform",
+			Module:      "graphite.render.functions",
+			Name:        "xFilesFactor",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "xFilesFactor",
+					Required: false,
+					Type:     types.Float,
+				},
+			},
+		},
 	}
 }

--- a/expr/functions/sinFunction/function.go
+++ b/expr/functions/sinFunction/function.go
@@ -81,10 +81,10 @@ func (f *sinFunction) Description() map[string]types.FunctionDescription {
 				"Example:\n\n.. code-block:: none\n\n &target=sin(\"The.time.series\", 2)\n\n" +
 				"This would create a series named “The.time.series” that contains sin(x)*2. Accepts optional second argument as ‘amplitude’ parameter (default amplitude is 1)\n Accepts optional third argument as ‘step’ parameter (default step is 60 sec)\n\n" +
 				"Alias: sin",
-			Function: "sinFunction(name, amplitude=1, step=60)",
+			Function: "sin(name, amplitude=1, step=60)",
 			Group:    "Transform",
 			Module:   "graphite.render.functions",
-			Name:     "scale",
+			Name:     "sin",
 			Params: []types.FunctionParam{
 				{
 					Name:     "name",
@@ -113,7 +113,7 @@ func (f *sinFunction) Description() map[string]types.FunctionDescription {
 			Function: "sinFunction(name, amplitude=1, step=60)",
 			Group:    "Transform",
 			Module:   "graphite.render.functions",
-			Name:     "scale",
+			Name:     "sinFunction",
 			Params: []types.FunctionParam{
 				{
 					Name:     "name",

--- a/expr/functions/sinFunction/function.go
+++ b/expr/functions/sinFunction/function.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"math"
 
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
-	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )
 
 type sinFunction struct {
@@ -75,6 +76,35 @@ func (f *sinFunction) Do(ctx context.Context, e parser.Expr, from, until int64, 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
 func (f *sinFunction) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
+		"sin": {
+			Description: "Just returns the sine of the current time. The optional amplitude parameter changes the amplitude of the wave.\n" +
+				"Example:\n\n.. code-block:: none\n\n &target=sin(\"The.time.series\", 2)\n\n" +
+				"This would create a series named “The.time.series” that contains sin(x)*2. Accepts optional second argument as ‘amplitude’ parameter (default amplitude is 1)\n Accepts optional third argument as ‘step’ parameter (default step is 60 sec)\n\n" +
+				"Alias: sin",
+			Function: "sinFunction(name, amplitude=1, step=60)",
+			Group:    "Transform",
+			Module:   "graphite.render.functions",
+			Name:     "scale",
+			Params: []types.FunctionParam{
+				{
+					Name:     "name",
+					Required: true,
+					Type:     types.String,
+				},
+				{
+					Name:     "amplitude",
+					Required: false,
+					Type:     types.Integer,
+					Default:  types.NewSuggestion(1),
+				},
+				{
+					Name:     "step",
+					Required: false,
+					Type:     types.Integer,
+					Default:  types.NewSuggestion(60),
+				},
+			},
+		},
 		"sinFunction": {
 			Description: "Just returns the sine of the current time. The optional amplitude parameter changes the amplitude of the wave.\n" +
 				"Example:\n\n.. code-block:: none\n\n &target=sin(\"The.time.series\", 2)\n\n" +


### PR DESCRIPTION
* `sin` - this was added to function metadata but was missing from Description()
* `exp` - description name was set to "add" instead of "exp"
* Added `pct` as an function alias for `asPercent` as graphite-web does https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L6011
* `xFilesFactor` - this was added to function metadata but was missing from Description()
* Corrected the Function and Name fields in the function descriptions for `scaleAfterTimestamp` and `sinFunction`