### PR TITLE
Carbonapi docs Example path logger, point to directory /var/log

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -490,7 +490,7 @@ logger:
       encodingTime: "iso8601"
       encodingDuration: "seconds"
     - logger: ""
-      file: "carbonapi.log"
+      file: "/var/log/carbonapi.log"
       level: "info"
       encoding: "json"
     # disable slow log completely


### PR DESCRIPTION
Example of documentation is now misleading, the log will be placed in the root