### PR TITLE
fix return code for render_handler

### DIFF
--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -352,7 +352,8 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 		// Obtain error code from the errors
 		// In case we have only "Not Found" errors, result should be 404
 		// Otherwise it should be 500
-		returnCode, errMsgs := helper.MergeHttpErrorMap(errors)
+		var errMsgs []string
+		returnCode, errMsgs = helper.MergeHttpErrorMap(errors)
 		logger.Debug("error response or no response", zap.Strings("error", errMsgs))
 		// Allow override status code for 404-not-found replies.
 		if returnCode == 404 {


### PR DESCRIPTION
Hello,

carbonapi do not response correct code 404 when no metric is found from gocarbon/carbonserver when requesting for a render

This should fix the issue : 

returnCode is reasigned in an other scope, so any modification won't have effect ouside the if