### PR TITLE
Use IntOrInf type for keepLastValue and interpolate

### DIFF
--- a/expr/functions/interpolate/function.go
+++ b/expr/functions/interpolate/function.go
@@ -31,7 +31,7 @@ func (f *interpolate) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		return nil, err
 	}
 
-	limit, err := e.GetFloatArgDefault(1, math.Inf(1))
+	limit, err := e.GetIntOrInfArgDefault(1, parser.IntOrInf{IsInf: true})
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (f *interpolate) Do(ctx context.Context, e parser.Expr, from, until int64, 
 				// have a value and can interpolate
 				// if a non-null value is seen before the limit is hit
 				// backfill all the missing datapoints with the last known value
-				if consecutiveNulls > 0 && float64(consecutiveNulls) <= limit {
+				if consecutiveNulls > 0 && (limit.IsInf || consecutiveNulls <= limit.IntVal) {
 					lastNotNullIndex := i - consecutiveNulls - 1
 					lastNotNullValue := resultSeries.Values[lastNotNullIndex]
 
@@ -110,7 +110,8 @@ func (f *interpolate) Description() map[string]types.FunctionDescription {
 				{
 					Name:     "limit",
 					Required: false,
-					Type:     types.Float,
+					Type:     types.IntOrInf,
+					Default:  types.NewSuggestion(math.Inf(1)),
 				},
 			},
 			NameChange:   true, // name changed

--- a/expr/functions/interpolate/function_test.go
+++ b/expr/functions/interpolate/function_test.go
@@ -128,6 +128,31 @@ func TestInterpolate_Do(t *testing.T) {
 				),
 			},
 		},
+		{
+			"interpolate(x1.y1.z1, inf)",
+			map[parser.MetricRequest][]*types.MetricData{
+				parser.MetricRequest{
+					Metric: "x1.y1.z1",
+					From:   0,
+					Until:  1,
+				}: {
+					types.MakeMetricData(
+						"x1.y1.z1",
+						[]float64{1, 2, 3, 4, nan, nan, nan, 6, 7, 8},
+						1,
+						now32,
+					),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData(
+					"interpolate(x1.y1.z1)",
+					[]float64{1, 2, 3, 4, 4.5, 5, 5.5, 6, 7, 8},
+					1,
+					now32,
+				),
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/expr/types/list.go
+++ b/expr/types/list.go
@@ -209,6 +209,8 @@ func (t *Suggestion) UnmarshalJSON(d []byte) error {
 		switch string(d) {
 		case "1e9999":
 			res = math.Inf(1)
+		case "-1e9999":
+			res = math.Inf(-1)
 		default:
 			return err
 		}

--- a/expr/types/list.go
+++ b/expr/types/list.go
@@ -178,7 +178,14 @@ func (t Suggestion) MarshalJSON() ([]byte, error) {
 	case SUint64:
 		return json.Marshal(t.Value.(uint64))
 	case SFloat64:
-		return json.Marshal(t.Value.(float64))
+		fVal := t.Value.(float64)
+		if math.IsInf(fVal, 1) {
+			return []byte("1e9999"), nil
+		}
+		if math.IsInf(fVal, -1) {
+			return []byte("-1e9999"), nil
+		}
+		return json.Marshal(fVal)
 	case SString:
 		return json.Marshal(t.Value.(string))
 	case SBool:

--- a/expr/types/list_test.go
+++ b/expr/types/list_test.go
@@ -1,0 +1,63 @@
+package types
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestSuggestion_MarshalJSON(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		s                    *Suggestion
+		expectedJSON         string
+		expectedUnmarshalled *Suggestion // used when unmarshalling the result JSON doesn't equal the original suggestion
+	}{
+		{
+			name:                 "int",
+			s:                    NewSuggestion(1234),
+			expectedJSON:         `1234`,
+			expectedUnmarshalled: NewSuggestion(1234.), // JSON numbers are always unmarshalled as floats
+
+		},
+		{
+			name:         "float",
+			s:            NewSuggestion(12.34),
+			expectedJSON: `12.34`,
+		},
+		{
+			name:         "inf",
+			s:            NewSuggestion(math.Inf(1)),
+			expectedJSON: `1e9999`,
+		},
+		{
+			name:         "-inf",
+			s:            NewSuggestion(math.Inf(-1)),
+			expectedJSON: `-1e9999`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := json.Marshal(tc.s)
+			if err != nil {
+				t.Fatalf("Error marshalling suggestion, err: %s", err.Error())
+			}
+			actualStr := string(actual)
+			if actualStr != tc.expectedJSON {
+				t.Fatalf("Marshalled JSON not equal: got\n%+v\nwant\n%+v", actualStr, tc.expectedJSON)
+			}
+			var unmarshalled Suggestion
+			err = json.Unmarshal(actual, &unmarshalled)
+			if err != nil {
+				t.Fatalf("Error unmarshalling suggestion, err: %s", err.Error())
+			}
+			expectedUnmarshalled := *tc.s
+			if tc.expectedUnmarshalled != nil {
+				expectedUnmarshalled = *tc.expectedUnmarshalled
+			}
+			if !reflect.DeepEqual(unmarshalled, expectedUnmarshalled) {
+				t.Fatalf("Unmarshalled JSON not equal: got\n%+v\nwant\n%+v", unmarshalled, expectedUnmarshalled)
+			}
+		})
+	}
+}

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -62,7 +62,7 @@ type NodeOrTag struct {
 }
 
 // IntOrInf is either positive infinity or an integer value.
-// They are distinguised by "IfInf" = true if it is positive infinity.
+// They are distinguished by "IsInf" = true if it is positive infinity.
 type IntOrInf struct {
 	IsInf  bool
 	IntVal int

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -61,6 +61,13 @@ type NodeOrTag struct {
 	Value interface{}
 }
 
+// IntOrInf is either positive infinity or an integer value.
+// They are distinguised by "IfInf" = true if it is positive infinity.
+type IntOrInf struct {
+	IsInf  bool
+	IntVal int
+}
+
 // Expr defines an interface to talk with expressions
 type Expr interface {
 	// IsName checks if Expression is 'Series Name' expression
@@ -148,6 +155,10 @@ type Expr interface {
 	GetIntNamedOrPosArgWithIndication(k string, n int) (int, bool, error)
 	// GetIntNamedOrPosArgDefault returns specific positioned int-typed argument or replace it with default if none found.
 	GetIntNamedOrPosArgDefault(k string, n int, d int) (int, error)
+
+	GetIntOrInfArg(n int) (IntOrInf, error)
+	GetIntOrInfArgDefault(n int, d IntOrInf) (IntOrInf, error)
+	GetIntOrInfNamedOrPosArgDefault(k string, n int, d IntOrInf) (IntOrInf, error)
 
 	GetNamedArg(name string) Expr
 

--- a/pkg/parser/internal.go
+++ b/pkg/parser/internal.go
@@ -3,10 +3,9 @@ package parser
 import (
 	"fmt"
 	"math"
+	"runtime/debug"
 	"strconv"
 	"strings"
-
-	"runtime/debug"
 )
 
 func (e *expr) doGetIntArg() (int, error) {
@@ -19,6 +18,18 @@ func (e *expr) doGetIntArg() (int, error) {
 	}
 
 	return int(e.val), nil
+}
+
+func (e *expr) doGetIntOrInfArg() (IntOrInf, error) {
+	if e.etype == EtName && strings.ToLower(e.Target()) == "inf" ||
+		e.etype == EtString && strings.ToLower(e.valStr) == "inf" {
+		return IntOrInf{IsInf: true}, nil
+	}
+	intVal, err := e.doGetIntArg()
+	if err != nil {
+		return IntOrInf{}, err
+	}
+	return IntOrInf{IntVal: intVal}, nil
 }
 
 func (e *expr) getNamedArg(name string) *expr {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -472,6 +472,30 @@ func (e *expr) GetIntNamedOrPosArgDefault(k string, n, d int) (int, error) {
 	return e.GetIntArgDefault(n, d)
 }
 
+func (e *expr) GetIntOrInfArg(n int) (IntOrInf, error) {
+	if len(e.args) <= n {
+		return IntOrInf{}, ErrMissingArgument
+	}
+
+	return e.args[n].doGetIntOrInfArg()
+}
+
+func (e *expr) GetIntOrInfArgDefault(n int, d IntOrInf) (IntOrInf, error) {
+	if len(e.args) <= n {
+		return d, nil
+	}
+
+	return e.args[n].doGetIntOrInfArg()
+}
+
+func (e *expr) GetIntOrInfNamedOrPosArgDefault(k string, n int, d IntOrInf) (IntOrInf, error) {
+	if a := e.getNamedArg(k); a != nil {
+		return a.doGetIntOrInfArg()
+	}
+
+	return e.GetIntOrInfArgDefault(n, d)
+}
+
 func (e *expr) GetNamedArg(name string) Expr {
 	return e.getNamedArg(name)
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -609,6 +609,50 @@ func TestDoGetIntArg(t *testing.T) {
 	}
 }
 
+func TestDoGetIntOrInf(t *testing.T) {
+	tests := []struct {
+		s string
+		e *expr
+		r IntOrInf
+	}{
+		{
+			"parse int",
+			&expr{val: 5, etype: EtConst, valStr: "5"},
+			IntOrInf{IntVal: 5},
+		},
+		{
+			"parse string to int",
+			&expr{etype: EtString, valStr: "1"},
+			IntOrInf{IntVal: 1},
+		},
+		{
+			"parse inf",
+			&expr{etype: EtName, target: "inf"},
+			IntOrInf{IsInf: true},
+		},
+		{
+			"parse capitalized inf",
+			&expr{etype: EtName, target: "INF"},
+			IntOrInf{IsInf: true},
+		},
+		{
+			"parse string to inf",
+			&expr{etype: EtString, valStr: "inf"},
+			IntOrInf{IsInf: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r, err := tt.e.doGetIntOrInfArg()
+			if assert.NoError(err) {
+				assert.Equal(tt.r, r, tt.s)
+			}
+		})
+	}
+}
+
 func TestMetrics(t *testing.T) {
 	tests := []struct {
 		s        string


### PR DESCRIPTION
This PR makes infinity handling in carbonapi closer to graphite-web behaviour.

## IntOrInf parameter
In graphite-web, the second parameter for the functions `keepLastValue` and `interpolate` is `intOrInf`, with the default being `INF`

* https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L779-L783
* https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L835-L839

Currently carbonapi treats the second parameter as a float that could be infinity.

graphite-web does not allow floats apart from infinity for this parameter:
https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/functions/params.py#L64-L77

This PR introduces an `InfOrInf` type that behaves like graphite-web for these two functions.

## Inf marshalling
In graphite-web, infinity values in suggestions are marshalled to `1e9999` in JSON, as infinity is not valid for browsers/nodejs

See: https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/functions/views.py#L9 and https://github.com/graphite-project/graphite-web/pull/2612.

Therefore I've updated the suggestion struct marshalling function to replace infinity with 1e9999 to match graphite-web behaviour.
