### PR TITLE
fix(expr): deadlock on uninitialized (nil) limiter

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -18,7 +18,9 @@ import (
 type evaluator struct{}
 
 func (eval evaluator) Fetch(ctx context.Context, exprs []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (map[parser.MetricRequest][]*types.MetricData, error) {
-	config.Config.Limiter.Enter()
+	if err := config.Config.Limiter.Enter(ctx); err != nil {
+		return nil, err
+	}
 	defer config.Config.Limiter.Leave()
 
 	multiFetchRequest := pb.MultiFetchRequest{}

--- a/limiter/simple.go
+++ b/limiter/simple.go
@@ -1,9 +1,27 @@
 package limiter
 
+import "context"
+
 type SimpleLimiter chan struct{}
 
-func (l SimpleLimiter) Enter() { l <- struct{}{} }
-func (l SimpleLimiter) Leave() { <-l }
+func (l SimpleLimiter) Enter(ctx context.Context) error {
+	if l == nil {
+		return nil
+	}
+
+	select {
+	case l <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ErrTimeout
+	}
+}
+
+func (l SimpleLimiter) Leave() {
+	if l != nil {
+		<-l
+	}
+}
 
 func NewSimpleLimiter(l int) SimpleLimiter {
 	return make(chan struct{}, l)


### PR DESCRIPTION
Fix deadlock (limiter not initialized) on usage expr/evaluator as package.