### PR TITLE
feat(config): add -exact-config command line argument

### DIFF
--- a/cmd/carbonapi/config/init.go
+++ b/cmd/carbonapi/config/init.go
@@ -330,7 +330,7 @@ func createCache(logger *zap.Logger, cacheName string, cacheConfig *CacheConfig)
 	}
 }
 
-func SetUpViper(logger *zap.Logger, configPath *string, viperPrefix string) {
+func SetUpViper(logger *zap.Logger, configPath *string, exactConfig bool, viperPrefix string) {
 	if *configPath != "" {
 		b, err := os.ReadFile(*configPath)
 		if err != nil {
@@ -386,13 +386,13 @@ func SetUpViper(logger *zap.Logger, configPath *string, viperPrefix string) {
 	viper.SetDefault("upstreams.internalRoutingCache", "600s")
 	viper.SetDefault("upstreams.buckets", 10)
 	viper.SetDefault("upstreams.sumBuckets", false)
-	viper.SetDefault("upstreams.bucketsWeight", []int64{})
-	viper.SetDefault("upstreams.bucketsNames", []string{})
+	viper.SetDefault("upstreams.bucketsWidth", []int64{})
+	viper.SetDefault("upstreams.bucketsLabels", []string{})
 	viper.SetDefault("upstreams.slowLogThreshold", "1s")
-	viper.SetDefault("upstreams.timeouts.global", "10s")
-	viper.SetDefault("upstreams.timeouts.afterStarted", "2s")
+	viper.SetDefault("upstreams.timeouts.find", "2s")
+	viper.SetDefault("upstreams.timeouts.render", "10s")
 	viper.SetDefault("upstreams.timeouts.connect", "200ms")
-	viper.SetDefault("upstreams.concurrencyLimit", 0)
+	viper.SetDefault("upstreams.concurrencyLimitPerServer", 0)
 	viper.SetDefault("upstreams.keepAliveInterval", "30s")
 	viper.SetDefault("upstreams.maxIdleConnsPerHost", 100)
 	viper.SetDefault("upstreams.scaleToCommonStep", true)
@@ -403,7 +403,13 @@ func SetUpViper(logger *zap.Logger, configPath *string, viperPrefix string) {
 	viper.SetDefault("combineMultipleTargetsInOne", false)
 	viper.AutomaticEnv()
 
-	err := viper.Unmarshal(&Config)
+	var err error
+	if exactConfig {
+		err = viper.UnmarshalExact(&Config)
+	} else {
+		err = viper.Unmarshal(&Config)
+	}
+
 	if err != nil {
 		logger.Fatal("failed to parse config",
 			zap.Error(err),

--- a/cmd/carbonapi/http/main_test.go
+++ b/cmd/carbonapi/http/main_test.go
@@ -114,7 +114,7 @@ func init() {
 	logger := zapwriter.Logger("main")
 
 	cfgFile := ""
-	config.SetUpViper(logger, &cfgFile, "CARBONAPI_")
+	config.SetUpViper(logger, &cfgFile, false, "CARBONAPI_")
 	config.Config.Upstreams.Backends = []string{"dummy"}
 	config.SetUpConfigUpstreams(logger)
 	config.SetUpConfig(logger, "(test)")

--- a/cmd/carbonapi/main.go
+++ b/cmd/carbonapi/main.go
@@ -35,6 +35,7 @@ func main() {
 
 	configPath := flag.String("config", "", "Path to the `config file`.")
 	checkConfig := flag.Bool("check-config", false, "Check config file and exit.")
+	exactConfig := flag.Bool("exact-config", false, "Ensure that all config params are contained in the target struct.")
 	envPrefix := flag.String("envprefix", "CARBONAPI", "Prefix for environment variables override")
 	if *envPrefix == "(empty)" {
 		*envPrefix = ""
@@ -43,7 +44,7 @@ func main() {
 		logger.Warn("empty prefix is not recommended due to possible collisions with OS environment variables")
 	}
 	flag.Parse()
-	config.SetUpViper(logger, configPath, *envPrefix)
+	config.SetUpViper(logger, configPath, *exactConfig, *envPrefix)
 	if *checkConfig {
 		os.Exit(0)
 	}


### PR DESCRIPTION
This PR adds the "-exact-config" command line argument which ensures that all parameters in a config file are contained inside the corresponding struct.
If you run e2e tests with this, they are going to fail since "graphite09compat" has incorrect indentation.