### PR TITLE
feat(functions): add a config option to pass consolidateBy to the storage backend

### DIFF
--- a/cmd/carbonapi/config/config.go
+++ b/cmd/carbonapi/config/config.go
@@ -87,6 +87,7 @@ type ConfigType struct {
 	SendGlobsAsIs              *bool              `mapstructure:"sendGlobsAsIs"`
 	AlwaysSendGlobsAsIs        *bool              `mapstructure:"alwaysSendGlobsAsIs"`
 	ExtractTagsFromArgs        bool               `mapstructure:"extractTagsFromArgs"`
+	PassFunctionsToBackend     bool               `mapstructure:"passFunctionsToBackend"`
 	MaxBatchSize               int                `mapstructure:"maxBatchSize"`
 	Zipper                     string             `mapstructure:"zipper"`
 	Upstreams                  zipperCfg.Config   `mapstructure:"upstreams"`
@@ -138,7 +139,7 @@ func (c ConfigType) String() string {
 
 func (c *ConfigType) SetZipper(zipper zipper.CarbonZipper) (err error) {
 	c.ZipperInstance = zipper
-	c.Evaluator, err = expr.NewEvaluator(c.Limiter, c.ZipperInstance)
+	c.Evaluator, err = expr.NewEvaluator(c.Limiter, c.ZipperInstance, c.PassFunctionsToBackend)
 	return
 }
 

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -48,9 +48,16 @@ func (eval Evaluator) Fetch(ctx context.Context, exprs []parser.Expr, from, unti
 				MaxDataPoints:  maxDataPoints,
 			}
 			metricRequest := parser.MetricRequest{
-				Metric: fetchRequest.PathExpression,
-				From:   fetchRequest.StartTime,
-				Until:  fetchRequest.StopTime,
+				Metric:            fetchRequest.PathExpression,
+				From:              fetchRequest.StartTime,
+				Until:             fetchRequest.StopTime,
+				ConsolidationFunc: m.ConsolidationFunc,
+			}
+
+			if m.ConsolidationFunc != "" {
+				fetchRequest.FilterFunctions = append(fetchRequest.FilterFunctions, &pb.FilteringFunction{
+					Name: m.ConsolidationFunc,
+				})
 			}
 
 			if exp.Target() == "fallbackSeries" {

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -48,15 +48,15 @@ func (eval Evaluator) Fetch(ctx context.Context, exprs []parser.Expr, from, unti
 				MaxDataPoints:  maxDataPoints,
 			}
 			metricRequest := parser.MetricRequest{
-				Metric:            fetchRequest.PathExpression,
-				From:              fetchRequest.StartTime,
-				Until:             fetchRequest.StopTime,
-				ConsolidationFunc: m.ConsolidationFunc,
+				Metric: fetchRequest.PathExpression,
+				From:   fetchRequest.StartTime,
+				Until:  fetchRequest.StopTime,
 			}
 
 			if m.ConsolidationFunc != "" {
 				fetchRequest.FilterFunctions = append(fetchRequest.FilterFunctions, &pb.FilteringFunction{
-					Name: m.ConsolidationFunc,
+					Name:      "consolidateBy",
+					Arguments: []string{m.ConsolidationFunc},
 				})
 			}
 

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -21,8 +21,9 @@ import (
 var ErrZipperNotInit = errors.New("zipper not initialized")
 
 type Evaluator struct {
-	limiter limiter.SimpleLimiter
-	zipper  zipper.CarbonZipper
+	limiter                limiter.SimpleLimiter
+	zipper                 zipper.CarbonZipper
+	passFunctionsToBackend bool
 }
 
 func (eval Evaluator) Fetch(ctx context.Context, exprs []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (map[parser.MetricRequest][]*types.MetricData, error) {
@@ -53,7 +54,7 @@ func (eval Evaluator) Fetch(ctx context.Context, exprs []parser.Expr, from, unti
 				Until:  fetchRequest.StopTime,
 			}
 
-			if m.ConsolidationFunc != "" {
+			if eval.passFunctionsToBackend && m.ConsolidationFunc != "" {
 				fetchRequest.FilterFunctions = append(fetchRequest.FilterFunctions, &pb.FilteringFunction{
 					Name:      "consolidateBy",
 					Arguments: []string{m.ConsolidationFunc},
@@ -147,11 +148,11 @@ func (eval Evaluator) Eval(ctx context.Context, exp parser.Expr, from, until int
 }
 
 // NewEvaluator create evaluator with limiter and zipper
-func NewEvaluator(limiter limiter.SimpleLimiter, zipper zipper.CarbonZipper) (*Evaluator, error) {
+func NewEvaluator(limiter limiter.SimpleLimiter, zipper zipper.CarbonZipper, passFunctionsToBackend bool) (*Evaluator, error) {
 	if zipper == nil {
 		return nil, ErrZipperNotInit
 	}
-	return &Evaluator{limiter: limiter, zipper: zipper}, nil
+	return &Evaluator{limiter: limiter, zipper: zipper, passFunctionsToBackend: passFunctionsToBackend}, nil
 }
 
 // EvalExpr is the main expression evaluator.

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -206,7 +206,7 @@ func TestEvalExpr(t *testing.T) {
 				&data,
 			}
 
-			eval, err := NewEvaluator(nil, th.NewTestZipper(nil))
+			eval, err := NewEvaluator(nil, th.NewTestZipper(nil), false)
 			if err == nil {
 				_, err = EvalExpr(context.Background(), eval, exp, request.From, request.Until, metricMap)
 			}
@@ -361,7 +361,7 @@ func TestEvalExpression(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			eval, err := NewEvaluator(nil, th.NewTestZipper(nil))
+			eval, err := NewEvaluator(nil, th.NewTestZipper(nil), false)
 			if err == nil {
 				th.TestEvalExpr(t, eval, &tt)
 			} else {
@@ -464,7 +464,7 @@ func TestRewriteExpr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			eval, err := NewEvaluator(nil, th.NewTestZipper(nil))
+			eval, err := NewEvaluator(nil, th.NewTestZipper(nil), false)
 			if err == nil {
 				rewritten, newTargets, err := RewriteExpr(context.Background(), eval, tt.e, 0, 1, tt.m)
 
@@ -521,7 +521,7 @@ func TestEvalCustomFromUntil(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			originalMetrics := th.DeepClone(tt.m)
 			exp, _, _ := parser.ParseExpr(tt.target)
-			eval, err := NewEvaluator(nil, th.NewTestZipper(nil))
+			eval, err := NewEvaluator(nil, th.NewTestZipper(nil), false)
 			if err == nil {
 				g, err := EvalExpr(context.Background(), eval, exp, tt.from, tt.until, tt.m)
 				if err != nil {

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 	"unicode"
 
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+
 	"github.com/go-graphite/carbonapi/expr/functions"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/rewrite"
@@ -15,7 +17,6 @@ import (
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	th "github.com/go-graphite/carbonapi/tests"
 	"github.com/go-graphite/carbonapi/tests/compare"
-	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )
 
 func init() {
@@ -236,7 +237,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"metric*",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{"metric*", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, 3, 4, 5, 6}, 1, now32),
 				},

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -225,7 +225,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"metric",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric", From: 0, Until: 1}: {types.MakeMetricData("metric", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric", []float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
@@ -250,7 +250,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"reduceSeries(mapSeries(devops.service.*.filter.received.*.count,2), \"asPercent\", 5,\"valid\",\"total\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"devops.service.*.filter.received.*.count", 0, 1}: {
+				{Metric: "devops.service.*.filter.received.*.count", From: 0, Until: 1}: {
 					types.MakeMetricData("devops.service.server1.filter.received.valid.count", []float64{2, 4, 8}, 1, now32),
 					types.MakeMetricData("devops.service.server1.filter.received.total.count", []float64{8, 2, 4}, 1, now32),
 					types.MakeMetricData("devops.service.server2.filter.received.valid.count", []float64{3, 9, 12}, 1, now32),
@@ -265,7 +265,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"reduceSeries(mapSeries(devops.service.*.filter.received.*.count,2), \"asPercent\", 5,\"valid\",\"total\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"devops.service.*.filter.received.*.count", 0, 1}: {
+				{Metric: "devops.service.*.filter.received.*.count", From: 0, Until: 1}: {
 					types.MakeMetricData("devops.service.server1.filter.received.total.count", []float64{8, 2, 4}, 1, now32),
 					types.MakeMetricData("devops.service.server2.filter.received.valid.count", []float64{3, 9, 12}, 1, now32),
 					types.MakeMetricData("devops.service.server2.filter.received.total.count", []float64{12, 9, 3}, 1, now32),
@@ -278,7 +278,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"sumSeries(pow(devops.service.*.filter.received.*.count, 0))",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"devops.service.*.filter.received.*.count", 0, 1}: {
+				{Metric: "devops.service.*.filter.received.*.count", From: 0, Until: 1}: {
 					types.MakeMetricData("devops.service.server1.filter.received.total.count", []float64{8, 2, 4}, 1, now32),
 					types.MakeMetricData("devops.service.server2.filter.received.valid.count", []float64{3, 9, 12}, 1, now32),
 					types.MakeMetricData("devops.service.server2.filter.received.total.count", []float64{math.NaN(), math.NaN(), math.NaN()}, 1, now32),
@@ -289,7 +289,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"multiplySeriesWithWildcards(metric1.foo.*.*,1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar3.baz", []float64{2, 2, 2, 2, 2}, 1, now32),
@@ -300,7 +300,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"groupByNode(metric1foo.*,0,\"asPercent\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1foo.*", 0, 1}: {
+				{Metric: "metric1foo.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, now32),
 					types.MakeMetricData("metric1foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, now32),
@@ -312,7 +312,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"groupByNodes(test.metric*.foo*,\"keepLastValue\",1,0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"test.metric*.foo*", 0, 1}: {
+				{Metric: "test.metric*.foo*", From: 0, Until: 1}: {
 					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),
@@ -327,7 +327,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"groupByNodes(test.metric*.foo*,\"keepLastValue\",1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"test.metric*.foo*", 0, 1}: {
+				{Metric: "test.metric*.foo*", From: 0, Until: 1}: {
 					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),
@@ -344,7 +344,7 @@ func TestEvalExpression(t *testing.T) {
 		{
 			"groupByNodes(test.metric*.foo*,\"keepLastValue\",1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"test.metric*.foo*", 0, 1}: {
+				{Metric: "test.metric*.foo*", From: 0, Until: 1}: {
 					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),
@@ -388,10 +388,10 @@ func TestRewriteExpr(t *testing.T) {
 				"metric*",
 			),
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
 				},
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
 				},
 			},
@@ -407,10 +407,10 @@ func TestRewriteExpr(t *testing.T) {
 				parser.ArgValue("%.count"),
 			),
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
 				},
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
 				},
 			},
@@ -427,10 +427,10 @@ func TestRewriteExpr(t *testing.T) {
 				parser.ArgValue("% count"),
 			),
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
 				},
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32),
 				},
 			},
@@ -446,14 +446,14 @@ func TestRewriteExpr(t *testing.T) {
 				parser.ArgValue("%.count"),
 			),
 			map[parser.MetricRequest][]*types.MetricData{
-				{"foo.metric*", 0, 1}: {
+				{Metric: "foo.metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("foo.metric1", []float64{1, 2, 3}, 1, now32),
 					types.MakeMetricData("foo.metric2", []float64{1, 2, 3}, 1, now32),
 				},
-				{"foo.metric1", 0, 1}: {
+				{Metric: "foo.metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("foo.metric1", []float64{1, 2, 3}, 1, now32),
 				},
-				{"foo.metric2", 0, 1}: {
+				{Metric: "foo.metric2", From: 0, Until: 1}: {
 					types.MakeMetricData("foo.metric2", []float64{1, 2, 3}, 1, now32),
 				},
 			},

--- a/expr/functions/absolute/function_test.go
+++ b/expr/functions/absolute/function_test.go
@@ -28,7 +28,7 @@ func TestAbsolute(t *testing.T) {
 		{
 			"absolute(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, -1, 2, -3, 4, 5}, 1, now32)},
+				{"metric1", "", 0, 1}: {types.MakeMetricData("metric1", []float64{0, -1, 2, -3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("absolute(metric1)",
 				[]float64{0, 1, 2, 3, 4, 5}, 1, now32).SetTag("absolute", "1").SetNameTag("absolute(metric1)")},
@@ -42,5 +42,4 @@ func TestAbsolute(t *testing.T) {
 			th.TestEvalExpr(t, eval, &tt)
 		})
 	}
-
 }

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -34,14 +34,14 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "avg")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {},
+				{"metric[123]", "", 0, 1}: {},
 			},
 			[]*types.MetricData{},
 		},
 		{
 			`aggregate(metric[123], "avg")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -53,7 +53,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "avg_zero")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 4, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -65,7 +65,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "count")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -77,7 +77,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "diff")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -89,7 +89,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "last")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -101,7 +101,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "current")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -113,7 +113,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "max")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -125,7 +125,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "min")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -137,7 +137,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "median")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -149,7 +149,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "multiply")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -161,7 +161,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "range")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -173,7 +173,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "rangeOf")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -185,7 +185,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "sum")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -197,7 +197,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "total")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -209,7 +209,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "avg", 0.7)`, // Test with xFilesFactor
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, math.NaN(), 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -221,7 +221,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "sum", 0.5)`, // Test with xFilesFactor
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -233,7 +233,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "max", 0.3)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, math.NaN(), 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -245,7 +245,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`stddevSeries(metric[123])`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{"metric[123]", "", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -257,9 +257,9 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`stddevSeries(metric1,metric2,metric3)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32)},
-				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32)},
+				{Metric: "metric3", From: 0, Until: 1}: {types.MakeMetricData("metric3", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("stddevSeries(metric1,metric2,metric3)",
 				[]float64{0.4714045207910317, 0.9428090415820634, 1.4142135623730951, 1.8856180831641267, 2.357022603955158}, 1, now32).SetTag("aggregatedBy", "stddev")},
@@ -267,7 +267,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "stddev")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -279,7 +279,7 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "stddev")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
 					types.MakeMetricData("metric3", []float64{1, 2, 3, 4, 5}, 1, now32),
@@ -293,8 +293,8 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`sum(metric1,metric2)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, -1, 2, -3, 4, 5}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{0, 1, -2, 3, -4, -5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0, -1, 2, -3, 4, 5}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{0, 1, -2, 3, -4, -5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2)",
 				[]float64{0, 0, 0, 0, 0, 0}, 1, now32).SetTag("aggregatedBy", "sum")},
@@ -302,18 +302,18 @@ func TestAverageSeries(t *testing.T) {
 		{
 			"sum(metric1,metric2,metric3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, math.NaN()}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, 3, math.NaN(), 5, 6, math.NaN()}, 1, now32)},
-				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, 4, 5, 6, math.NaN(), math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, math.NaN()}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, 3, math.NaN(), 5, 6, math.NaN()}, 1, now32)},
+				{Metric: "metric3", From: 0, Until: 1}: {types.MakeMetricData("metric3", []float64{3, 4, 5, 6, math.NaN(), math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2,metric3)", []float64{6, 9, 8, 15, 11, math.NaN()}, 1, now32).SetTag("aggregatedBy", "sum")},
 		},
 		{
 			"sum(metric1,metric2,metric3,metric4)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, math.NaN()}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, 3, math.NaN(), 5, 6, math.NaN()}, 1, now32)},
-				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, 4, 5, 6, math.NaN(), math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, math.NaN()}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, 3, math.NaN(), 5, 6, math.NaN()}, 1, now32)},
+				{Metric: "metric3", From: 0, Until: 1}: {types.MakeMetricData("metric3", []float64{3, 4, 5, 6, math.NaN(), math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2,metric3)", []float64{6, 9, 8, 15, 11, math.NaN()}, 1, now32).SetTag("aggregatedBy", "sum")},
 		},
@@ -322,9 +322,9 @@ func TestAverageSeries(t *testing.T) {
 		{
 			"maxSeries(metric1,metric2,metric3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32)},
-				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32)},
+				{Metric: "metric3", From: 0, Until: 1}: {types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("maxSeries(metric1,metric2,metric3)",
 				[]float64{3, math.NaN(), 4, 5, 6, 6}, 1, now32).SetTag("aggregatedBy", "max")},
@@ -332,9 +332,9 @@ func TestAverageSeries(t *testing.T) {
 		{
 			"minSeries(metric1,metric2,metric3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32)},
-				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32)},
+				{Metric: "metric3", From: 0, Until: 1}: {types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("minSeries(metric1,metric2,metric3)",
 				[]float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32).SetTag("aggregatedBy", "min")},
@@ -344,9 +344,9 @@ func TestAverageSeries(t *testing.T) {
 		{
 			"averageSeries(metric1,metric2,metric3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32)},
-				{"metric3", 0, 1}: {types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32)},
+				{Metric: "metric3", From: 0, Until: 1}: {types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("averageSeries(metric1,metric2,metric3)",
 				[]float64{2, math.NaN(), 3, 4, 5, 5.5}, 1, now32).SetTag("aggregatedBy", "average")},
@@ -356,13 +356,13 @@ func TestAverageSeries(t *testing.T) {
 		{
 			"sum(seriesByTag('tag2=value*', 'name=metric'))",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+				{Metric: "seriesByTag('tag2=value*', 'name=metric')", From: 0, Until: 1}: {
 					// No tags in common
 					types.MakeMetricData("metric;tag1=value1;tag2=value21", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric;tag2=value23;tag3=value3;tag4=val4", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
 				},
-				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+				{Metric: "metric", From: 0, Until: 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2=value*', 'name=metric'))",
 				[]float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32).SetTags(map[string]string{"aggregatedBy": "sum", "name": "metric"})},
@@ -370,12 +370,12 @@ func TestAverageSeries(t *testing.T) {
 		{
 			"sum(seriesByTag('tag2!=value2*', 'name=metric.name'))",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('tag2!=value2*', 'name=metric.name')", 0, 1}: {
+				{Metric: "seriesByTag('tag2!=value2*', 'name=metric.name')", From: 0, Until: 1}: {
 					// One tag in common
 					types.MakeMetricData("metric.name;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric.name;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
 				},
-				{"metric.name", 0, 1}: {types.MakeMetricData("metric.name", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+				{Metric: "metric.name", From: 0, Until: 1}: {types.MakeMetricData("metric.name", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2!=value2*', 'name=metric.name'))",
 				// []float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "metric.name"})},
@@ -384,12 +384,12 @@ func TestAverageSeries(t *testing.T) {
 		{
 			"sum(seriesByTag('tag2=value21'))",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('tag2=value21')", 0, 1}: {
+				{Metric: "seriesByTag('tag2=value21')", From: 0, Until: 1}: {
 					// All tags in common
 					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
 				},
-				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+				{Metric: "metric", From: 0, Until: 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2=value21'))",
 				// []float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "sumSeries", "tag2": "value21"})},
@@ -417,12 +417,12 @@ func TestAverageSeriesExtractSeriesByTag(t *testing.T) {
 		{
 			"sum(seriesByTag('tag2=value*', 'name=metric'))",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+				{Metric: "seriesByTag('tag2=value*', 'name=metric')", From: 0, Until: 1}: {
 					types.MakeMetricData("metric;tag1=value1;tag2=value21", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
 				},
-				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+				{Metric: "metric", From: 0, Until: 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2=value*', 'name=metric'))",
 				[]float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32).SetTags(map[string]string{"name": "metric", "tag2": "value*", "aggregatedBy": "sum"})},
@@ -430,11 +430,11 @@ func TestAverageSeriesExtractSeriesByTag(t *testing.T) {
 		{
 			"sum(seriesByTag('tag2!=value2*', 'name=metric.name'))",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('tag2!=value2*', 'name=metric.name')", 0, 1}: {
+				{Metric: "seriesByTag('tag2!=value2*', 'name=metric.name')", From: 0, Until: 1}: {
 					types.MakeMetricData("metric.name;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric.name;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
 				},
-				{"metric.name", 0, 1}: {types.MakeMetricData("metric.name", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+				{Metric: "metric.name", From: 0, Until: 1}: {types.MakeMetricData("metric.name", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2!=value2*', 'name=metric.name'))",
 				[]float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "metric.name", "aggregatedBy": "sum"})},
@@ -442,11 +442,11 @@ func TestAverageSeriesExtractSeriesByTag(t *testing.T) {
 		{
 			"sum(seriesByTag('tag2=value21'))",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('tag2=value21')", 0, 1}: {
+				{Metric: "seriesByTag('tag2=value21')", From: 0, Until: 1}: {
 					types.MakeMetricData("metric;tag2=value22;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric;tag2=value23;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
 				},
-				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+				{Metric: "metric", From: 0, Until: 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(seriesByTag('tag2=value21'))",
 				[]float64{5, math.NaN(), 7, 5, 11, 6}, 1, now32).SetTags(map[string]string{"name": "sumSeries", "tag2": "value21", "aggregatedBy": "sum"})},
@@ -479,8 +479,8 @@ func TestAverageSeriesAlign(t *testing.T) {
 			// timeseries with different length
 			Target: "sum(metric1_2,metric2_1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1_2", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 3, 5}, 1, 1)},
-				{"metric2_1", 0, 1}: {types.MakeMetricData("metric2", []float64{1, 5}, 2, 1)},
+				{Metric: "metric1_2", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 3, 5}, 1, 1)},
+				{Metric: "metric2_1", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{1, 5}, 2, 1)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData("sumSeries(metric1_2,metric2_1)",
 				[]float64{2, 9}, 2, 0).SetTag("aggregatedBy", "sum")},
@@ -489,8 +489,8 @@ func TestAverageSeriesAlign(t *testing.T) {
 			// First timeseries with broker StopTime
 			Target: "sum(metric1,metric2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 3, 5, 8}, 1, 1).AppendStopTime(-1)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{1, 5, 7}, 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 3, 5, 8}, 1, 1).AppendStopTime(-1)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{1, 5, 7}, 1, 1)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2)",
 				[]float64{2, 8, 12, 8}, 1, 1).SetTag("aggregatedBy", "sum")},
@@ -510,7 +510,7 @@ func TestAverageSeriesAlign(t *testing.T) {
 func BenchmarkAverageSeries(b *testing.B) {
 	target := "sum(metric*)"
 	metrics := map[parser.MetricRequest][]*types.MetricData{
-		{"metric*", 0, 1}: {
+		{Metric: "metric*", From: 0, Until: 1}: {
 			types.MakeMetricData("metric2", compare.GenerateMetrics(2046, 1, 10, 1), 2, 1),
 			types.MakeMetricData("metric1", compare.GenerateMetrics(4096, 1, 10, 1), 1, 1),
 			types.MakeMetricData("metric3", compare.GenerateMetrics(1360, 1, 10, 1), 3, 1),

--- a/expr/functions/aggregateLine/function_test.go
+++ b/expr/functions/aggregateLine/function_test.go
@@ -30,7 +30,7 @@ func TestConstantLine(t *testing.T) {
 		{
 			"aggregateLine(metric[123])",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1.0, math.NaN(), 2.0, 3.0, 4.0, 5.0}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2.0, math.NaN(), 3.0, math.NaN(), 5.0, 6.0}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3.0, math.NaN(), 4.0, 5.0, 6.0, math.NaN()}, 1, now32),
@@ -45,7 +45,7 @@ func TestConstantLine(t *testing.T) {
 		{
 			"aggregateLine(metric[12],'avg',true)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[12]", 0, 1}: {
+				{Metric: "metric[12]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2.0, 6.0, 3.0, 2.0, 5.0, 6.0}, 1, now32),
 				},
@@ -70,7 +70,7 @@ func TestConstantLine(t *testing.T) {
 func BenchmarkAverageSeries(b *testing.B) {
 	target := "aggregateLine(metric[12],'avg',true)"
 	metrics := map[parser.MetricRequest][]*types.MetricData{
-		{"metric[12]", 0, 1}: {
+		{Metric: "metric[12]", From: 0, Until: 1}: {
 			types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 1),
 			types.MakeMetricData("metric2", []float64{2.0, 6.0, 3.0, 2.0, 5.0, 6.0}, 1, 1),
 		},

--- a/expr/functions/aggregateSeriesLists/function_test.go
+++ b/expr/functions/aggregateSeriesLists/function_test.go
@@ -40,8 +40,8 @@ func TestFunction(t *testing.T) {
 		{
 			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"mining.*.shipped", 0, 1}:   shipped,
-				{"mining.*.extracted", 0, 1}: extracted,
+				{Metric: "mining.*.shipped", From: 0, Until: 1}:   shipped,
+				{Metric: "mining.*.extracted", From: 0, Until: 1}: extracted,
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\")", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
@@ -53,8 +53,8 @@ func TestFunction(t *testing.T) {
 		{
 			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"mining.*.shipped", 0, 1}:   shipped,
-				{"mining.*.extracted", 0, 1}: extracted,
+				{Metric: "mining.*.shipped", From: 0, Until: 1}:   shipped,
+				{Metric: "mining.*.extracted", From: 0, Until: 1}: extracted,
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\")", []float64{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40}, 1, now),
@@ -66,8 +66,8 @@ func TestFunction(t *testing.T) {
 		{
 			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"mining.*.shipped", 0, 1}:   shipped,
-				{"mining.*.extracted", 0, 1}: extracted,
+				{Metric: "mining.*.shipped", From: 0, Until: 1}:   shipped,
+				{Metric: "mining.*.extracted", From: 0, Until: 1}: extracted,
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\")", []float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, now),
@@ -79,8 +79,8 @@ func TestFunction(t *testing.T) {
 		{
 			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"mining.*.shipped", 0, 1}:   shipped,
-				{"mining.*.extracted", 0, 1}: extracted,
+				{Metric: "mining.*.shipped", From: 0, Until: 1}:   shipped,
+				{Metric: "mining.*.extracted", From: 0, Until: 1}: extracted,
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\")", []float64{1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 256, 289, 324, 361, 400}, 1, now),
@@ -92,8 +92,8 @@ func TestFunction(t *testing.T) {
 		{
 			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"mining.*.shipped", 0, 1}:   shipped,
-				{"mining.*.extracted", 0, 1}: extracted,
+				{Metric: "mining.*.shipped", From: 0, Until: 1}:   shipped,
+				{Metric: "mining.*.extracted", From: 0, Until: 1}: extracted,
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\")", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
@@ -105,8 +105,8 @@ func TestFunction(t *testing.T) {
 		{
 			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"mining.*.shipped", 0, 1}:   shipped,
-				{"mining.*.extracted", 0, 1}: extracted,
+				{Metric: "mining.*.shipped", From: 0, Until: 1}:   shipped,
+				{Metric: "mining.*.extracted", From: 0, Until: 1}: extracted,
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\")", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
@@ -118,8 +118,8 @@ func TestFunction(t *testing.T) {
 		{
 			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\", 0.6)", // Test with xFilesFactor
 			map[parser.MetricRequest][]*types.MetricData{
-				{"mining.*.shipped", 0, 1}:   shipped,
-				{"mining.*.extracted", 0, 1}: extracted,
+				{Metric: "mining.*.shipped", From: 0, Until: 1}:   shipped,
+				{Metric: "mining.*.extracted", From: 0, Until: 1}: extracted,
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\", 0.6)", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),

--- a/expr/functions/aggregateWithWildcards/function_test.go
+++ b/expr/functions/aggregateWithWildcards/function_test.go
@@ -30,7 +30,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[123],"avg",0)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar.baz", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2.foo.bar.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3.foo.bar.baz", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -42,7 +42,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[123],"diff",1)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar.baz", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo2.bar.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric2.foo.bar.baz", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -56,7 +56,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[1234],"max",2)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar2.baz2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar3.baz1", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -71,7 +71,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[1234],"min",3)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar.baz1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar.baz2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric2.foo.bar.baz3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -86,7 +86,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[1234],"median",0,3)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2.foo.bar1.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3.foo.bar2.baz", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -101,7 +101,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[1234],"multiply",1,2)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo1.bar.baz", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric1.foo2.bar.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo3.bar.qux", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -116,7 +116,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[1234],"range",0,2)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar.baz.1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2.foo.bar.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3.foo.bar.baz.1", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -131,7 +131,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[1234],"sum",1,3)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo1.bar.baz.qux", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric1.foo2.bar.baz.quux", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo3.bar.baz.qux", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -146,7 +146,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[1234],"sum")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo1.bar.baz.qux", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric1.foo2.bar.baz.quux", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 				},
@@ -159,7 +159,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		{
 			`aggregateWithWildcards(metric[123456],"stddev",0,1,2)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123456]", 0, 1}: {
+				{Metric: "metric[123456]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar.baz1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
 					types.MakeMetricData("metric2.foo.bar.baz2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
 					types.MakeMetricData("metric3.foo.bar.baz1", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -192,7 +192,7 @@ func TestFunctionSumSeriesWithWildcards(t *testing.T) {
 		{
 			"sumSeriesWithWildcards(metric1.foo.*.*,1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, now32),
@@ -225,7 +225,7 @@ func TestAverageSeriesWithWildcards(t *testing.T) {
 		{
 			"averageSeriesWithWildcards(metric1.foo.*.*,1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, now32),
@@ -257,7 +257,7 @@ func TestFunctionMultiplySeriesWithWildcards(t *testing.T) {
 		{
 			"multiplySeriesWithWildcards(metric1.foo.*.*,1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 0, 8, 9, 10}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, now32),
@@ -288,7 +288,7 @@ func TestEmptyData(t *testing.T) {
 		{
 			"multiplySeriesWithWildcards(metric1.foo.*.*,1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {},
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {},
 			},
 			[]*types.MetricData{},
 		},
@@ -311,7 +311,7 @@ func BenchmarkMultiplySeriesWithWildcards(b *testing.B) {
 		{
 			target: "multiplySeriesWithWildcards(metric1.foo.bar*.*,1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar*.*", 0, 1}: {
+				{Metric: "metric1.foo.bar*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, 1),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, 1),
 					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, 1),
@@ -322,7 +322,7 @@ func BenchmarkMultiplySeriesWithWildcards(b *testing.B) {
 		{
 			target: "multiplySeriesWithWildcards(metric1.foo.*.*,1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, 1),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, 1),
 
@@ -438,7 +438,7 @@ func BenchmarkMultiplyAverageSeriesWithWildcards(b *testing.B) {
 		{
 			target: "averageSeriesWithWildcards(metric1.foo.bar*.*,1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar*.*", 0, 1}: {
+				{Metric: "metric1.foo.bar*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, 1),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, 1),
 					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, 1),
@@ -449,7 +449,7 @@ func BenchmarkMultiplyAverageSeriesWithWildcards(b *testing.B) {
 		{
 			target: "averageSeriesWithWildcards(metric1.foo.*.*,1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, 1),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, 1),
 
@@ -565,7 +565,7 @@ func BenchmarkSumSeriesWithWildcards(b *testing.B) {
 		{
 			target: "sumSeriesWithWildcards(metric1.foo.bar*.*,1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar*.*", 0, 1}: {
+				{Metric: "metric1.foo.bar*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, 1),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, 1),
 					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, 1),
@@ -576,7 +576,7 @@ func BenchmarkSumSeriesWithWildcards(b *testing.B) {
 		{
 			target: "sumSeriesWithWildcards(metric1.foo.*.*,1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, 1),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, 1),
 

--- a/expr/functions/aliasByMetric/function_test.go
+++ b/expr/functions/aliasByMetric/function_test.go
@@ -29,7 +29,7 @@ func TestAliasByMetric(t *testing.T) {
 		{
 			"aliasByMetric(metric1.foo.bar.baz)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 		},

--- a/expr/functions/aliasByNode/function_test.go
+++ b/expr/functions/aliasByNode/function_test.go
@@ -52,7 +52,7 @@ func TestAliasByNode(t *testing.T) {
 		{
 			"aliasByNode(aliasSub(a.b.c.d.e, '(.*)', '0.1.2.@.4'), 2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"a.b.c.d.e", 0, 1}: {
+				{Metric: "a.b.c.d.e", From: 0, Until: 1}: {
 					types.MakeMetricData("a.b.c.d.e", []float64{8, 2, 4}, 1, now32),
 				},
 			},
@@ -149,7 +149,7 @@ func TestAliasByNode(t *testing.T) {
 		{
 			Target: `aliasByNode(sumSeries(metric.{a,b}*.b), 1, 2)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric.{a,b}*.b", 0, 1}: {
+				{Metric: "metric.{a,b}*.b", From: 0, Until: 1}: {
 					types.MakeMetricData("metric.a1.b", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric.b2.b", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric.c2.b", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
@@ -161,12 +161,12 @@ func TestAliasByNode(t *testing.T) {
 		{
 			Target: `aliasByTags(sumSeries(seriesByTag('tag2=value*', 'name=metric')), 'tag2', 'name')`,
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+				{Metric: "seriesByTag('tag2=value*', 'name=metric')", From: 0, Until: 1}: {
 					types.MakeMetricData("metric;tag1=value1;tag2=value21", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric;tag2=value21;tag3=value3", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric;tag2=value21;tag3=value3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
 				},
-				{"metric", 0, 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
+				{Metric: "metric", From: 0, Until: 1}: {types.MakeMetricData("metric", []float64{2, math.NaN(), 3, math.NaN(), 5, 11}, 1, now32)},
 			},
 			// Want: []*types.MetricData{types.MakeMetricData("value____.metric", []float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
 			Want: []*types.MetricData{

--- a/expr/functions/aliasSub/function_test.go
+++ b/expr/functions/aliasSub/function_test.go
@@ -29,7 +29,7 @@ func TestAliasSub(t *testing.T) {
 		{
 			"aliasSub(metric1.foo.bar.baz, \"foo\", \"replaced\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1.replaced.bar.baz",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -37,7 +37,7 @@ func TestAliasSub(t *testing.T) {
 		{
 			"aliasSub(metric1.TCP100,\"^.*TCP(\\d+)\",\"$1\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.TCP100", 0, 1}: {types.MakeMetricData("metric1.TCP100", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.TCP100", From: 0, Until: 1}: {types.MakeMetricData("metric1.TCP100", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("100",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -45,7 +45,7 @@ func TestAliasSub(t *testing.T) {
 		{
 			"aliasSub(metric1.TCP100,\"^.*TCP(\\d+)\", \"\\1\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.TCP100", 0, 1}: {types.MakeMetricData("metric1.TCP100", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.TCP100", From: 0, Until: 1}: {types.MakeMetricData("metric1.TCP100", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("100",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -53,7 +53,7 @@ func TestAliasSub(t *testing.T) {
 		{
 			"aliasSub(metric1.foo.bar.baz, \"foo\", \"replaced\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1.replaced.bar.baz",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -63,7 +63,7 @@ func TestAliasSub(t *testing.T) {
 			//"aliasSub(*, '.dns.([^.]+).zone.', '\\1 diff to sql')",
 			"aliasSub(*, 'dns.([^.]*).zone.', '\\1 diff to sql ')",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"*", 0, 1}: {types.MakeMetricData("diffSeries(dns.snake.sql_updated, dns.snake.zone_updated)", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "*", From: 0, Until: 1}: {types.MakeMetricData("diffSeries(dns.snake.sql_updated, dns.snake.zone_updated)", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("diffSeries(dns.snake.sql_updated, snake diff to sql updated)",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetNameTag("diffSeries(dns.snake.sql_updated, snake diff to sql updated)")},
@@ -83,8 +83,8 @@ func TestAliasSub(t *testing.T) {
 func BenchmarkAverageAlias(b *testing.B) {
 	target := `aliasSub(metric1.TCP100,"^.*TCP(\\d+)","$1")`
 	metrics := map[parser.MetricRequest][]*types.MetricData{
-		{"metric1.TCP100", 0, 1}:  {types.MakeMetricData("metric1.TCP100", []float64{1, 2, 3, 4, 5}, 1, 1)},
-		{"metric1.TCP1024", 0, 1}: {types.MakeMetricData("metric1.TCP1024", []float64{1, 2, 3, 4, 5}, 1, 1)},
+		{Metric: "metric1.TCP100", From: 0, Until: 1}:  {types.MakeMetricData("metric1.TCP100", []float64{1, 2, 3, 4, 5}, 1, 1)},
+		{Metric: "metric1.TCP1024", From: 0, Until: 1}: {types.MakeMetricData("metric1.TCP1024", []float64{1, 2, 3, 4, 5}, 1, 1)},
 	}
 
 	eval := th.EvaluatorFromFunc(md[0].F)

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -31,8 +31,8 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(metric1,metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 12}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, NaN, 3, NaN, 0, 6}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 12}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, NaN, 3, NaN, 0, 6}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("asPercent(metric1,metric2)",
 				[]float64{50, NaN, NaN, NaN, NaN, 200}, 1, now32)},
@@ -40,7 +40,7 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(metric1,'5')", // Ensure quoted numeric values are handled
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 12}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 12}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("asPercent(metric1,5)",
 				[]float64{20, NaN, NaN, 60, 80, 240}, 1, now32)},
@@ -48,11 +48,11 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(metricA*,metricB*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metricA*", 0, 1}: {
+				{Metric: "metricA*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA1", []float64{1, 20, 10}, 1, now32),
 					types.MakeMetricData("metricA2", []float64{1, 10, 20}, 1, now32),
 				},
-				{"metricB*", 0, 1}: {
+				{Metric: "metricB*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricB1", []float64{4, 4, 8}, 1, now32),
 					types.MakeMetricData("metricB2", []float64{4, 16, 2}, 1, now32),
 				},
@@ -65,11 +65,11 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(Server{1,2}.memory.used,Server{1,3}.memory.total)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.used", []float64{1, 20, 10}, 1, now32),
 					types.MakeMetricData("Server2.memory.used", []float64{1, 10, 20}, 1, now32),
 				},
-				{"Server{1,3}.memory.total", 0, 1}: {
+				{Metric: "Server{1,3}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.total", []float64{4, 4, 8}, 1, now32),
 					types.MakeMetricData("Server3.memory.total", []float64{4, 16, 2}, 1, now32),
 				},
@@ -82,11 +82,11 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(metricC*,metricD*)", // This test is to verify that passing in metrics with different number of values and different step values for the series and the totalSeries does not throw an error
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metricC*", 0, 1}: {
+				{Metric: "metricC*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricC1", []float64{1, 20, 10, 15, 5}, 1, now32), // Test that error isn't thrown when seriesList has more values than totalSeries
 					types.MakeMetricData("metricC2", []float64{1, 10, 20, 15, 5}, 1, now32),
 				},
-				{"metricD*", 0, 1}: {
+				{Metric: "metricD*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricD1", []float64{4, 4, 8}, 2, now32),
 					types.MakeMetricData("metricD2", []float64{4, 16, 2}, 2, now32),
 				},
@@ -99,12 +99,12 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(metricE*,metricF*)", // This test is to verify that passing in metrics with different lengths and different number of values and different step values for the series and the totalSeries does not throw an error
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metricE*", 0, 1}: {
+				{Metric: "metricE*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricE1", []float64{1, 20, 10, 15, 5}, 1, now32), // Test that error isn't thrown when seriesList has more values than totalSeries
 					types.MakeMetricData("metricE2", []float64{1, 10, 20, 15, 5}, 1, now32),
 					types.MakeMetricData("metricE3", []float64{1, 10, 20, 15, 5}, 1, now32),
 				},
-				{"metricF*", 0, 1}: {
+				{Metric: "metricF*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricF1", []float64{4, 4, 8}, 2, now32),
 					types.MakeMetricData("metricF2", []float64{4, 16, 2}, 2, now32),
 				},
@@ -121,7 +121,7 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 14}, 1, now32),
 					types.MakeMetricData("metric2", []float64{4, NaN, 3, NaN, 0, 6}, 1, now32),
 				},
@@ -134,11 +134,11 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(Server{1,2}.memory.used,Server{1,2}.memory.total)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.used", []float64{1, 20, 10}, 1, now32),
 					types.MakeMetricData("Server2.memory.used", []float64{1, 11, 20}, 1, now32),
 				},
-				{"Server{1,2}.memory.total", 0, 1}: {
+				{Metric: "Server{1,2}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server2.memory.total", []float64{4, 2, 2}, 1, now32),
 					types.MakeMetricData("Server1.memory.total", []float64{4, 4, 8}, 1, now32),
 				},
@@ -151,11 +151,11 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(Server{1,2}.memory.used,Server{1,2,3}.memory.total)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.used", []float64{1, 20, 15}, 1, now32),
 					types.MakeMetricData("Server2.memory.used", []float64{1, 11, 20}, 1, now32),
 				},
-				{"Server{1,2,3}.memory.total", 0, 1}: {
+				{Metric: "Server{1,2,3}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.total", []float64{4, 40, 25}, 1, now32),
 					types.MakeMetricData("Server2.memory.total", []float64{4, 20, 40}, 1, now32),
 					types.MakeMetricData("Server3.memory.total", []float64{4, 20, 40}, 1, now32),
@@ -170,12 +170,12 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(Server{1,2,3}.memory.used,Server{1,2}.memory.total)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2,3}.memory.used", 0, 1}: {
+				{Metric: "Server{1,2,3}.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.used", []float64{1, 20, 15}, 1, now32),
 					types.MakeMetricData("Server2.memory.used", []float64{1, 11, 20}, 1, now32),
 					types.MakeMetricData("Server3.memory.used", []float64{1, 11, 20}, 1, now32),
 				},
-				{"Server{1,2}.memory.total", 0, 1}: {
+				{Metric: "Server{1,2}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.total", []float64{4, 40, 25}, 1, now32),
 					types.MakeMetricData("Server2.memory.total", []float64{4, 20, 40}, 1, now32),
 				},
@@ -190,11 +190,11 @@ func TestAsPercent(t *testing.T) {
 		{
 			"asPercent(seriesByTag('name=metric', 'tag=A*'),metricB*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('name=metric', 'tag=A*')", 0, 1}: {
+				{Metric: "seriesByTag('name=metric', 'tag=A*')", From: 0, Until: 1}: {
 					types.MakeMetricData("metric;tag=A1", []float64{1, 20, 10}, 1, now32),
 					types.MakeMetricData("metric;tag=A2", []float64{1, 10, 20}, 1, now32),
 				},
-				{"metricB*", 0, 1}: {
+				{Metric: "metricB*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricB1", []float64{4, 4, 8}, 1, now32),
 					types.MakeMetricData("metricB2", []float64{4, 16, 2}, 1, now32),
 				},
@@ -222,11 +222,11 @@ func TestAsPercentAlignment(t *testing.T) {
 		{
 			"asPercent(Server{1,2}.aligned.memory.used,Server{1,3}.aligned.memory.total)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.aligned.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.aligned.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.used", []float64{1, 20, 10, 20}, 1, now32),
 					types.MakeMetricData("Server2.aligned.memory.used", []float64{0, 1, 10, 20}, 1, now32-1),
 				},
-				{"Server{1,3}.aligned.memory.total", 0, 1}: {
+				{Metric: "Server{1,3}.aligned.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.total", []float64{1, 4, 4, 8}, 1, now32-1),
 					types.MakeMetricData("Server3.aligned.memory.total", []float64{4, 16, 2, 10}, 1, now32),
 				},
@@ -239,11 +239,11 @@ func TestAsPercentAlignment(t *testing.T) {
 		{
 			"asPercent(Server{1,2}.aligned.memory.used,Server3.aligned.memory.total)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.aligned.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.aligned.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.used", []float64{1, 20, 10, 20}, 1, now32),
 					types.MakeMetricData("Server2.aligned.memory.used", []float64{0, 2, 10, 20}, 1, now32-1),
 				},
-				{"Server3.aligned.memory.total", 0, 1}: {
+				{Metric: "Server3.aligned.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server3.aligned.memory.total", []float64{4, 16, 2, 10, 40}, 1, now32-1),
 				},
 			},
@@ -255,7 +255,7 @@ func TestAsPercentAlignment(t *testing.T) {
 		{
 			"asPercent(Server{1,2}.aligned.memory.used,100)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.aligned.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.aligned.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.used", []float64{1, 20, 10, 20}, 1, now32),
 					types.MakeMetricData("Server2.aligned.memory.used", []float64{0, 1, 10, 20}, 1, now32-1),
 				},
@@ -284,11 +284,11 @@ func TestAsPercentGroup(t *testing.T) {
 		{
 			"asPercent(Server{1,2}.memory.used,Server{1,3}.memory.total,0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.used", []float64{1, 20, 10}, 1, now32),
 					types.MakeMetricData("Server2.memory.used", []float64{1, 10, 20}, 1, now32),
 				},
-				{"Server{1,3}.memory.total", 0, 1}: {
+				{Metric: "Server{1,3}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.total", []float64{4, 4, 8}, 1, now32),
 					types.MakeMetricData("Server3.memory.total", []float64{4, 16, 2}, 1, now32),
 				},
@@ -304,13 +304,13 @@ func TestAsPercentGroup(t *testing.T) {
 		{
 			"asPercent(Server{1,2}.memory.{used,free},Server{1,3}.memory.total,0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.{used,free}", 0, 1}: {
+				{Metric: "Server{1,2}.memory.{used,free}", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.used", []float64{1, 20, 10}, 1, now32),
 					types.MakeMetricData("Server1.memory.free", []float64{1, 20, 10}, 1, now32),
 					types.MakeMetricData("Server2.memory.used", []float64{1, 10, 20}, 1, now32),
 					types.MakeMetricData("Server2.memory.free", []float64{1, 20, 10}, 1, now32),
 				},
-				{"Server{1,3}.memory.total", 0, 1}: {
+				{Metric: "Server{1,3}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.total", []float64{4, 4, 8}, 1, now32),
 					types.MakeMetricData("Server3.memory.total", []float64{4, 16, 2}, 1, now32),
 				},
@@ -326,7 +326,7 @@ func TestAsPercentGroup(t *testing.T) {
 		{
 			"asPercent(Server{1,2}.memory.{used,free},None,0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.{used,free}", 0, 1}: {
+				{Metric: "Server{1,2}.memory.{used,free}", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.used", []float64{2, 1, NaN}, 1, now32),
 					types.MakeMetricData("Server1.memory.free", []float64{3, NaN, 8}, 1, now32),
 					types.MakeMetricData("Server2.memory.used", []float64{4, NaN, 2}, 1, now32),
@@ -358,7 +358,7 @@ func BenchmarkAsPercent(b *testing.B) {
 		{
 			target: "asPercent(metric*)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 14}, 1, 1),
 					types.MakeMetricData("metric2", []float64{4, NaN, 3, NaN, 0, 6}, 1, 1),
 				},
@@ -367,18 +367,18 @@ func BenchmarkAsPercent(b *testing.B) {
 		{
 			target: "asPercent(metric1,metric2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 12}, 1, 1)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, NaN, 3, NaN, 0, 6}, 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, NaN, NaN, 3, 4, 12}, 1, 1)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, NaN, 3, NaN, 0, 6}, 1, 1)},
 			},
 		},
 		{
 			target: "asPercent(Server{1,2}.memory.used,Server{1,2,3}.memory.total)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.used", []float64{1, 20, 10, 20}, 1, 2),
 					types.MakeMetricData("Server2.aligned.memory.used", []float64{0, 1, 10, 20}, 1, 1),
 				},
-				{"Server{1,2,3}.memory.total", 0, 1}: {
+				{Metric: "Server{1,2,3}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.total", []float64{1, 4, 4, 8}, 1, 1),
 					types.MakeMetricData("Server2.aligned.memory.total", []float64{4, 16, 2, 10}, 1, 2),
 					types.MakeMetricData("Server3.aligned.memory.total", []float64{4, 16, 2, 10}, 1, 2),
@@ -388,12 +388,12 @@ func BenchmarkAsPercent(b *testing.B) {
 		{
 			target: "asPercent(Server{1,2,3}.memory.used,Server{1,2}.memory.total)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2,3}.memory.used", 0, 1}: {
+				{Metric: "Server{1,2,3}.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.used", []float64{1, 20, 10, 20}, 1, 2),
 					types.MakeMetricData("Server2.aligned.memory.used", []float64{0, 1, 10, 20}, 1, 1),
 					types.MakeMetricData("Server3.aligned.memory.used", []float64{0, 1, 10, 20}, 1, 1),
 				},
-				{"Server{1,2}.memory.total", 0, 1}: {
+				{Metric: "Server{1,2}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.total", []float64{1, 4, 4, 8}, 1, 1),
 					types.MakeMetricData("Server2.aligned.memory.total", []float64{4, 16, 2, 10}, 1, 2),
 				},
@@ -402,13 +402,13 @@ func BenchmarkAsPercent(b *testing.B) {
 		{
 			target: "asPercent(Server{1,2}.memory.{used,free},Server{1,2}.memory.total)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.{used,free}", 0, 1}: {
+				{Metric: "Server{1,2}.memory.{used,free}", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.used", []float64{1, 20, 10, 20}, 1, 2),
 					types.MakeMetricData("Server2.aligned.memory.used", []float64{0, 1, 10, 20}, 1, 1),
 					types.MakeMetricData("Server1.aligned.memory.free", []float64{1, 20, 10, 20}, 1, 2),
 					types.MakeMetricData("Server2.aligned.memory.free", []float64{0, 1, 10, 20}, 1, 1),
 				},
-				{"Server{1,2}.memory.total", 0, 1}: {
+				{Metric: "Server{1,2}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.total", []float64{1, 4, 4, 8}, 1, 1),
 					types.MakeMetricData("Server2.aligned.memory.total", []float64{4, 16, 2, 10}, 1, 2),
 				},
@@ -417,11 +417,11 @@ func BenchmarkAsPercent(b *testing.B) {
 		{
 			target: "asPercent(Server{1,2}.aligned.memory.used,Server{1,3}.aligned.memory.total)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.aligned.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.aligned.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.used", []float64{1, 20, 10, 20}, 1, 2),
 					types.MakeMetricData("Server2.aligned.memory.used", []float64{0, 1, 10, 20}, 1, 1),
 				},
-				{"Server{1,3}.aligned.memory.total", 0, 1}: {
+				{Metric: "Server{1,3}.aligned.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.total", []float64{1, 4, 4, 8}, 1, 1),
 					types.MakeMetricData("Server3.aligned.memory.total", []float64{4, 16, 2, 10}, 1, 2),
 				},
@@ -430,11 +430,11 @@ func BenchmarkAsPercent(b *testing.B) {
 		{
 			target: "asPercent(Server{1,2}.aligned.memory.used,Server3.aligned.memory.total)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.aligned.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.aligned.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.aligned.memory.used", []float64{1, 20, 10, 20}, 1, 2),
 					types.MakeMetricData("Server2.aligned.memory.used", []float64{0, 2, 10, 20}, 1, 1),
 				},
-				{"Server3.aligned.memory.total", 0, 1}: {
+				{Metric: "Server3.aligned.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server3.aligned.memory.total", []float64{4, 16, 2, 10, 40}, 1, 1),
 				},
 			},
@@ -481,11 +481,11 @@ func BenchmarkAsPercentGroup(b *testing.B) {
 		{
 			target: "asPercent(Server{1,2}.memory.used,Server{1,3}.memory.total,0)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.used", 0, 1}: {
+				{Metric: "Server{1,2}.memory.used", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.used", []float64{1, 20, 10}, 1, 1),
 					types.MakeMetricData("Server2.memory.used", []float64{1, 10, 20}, 1, 1),
 				},
-				{"Server{1,3}.memory.total", 0, 1}: {
+				{Metric: "Server{1,3}.memory.total", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.total", []float64{4, 4, 8}, 1, 1),
 					types.MakeMetricData("Server3.memory.total", []float64{4, 16, 2}, 1, 1),
 				},
@@ -494,7 +494,7 @@ func BenchmarkAsPercentGroup(b *testing.B) {
 		{
 			target: "asPercent(Server{1,2}.memory.{used,free},None,0)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"Server{1,2}.memory.{used,free}", 0, 1}: {
+				{Metric: "Server{1,2}.memory.{used,free}", From: 0, Until: 1}: {
 					types.MakeMetricData("Server1.memory.used", []float64{2, 1, NaN}, 1, 1),
 					types.MakeMetricData("Server1.memory.free", []float64{3, NaN, 8}, 1, 1),
 					types.MakeMetricData("Server2.memory.used", []float64{4, NaN, 2}, 1, 1),

--- a/expr/functions/averageOutsidePercentile/function_test.go
+++ b/expr/functions/averageOutsidePercentile/function_test.go
@@ -29,7 +29,7 @@ func TestAverageOutsidePercentile(t *testing.T) {
 		{
 			`averageOutsidePercentile(metric[1234], 30)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{7, 7, 7, 7, 7, 7}, 1, now32),
 					types.MakeMetricData("metric2", []float64{5, 5, 5, 5, 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{10, 10, 10, 10, 10, 10}, 1, now32),

--- a/expr/functions/below/function_test.go
+++ b/expr/functions/below/function_test.go
@@ -29,7 +29,7 @@ func TestBelow(t *testing.T) {
 		{
 			"currentAbove(metric1,7)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
@@ -42,7 +42,7 @@ func TestBelow(t *testing.T) {
 		{
 			"currentBelow(metric1,0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, math.NaN()}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{0, 4, 4, 5, 5, 6}, 1, now32),
@@ -54,7 +54,7 @@ func TestBelow(t *testing.T) {
 		{
 			"averageAbove(metric1,5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32), // avg=5.5
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32), // avg=5
@@ -67,7 +67,7 @@ func TestBelow(t *testing.T) {
 		{
 			"averageBelow(metric1,0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{0, 4, 4, 5, 5, 6}, 1, now32),
@@ -79,7 +79,7 @@ func TestBelow(t *testing.T) {
 		{
 			"maximumAbove(metric1,6)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
@@ -91,7 +91,7 @@ func TestBelow(t *testing.T) {
 		{
 			"maximumBelow(metric1,5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
@@ -103,7 +103,7 @@ func TestBelow(t *testing.T) {
 		{
 			"minimumAbove(metric1,1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{2, 4, 4, 5, 5, 6}, 1, now32),
@@ -115,7 +115,7 @@ func TestBelow(t *testing.T) {
 		{
 			"minimumBelow(metric1,-2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{-1, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{-2, 4, 4, 5, 5, 6}, 1, now32),

--- a/expr/functions/cactiStyle/function_test.go
+++ b/expr/functions/cactiStyle/function_test.go
@@ -29,7 +29,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1,\"si\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{math.NaN(), 20531.733333333334, 20196.4, 17925.333333333332, 20950.4, 35168.13333333333, 19965.866666666665, 24556.4, 22266.4, 58039.86666666667}, 1, now32),
 				},
@@ -43,7 +43,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1,\"si\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{1.432729, 1.434207, 1.404762, 1.414609, 1.399159, 1.411343, 1.406217, 1.407123, 1.392078, math.NaN()}, 1, now32).SetNameTag("metric1"),
 				},
@@ -56,7 +56,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1,\"si\",\"carrot\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{1.432729, 1.434207, 1.404762, 1.414609, 1.399159, 1.411343, 1.406217, 1.407123, 1.392078, math.NaN()}, 1, now32).SetNameTag("metric1"),
 				},
@@ -69,7 +69,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1,\"si\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{math.NaN(), 88364212.53333333, 79008410.93333334, 80312920.0, 69860465.2, 83876830.0, 80399148.8, 90481297.46666667, 79628113.73333333, math.NaN()}, 1, now32),
 				},
@@ -83,7 +83,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1,\"si\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{1000}, 1, now32),
 				},
@@ -95,7 +95,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{1000}, 1, now32),
 				},
@@ -107,7 +107,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1,units=\"apples\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{10}, 1, now32),
 				},
@@ -119,7 +119,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1,\"si\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{240.0, 240.0, 240.0, 240.0, 240.0, 240.0, 240.0, 240.0, 240.0, math.NaN()}, 1, now32),
 				},
@@ -132,7 +132,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1,\"si\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{-1.0, -2.0, -1.0, -3.0, -1.0, -1.0, -0.0, -0.0, -0.0}, 1, now32),
 				},
@@ -145,7 +145,7 @@ func TestCactiStyle(t *testing.T) {
 		{
 			"cactiStyle(metric1,\"si\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 				},

--- a/expr/functions/changed/function_test.go
+++ b/expr/functions/changed/function_test.go
@@ -29,7 +29,7 @@ func TestChanged(t *testing.T) {
 		{
 			"changed(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0, 0, 0, math.NaN(), math.NaN(), 1, 1, 2, 3, 4, 4, 5, 5, 5, 6, 7}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0, 0, 0, math.NaN(), math.NaN(), 1, 1, 2, 3, 4, 4, 5, 5, 5, 6, 7}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("changed(metric1)",
 				[]float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1}, 1, now32)},

--- a/expr/functions/consolidateBy/function_test.go
+++ b/expr/functions/consolidateBy/function_test.go
@@ -28,7 +28,7 @@ func TestConsolidateBy(t *testing.T) {
 		{
 			"consolidateBy(metric1,\"sum\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"sum\")",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "sum").SetConsolidationFunc("sum")},
@@ -36,7 +36,7 @@ func TestConsolidateBy(t *testing.T) {
 		{
 			"consolidateBy(metric1,\"avg\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"avg\")",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "avg").SetConsolidationFunc("avg")},
@@ -44,7 +44,7 @@ func TestConsolidateBy(t *testing.T) {
 		{
 			"consolidateBy(metric1,\"min\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"min\")",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "min").SetConsolidationFunc("min")},
@@ -52,7 +52,7 @@ func TestConsolidateBy(t *testing.T) {
 		{
 			"consolidateBy(metric1,\"max\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"max\")",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "max").SetConsolidationFunc("max")},
@@ -60,7 +60,7 @@ func TestConsolidateBy(t *testing.T) {
 		{
 			"consolidateBy(metric1,\"first\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"first\")",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "first").SetConsolidationFunc("first")},
@@ -68,7 +68,7 @@ func TestConsolidateBy(t *testing.T) {
 		{
 			"consolidateBy(metric1,\"last\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"last\")",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "last").SetConsolidationFunc("last")},

--- a/expr/functions/cumulative/function_test.go
+++ b/expr/functions/cumulative/function_test.go
@@ -28,7 +28,7 @@ func TestCumulative(t *testing.T) {
 		{
 			"cumulative(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("consolidateBy(metric1,\"sum\")",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetTag("consolidateBy", "sum").SetConsolidationFunc("sum")},

--- a/expr/functions/delay/function_test.go
+++ b/expr/functions/delay/function_test.go
@@ -31,7 +31,7 @@ func TestDelay(t *testing.T) {
 		{
 			"delay(metric1,3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("delay(metric1,3)",
 				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 3, math.NaN()}, 1, now32).SetTag("delay", "3").SetNameTag("delay(metric1,3)")},
@@ -39,7 +39,7 @@ func TestDelay(t *testing.T) {
 		{
 			"delay(metric1,-3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 3, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 3, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("delay(metric1,-3)",
 				[]float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("delay", "-3").SetNameTag("delay(metric1,-3)")},
@@ -47,7 +47,7 @@ func TestDelay(t *testing.T) {
 		{
 			"delay(metric1,0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("delay(metric1,0)",
 				[]float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("delay", "0").SetNameTag("delay(metric1,0)")},

--- a/expr/functions/derivative/function_test.go
+++ b/expr/functions/derivative/function_test.go
@@ -29,7 +29,7 @@ func TestDerivative(t *testing.T) {
 		{
 			"derivative(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 1, 4, math.NaN(), 8}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 1, 4, math.NaN(), 8}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("derivative(metric1)",
 				[]float64{math.NaN(), 2, 2, -5, 3, math.NaN(), 4}, 1, now32).SetTag("derivative", "1").SetNameTag("derivative(metric1)")},
@@ -37,7 +37,7 @@ func TestDerivative(t *testing.T) {
 		{
 			"derivative(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 4, 6, 1, 4, math.NaN(), 8}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 4, 6, 1, 4, math.NaN(), 8}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("derivative(metric1)",
 				[]float64{math.NaN(), math.NaN(), 2, -5, 3, math.NaN(), 4}, 1, now32).SetTag("derivative", "1").SetNameTag("derivative(metric1)")},

--- a/expr/functions/divideSeries/function_test.go
+++ b/expr/functions/divideSeries/function_test.go
@@ -29,14 +29,14 @@ func TestDivideSeriesMultiReturn(t *testing.T) {
 		{
 			"divideSeries(metric[12],metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[12]", 0, 1}: {
+				{Metric: "metric[12]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
 				},
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 				},
-				{"metric2", 0, 1}: {
+				{Metric: "metric2", From: 0, Until: 1}: {
 					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
 				},
 			},
@@ -64,8 +64,8 @@ func TestDivideSeries(t *testing.T) {
 		{
 			"divideSeries(metric1,metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("divideSeries(metric1,metric2)",
 				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2}, 1, now32)},
@@ -73,7 +73,7 @@ func TestDivideSeries(t *testing.T) {
 		{
 			"divideSeries(metric[12])",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[12]", 0, 1}: {
+				{Metric: "metric[12]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32),
 				},
@@ -84,7 +84,7 @@ func TestDivideSeries(t *testing.T) {
 		{
 			"divideSeries(testMetric,metric)", // verify that a non-existant denominator will not error out and instead will return a list of math.NaN() values
 			map[parser.MetricRequest][]*types.MetricData{
-				{"testMetric", 0, 1}: {types.MakeMetricData("testMetric", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
+				{Metric: "testMetric", From: 0, Until: 1}: {types.MakeMetricData("testMetric", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("divideSeries(testMetric,MISSING)",
 				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
@@ -107,10 +107,10 @@ func TestDivideSeriesAligned(t *testing.T) {
 		{
 			"divideSeries(metric1,metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, startTime),
 				},
-				{"metric2", 0, 1}: {
+				{Metric: "metric2", From: 0, Until: 1}: {
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, startTime),
 				},
 			},
@@ -122,7 +122,7 @@ func TestDivideSeriesAligned(t *testing.T) {
 		{
 			"divideSeries(metric[23])",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[23]", 0, 1}: {
+				{Metric: "metric[23]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric2", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, startTime),
 					types.MakeMetricData("metric3", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, startTime),
 				},
@@ -135,10 +135,10 @@ func TestDivideSeriesAligned(t *testing.T) {
 		{
 			"divideSeries(metric3,metric4)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric3", 0, 1}: {
+				{Metric: "metric3", From: 0, Until: 1}: {
 					types.MakeMetricData("metric3", []float64{1, math.NaN(), math.NaN(), 3, 4, 8, 2, math.NaN(), 3, math.NaN(), 0, 6}, 5, startTime),
 				},
-				{"metric4", 0, 1}: {
+				{Metric: "metric4", From: 0, Until: 1}: {
 					types.MakeMetricData("metric4", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 10, startTime),
 				},
 			},

--- a/expr/functions/ewma/function_test.go
+++ b/expr/functions/ewma/function_test.go
@@ -29,7 +29,7 @@ func TestEWMA(t *testing.T) {
 		{
 			"ewma(metric1,0.9)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 1, 1, 1, math.NaN(), 1, 1}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0, 1, 1, 1, math.NaN(), 1, 1}, 1, now32)},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("ewma(metric1,0.9)", []float64{0, 0.9, 0.99, 0.999, math.NaN(), 0.9999, 0.99999}, 1, now32),
@@ -38,7 +38,7 @@ func TestEWMA(t *testing.T) {
 		{
 			"exponentialWeightedMovingAverage(metric1,0.9)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 1, 1, 1, math.NaN(), 1, 1}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0, 1, 1, 1, math.NaN(), 1, 1}, 1, now32)},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("ewma(metric1,0.9)", []float64{0, 0.9, 0.99, 0.999, math.NaN(), 0.9999, 0.99999}, 1, now32),

--- a/expr/functions/exclude/function_test.go
+++ b/expr/functions/exclude/function_test.go
@@ -28,7 +28,7 @@ func TestExclude(t *testing.T) {
 		{
 			"exclude(metric1,\"(Foo|Baz)\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricFoo", []float64{1, 1, 1, 1, 1}, 1, now32),
 					types.MakeMetricData("metricBar", []float64{2, 2, 2, 2, 2}, 1, now32),
 					types.MakeMetricData("metricBaz", []float64{3, 3, 3, 3, 3}, 1, now32),

--- a/expr/functions/exp/function_test.go
+++ b/expr/functions/exp/function_test.go
@@ -29,7 +29,7 @@ func TestExp(t *testing.T) {
 		{
 			"exp(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 2, math.NaN(), 3, 4, 5, 6, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 1, 2, math.NaN(), 3, 4, 5, 6, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("exp(metric1)",
 				[]float64{2.718281828459, 2.718281828459, 7.3890560989307, math.NaN(), 20.085536923188, 54.598150033144, 148.41315910258, 403.42879349274, math.NaN()}, 1, now32).SetTag("exp", "e")},

--- a/expr/functions/exponentialMovingAverage/function_test.go
+++ b/expr/functions/exponentialMovingAverage/function_test.go
@@ -30,7 +30,7 @@ func TestExponentialMovingAverage(t *testing.T) {
 		{
 			Target: "exponentialMovingAverage(metric1,'30s')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", from - 30, from + step*6}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, step, from-30)},
+				{Metric: "metric1", From: from - 30, Until: from + step*6}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, step, from-30)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("exponentialMovingAverage(metric1,\"30s\")", []float64{4, 4.258065, 4.757544, 5.353832, 6.040681, 6.81225, 7.663073}, step, from).SetTag("exponentialMovingAverage", `"30s"`),
@@ -43,8 +43,8 @@ func TestExponentialMovingAverage(t *testing.T) {
 			M: map[parser.MetricRequest][]*types.MetricData{
 				// When the window is an integer, the original from-until range is used to get the step.
 				// That's why two requests are made.
-				{"empty", from, from + step*4}:          {},
-				{"empty", from - step*3, from + step*4}: {},
+				{Metric: "empty", From: from, Until: from + step*4}:          {},
+				{Metric: "empty", From: from - step*3, Until: from + step*4}: {},
 			},
 			Want:  []*types.MetricData{},
 			From:  from,
@@ -53,9 +53,9 @@ func TestExponentialMovingAverage(t *testing.T) {
 		{
 			Target: "exponentialMovingAverage(metric_changes_rollup,4)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric_changes_rollup", from, from + step*6}: {types.MakeMetricData("metric_changes_rollup", []float64{8, 12, 14, 16, 18, 20}, step, from)},
+				{Metric: "metric_changes_rollup", From: from, Until: from + step*6}: {types.MakeMetricData("metric_changes_rollup", []float64{8, 12, 14, 16, 18, 20}, step, from)},
 				// when querying for the preview window, the store changes the rollup and the step changes
-				{"metric_changes_rollup", from - step*4, from + step*6}: {types.MakeMetricData("metric_changes_rollup", []float64{10, 20}, step*10, from-step*4)},
+				{Metric: "metric_changes_rollup", From: from - step*4, Until: from + step*6}: {types.MakeMetricData("metric_changes_rollup", []float64{10, 20}, step*10, from-step*4)},
 			},
 			Want: []*types.MetricData{
 				// since the input is shorter than the window, the result should be just the average
@@ -68,8 +68,8 @@ func TestExponentialMovingAverage(t *testing.T) {
 			// copied from Graphite Web
 			Target: "exponentialMovingAverage(halfNone,10)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"halfNone", from, from + 10}:      {types.MakeMetricData("halfNone", append(append(append(nans(10), rangeFloats(0, 5, 1)...), math.NaN()), rangeFloats(5, 9, 1)...), 1, from)},
-				{"halfNone", from - 10, from + 10}: {types.MakeMetricData("halfNone", append(append(append(nans(10), rangeFloats(0, 5, 1)...), math.NaN()), rangeFloats(5, 9, 1)...), 1, from-10)},
+				{Metric: "halfNone", From: from, Until: from + 10}:      {types.MakeMetricData("halfNone", append(append(append(nans(10), rangeFloats(0, 5, 1)...), math.NaN()), rangeFloats(5, 9, 1)...), 1, from)},
+				{Metric: "halfNone", From: from - 10, Until: from + 10}: {types.MakeMetricData("halfNone", append(append(append(nans(10), rangeFloats(0, 5, 1)...), math.NaN()), rangeFloats(5, 9, 1)...), 1, from-10)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("exponentialMovingAverage(halfNone,10)", []float64{0, 0.0, 0.181818, 0.512397, 0.964688, 1.516563, math.NaN(), 2.149915, 2.849931, 3.604489, 4.403673}, 1, from).SetTag("exponentialMovingAverage", `10`),
@@ -81,7 +81,7 @@ func TestExponentialMovingAverage(t *testing.T) {
 		{
 			Target: `exponentialMovingAverage(collectd.test-db0.load.value,"-30s")`,
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"collectd.test-db0.load.value", from - 30, from + 30}: {types.MakeMetricData("collectd.test-db0.load.value", rangeFloats(0, 60, 1), 1, from-30)},
+				{Metric: "collectd.test-db0.load.value", From: from - 30, Until: from + 30}: {types.MakeMetricData("collectd.test-db0.load.value", rangeFloats(0, 60, 1), 1, from-30)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("exponentialMovingAverage(collectd.test-db0.load.value,\"-30s\")", []float64{
@@ -122,7 +122,7 @@ func rangeFloats(start, end, step float64) []float64 {
 func BenchmarkExponentialMovingAverage(b *testing.B) {
 	target := "exponentialMovingAverage(metric1,3)"
 	metrics := map[parser.MetricRequest][]*types.MetricData{
-		{"metric[1234]", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, 0)},
+		{Metric: "metric[1234]", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, 0)},
 	}
 
 	eval := th.EvaluatorFromFunc(md[0].F)
@@ -144,7 +144,7 @@ func BenchmarkExponentialMovingAverage(b *testing.B) {
 func BenchmarkExponentialMovingAverageStr(b *testing.B) {
 	target := "exponentialMovingAverage(metric1,'3s')"
 	metrics := map[parser.MetricRequest][]*types.MetricData{
-		{"metric[1234]", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, 0)},
+		{Metric: "metric[1234]", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, 0)},
 	}
 
 	eval := th.EvaluatorFromFunc(md[0].F)

--- a/expr/functions/fallbackSeries/function_test.go
+++ b/expr/functions/fallbackSeries/function_test.go
@@ -28,8 +28,8 @@ func TestFallbackSeries(t *testing.T) {
 		{
 			"fallbackSeries(metric*,fallbackmetric)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}:        {types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32)},
-				{"fallbackmetric", 0, 1}: {types.MakeMetricData("fallbackmetric", []float64{0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}:        {types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32)},
+				{Metric: "fallbackmetric", From: 0, Until: 1}: {types.MakeMetricData("fallbackmetric", []float64{0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7}, 1, now32)},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("fallbackmetric", []float64{0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7}, 1, now32),
@@ -38,8 +38,8 @@ func TestFallbackSeries(t *testing.T) {
 		{
 			"fallbackSeries(metric1,metrc2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7}, 1, now32)},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32),
@@ -48,8 +48,8 @@ func TestFallbackSeries(t *testing.T) {
 		{
 			"fallbackSeries(absentmetric,fallbackmetric)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}:        {types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32)},
-				{"fallbackmetric", 0, 1}: {types.MakeMetricData("fallbackmetric", []float64{0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}:        {types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32)},
+				{Metric: "fallbackmetric", From: 0, Until: 1}: {types.MakeMetricData("fallbackmetric", []float64{0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7}, 1, now32)},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("fallbackmetric", []float64{0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7}, 1, now32),
@@ -58,7 +58,7 @@ func TestFallbackSeries(t *testing.T) {
 		{
 			"fallbackSeries(metric1,metrc2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32)},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("metric1", []float64{0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9}, 1, now32),
@@ -83,7 +83,7 @@ func TestErrorMissingTimeSeriesFunction(t *testing.T) {
 		{
 			"fallbackSeries(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 					types.MakeMetricData("metricC", []float64{3, 4, 5, 6, 7, 8}, 1, now32),

--- a/expr/functions/filter/function_test.go
+++ b/expr/functions/filter/function_test.go
@@ -29,7 +29,7 @@ func TestConstantLine(t *testing.T) {
 		{
 			"filterSeries(metric[123], 'max', '>', 5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1.0, math.NaN(), 2.0, 3.0, 4.0, 5.0}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2.0, math.NaN(), 3.0, math.NaN(), 5.0, 6.0}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3.0, math.NaN(), 4.0, 5.0, 6.0, math.NaN()}, 1, now32),
@@ -43,7 +43,7 @@ func TestConstantLine(t *testing.T) {
 		{
 			"filterSeries(metric[123], 'max', '=', 5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1.0, math.NaN(), 2.0, 3.0, 4.0, 5.0}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2.0, math.NaN(), 3.0, math.NaN(), 5.0, 6.0}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3.0, math.NaN(), 4.0, 5.0, 6.0, math.NaN()}, 1, now32),
@@ -56,7 +56,7 @@ func TestConstantLine(t *testing.T) {
 		{
 			"filterSeries(metric[123], 'max', '!=', 6)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1.0, math.NaN(), 2.0, 3.0, 4.0, 5.0}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2.0, math.NaN(), 3.0, math.NaN(), 5.0, 6.0}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3.0, math.NaN(), 4.0, 5.0, 6.0, math.NaN()}, 1, now32),
@@ -69,7 +69,7 @@ func TestConstantLine(t *testing.T) {
 		{
 			"filterSeries(metric[123], 'max', '<', 6)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1.0, math.NaN(), 2.0, 3.0, 4.0, 5.0}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2.0, math.NaN(), 3.0, math.NaN(), 5.0, 6.0}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3.0, math.NaN(), 4.0, 5.0, 6.0, math.NaN()}, 1, now32),
@@ -82,7 +82,7 @@ func TestConstantLine(t *testing.T) {
 		{
 			"filterSeries(metric[123], 'max', '>=', 5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1.0, math.NaN(), 2.0, 3.0, 4.0, 5.0}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2.0, math.NaN(), 3.0, math.NaN(), 5.0, 6.0}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3.0, math.NaN(), 4.0, 5.0, 6.0, math.NaN()}, 1, now32),
@@ -97,7 +97,7 @@ func TestConstantLine(t *testing.T) {
 		{
 			"filterSeries(metric[123], 'max', '<=', 5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[123]", 0, 1}: {
+				{Metric: "metric[123]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1.0, math.NaN(), 2.0, 3.0, 4.0, 5.0}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2.0, math.NaN(), 3.0, math.NaN(), 5.0, 6.0}, 1, now32),
 					types.MakeMetricData("metric3", []float64{3.0, math.NaN(), 4.0, 5.0, 6.0, math.NaN()}, 1, now32),

--- a/expr/functions/grep/function_test.go
+++ b/expr/functions/grep/function_test.go
@@ -28,7 +28,7 @@ func TestGrep(t *testing.T) {
 		{
 			"grep(metric1,\"Bar\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricFoo", []float64{1, 1, 1, 1, 1}, 1, now32),
 					types.MakeMetricData("metricBar", []float64{2, 2, 2, 2, 2}, 1, now32),
 					types.MakeMetricData("metricBaz", []float64{3, 3, 3, 3, 3}, 1, now32),

--- a/expr/functions/groupByNode/function_test.go
+++ b/expr/functions/groupByNode/function_test.go
@@ -217,7 +217,7 @@ func TestGroupByNode(t *testing.T) {
 			Name:   "groupByNodes_range",
 			Target: `groupByNodes(test.metric*.foo*,"range",1,0)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"test.metric*.foo*", 0, 1}: {
+				{Metric: "test.metric*.foo*", From: 0, Until: 1}: {
 					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),
@@ -233,7 +233,7 @@ func TestGroupByNode(t *testing.T) {
 			Name:   "groupByNodes_average_no_nodes",
 			Target: `groupByNodes(test.metric*.foo*,"average")`,
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"test.metric*.foo*", 0, 1}: {
+				{Metric: "test.metric*.foo*", From: 0, Until: 1}: {
 					types.MakeMetricData("test.metric1.foo1", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric1.foo2", []float64{0}, 1, now32),
 					types.MakeMetricData("test.metric2.foo1", []float64{0}, 1, now32),

--- a/expr/functions/groupByTags/function_test.go
+++ b/expr/functions/groupByTags/function_test.go
@@ -35,7 +35,7 @@ func TestGroupByTags(t *testing.T) {
 		{
 			`groupByTags(metric1.foo.*, "avg", "dc")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*", 0, 1}: {
+				{Metric: "metric1.foo.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo;cpu=cpu1;dc=dc1", []float64{1, math.NaN(), 3, 4, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric1.foo;cpu=cpu2;dc=dc1", []float64{6, 7, 8, 9, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric1.foo;cpu=cpu3;dc=dc1", []float64{11, 12, 13, 14, math.NaN()}, 1, now32),
@@ -50,7 +50,7 @@ func TestGroupByTags(t *testing.T) {
 		{
 			`groupByTags(metric1.foo.*, "sum", "dc")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*", 0, 1}: {
+				{Metric: "metric1.foo.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo;cpu=cpu1;dc=dc1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo;cpu=cpu2;dc=dc1", []float64{6, 7, 8, 9, 10}, 1, now32),
 					types.MakeMetricData("metric1.foo;cpu=cpu3;dc=dc1", []float64{11, 12, 13, 14, 15}, 1, now32),
@@ -65,7 +65,7 @@ func TestGroupByTags(t *testing.T) {
 		{
 			`groupByTags(metric1.foo.*, "sum", "name", "dc")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*", 0, 1}: {
+				{Metric: "metric1.foo.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo;cpu=cpu1;dc=dc1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo;cpu=cpu2;dc=dc1", []float64{6, 7, 8, 9, 10}, 1, now32),
 					types.MakeMetricData("metric2.foo;cpu=cpu3;dc=dc1", []float64{11, 12, 13, 14, 15}, 1, now32),
@@ -81,7 +81,7 @@ func TestGroupByTags(t *testing.T) {
 		{
 			`groupByTags(metric1.foo.*, "diff", "dc")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*", 0, 1}: {
+				{Metric: "metric1.foo.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo;cpu=cpu1;dc=dc1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo;cpu=cpu2;dc=dc1", []float64{6, 7, 8, 9, 10}, 1, now32),
 				},
@@ -94,7 +94,7 @@ func TestGroupByTags(t *testing.T) {
 		{
 			`groupByTags(metric1.foo.*, "sum", "dc", "cpu", "rack")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*", 0, 1}: {
+				{Metric: "metric1.foo.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo;cpu=cpu1;dc=dc1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric1.foo;cpu=cpu2;dc=dc1", []float64{6, 7, 8, 9, 10}, 1, now32),
 					types.MakeMetricData("metric1.foo;cpu=cpu3;dc=dc1", []float64{11, 12, 13, 14, 15}, 1, now32),

--- a/expr/functions/heatMap/function_test.go
+++ b/expr/functions/heatMap/function_test.go
@@ -29,7 +29,7 @@ func TestHeatMap(t *testing.T) {
 		{
 			"heatMap(a.*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"a.*", 0, 1}: {
+				{Metric: "a.*", From: 0, Until: 1}: {
 					types.MakeMetricData("a.a1", []float64{1, 2, 3, 4, 5, 6}, 1, now32),
 					types.MakeMetricData("a.a2", []float64{2, math.NaN(), 20, 8, 10, 7}, 1, now32),
 					types.MakeMetricData("a.a3", []float64{10, math.NaN(), 3, 17, 10, 90}, 1, now32),

--- a/expr/functions/highestLowest/function_test.go
+++ b/expr/functions/highestLowest/function_test.go
@@ -29,7 +29,7 @@ func TestHighestMultiReturn(t *testing.T) {
 		{
 			"highestCurrent(metric1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 15}, 1, now32),
@@ -44,7 +44,7 @@ func TestHighestMultiReturn(t *testing.T) {
 		{
 			"highestCurrent(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"metric1", 0, 1}: {
+				parser.MetricRequest{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 15}, 1, now32),
@@ -58,7 +58,7 @@ func TestHighestMultiReturn(t *testing.T) {
 		{
 			"highestMax(metric1, 2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"metric1", 0, 1}: {
+				parser.MetricRequest{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 4, 12, 9}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 5, 5, 5, 5, 5, 3}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 10, 10}, 1, now32),
@@ -73,7 +73,7 @@ func TestHighestMultiReturn(t *testing.T) {
 		{
 			"highestMin(metric1, 2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"metric1", 0, 1}: {
+				parser.MetricRequest{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{6, 1, 3, 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metricB", []float64{2, 5, 5, 5, 5, 5}, 1, now32),
 					types.MakeMetricData("metricC", []float64{3, 2, 3, 3, 4, 10}, 1, now32),
@@ -88,7 +88,7 @@ func TestHighestMultiReturn(t *testing.T) {
 		{
 			"highest(metric1, 2, \"max\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 12, 11}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 10}, 1, now32),
@@ -103,7 +103,7 @@ func TestHighestMultiReturn(t *testing.T) {
 		{
 			"lowest(metric1, 2, \"max\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 12, 11}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 10}, 1, now32),
@@ -119,7 +119,7 @@ func TestHighestMultiReturn(t *testing.T) {
 		{
 			"lowestCurrent(metric1,3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 15}, 1, now32),
 					types.MakeMetricData("metricD", []float64{1, 1, 3, 3, 4, 3}, 1, now32),
@@ -136,7 +136,7 @@ func TestHighestMultiReturn(t *testing.T) {
 		{
 			"lowestCurrent(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"metric1", 0, 1}: {
+				parser.MetricRequest{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 15}, 1, now32),
 					types.MakeMetricData("metricD", []float64{1, 1, 3, 3, 4, 3}, 1, now32),
@@ -166,7 +166,7 @@ func TestHighest(t *testing.T) {
 		{
 			"highestCurrent(metric1,1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric0", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
@@ -179,7 +179,7 @@ func TestHighest(t *testing.T) {
 		{
 			"highestCurrent(metric1,4)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric0", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
@@ -198,7 +198,7 @@ func TestHighest(t *testing.T) {
 		{
 			"highestAverage(metric1,1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 5, 5, 5, 5, 5}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 10}, 1, now32),
@@ -210,7 +210,7 @@ func TestHighest(t *testing.T) {
 		{
 			"highestMax(metric1,1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 12, 11}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 10}, 1, now32),
@@ -222,7 +222,7 @@ func TestHighest(t *testing.T) {
 		{
 			"highestMin(metric1,1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{6, 1, 3, 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metricB", []float64{2, 5, 5, 5, 5, 5}, 1, now32),
 					types.MakeMetricData("metricC", []float64{3, 1, 3, 3, 4, 10}, 1, now32),
@@ -234,7 +234,7 @@ func TestHighest(t *testing.T) {
 		{
 			"highest(metric1,\"max\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 12, 11}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 10}, 1, now32),
@@ -246,7 +246,7 @@ func TestHighest(t *testing.T) {
 		{
 			"lowest(metric1,\"max\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 12, 11}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 10}, 1, now32),
@@ -259,7 +259,7 @@ func TestHighest(t *testing.T) {
 		{
 			"lowestCurrent(metric1,1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 1, 3, 3, 4, 15}, 1, now32),

--- a/expr/functions/hitcount/function_test.go
+++ b/expr/functions/hitcount/function_test.go
@@ -25,7 +25,7 @@ func TestHitcountEmptyData(t *testing.T) {
 		{
 			"hitcount(foo.bar, '1min')",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"foo.bar", 0, 1}: {},
+				{Metric: "foo.bar", From: 0, Until: 1}: {},
 			},
 			[]*types.MetricData{},
 		},
@@ -48,7 +48,7 @@ func TestHitcount(t *testing.T) {
 		{
 			Target: "hitcount(metric1,\"30s\")",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 31*5}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: now32, Until: now32 + 31*5}: {types.MakeMetricData("metric1", []float64{
 					1, 1, 1, 1, 1, 2,
 					2, 2, 2, 2, 3, 3,
 					3, 3, 3, 4, 4, 4,
@@ -67,7 +67,7 @@ func TestHitcount(t *testing.T) {
 		{
 			Target: "hitcount(metric1,\"1h\")",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", tenFiftyNine, tenFiftyNine + 25*5}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: tenFiftyNine, Until: tenFiftyNine + 25*5}: {types.MakeMetricData("metric1", []float64{
 					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
 					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
 					5}, 5, tenFiftyNine)},
@@ -83,7 +83,7 @@ func TestHitcount(t *testing.T) {
 		{
 			Target: "hitcount(metric1,\"1h\",true)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 1410343200, 1410350340}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: 1410343200, Until: 1410350340}: {types.MakeMetricData("metric1", []float64{
 					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
 					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
 					5}, 5, tenFiftyNine)},
@@ -99,7 +99,7 @@ func TestHitcount(t *testing.T) {
 		{
 			Target: "hitcount(metric1,\"1h\",alignToInterval=true)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 1410343200, 1410350340}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: 1410343200, Until: 1410350340}: {types.MakeMetricData("metric1", []float64{
 					1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3,
 					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
 					5}, 5, tenFiftyNine)},
@@ -115,7 +115,7 @@ func TestHitcount(t *testing.T) {
 		{
 			Target: "hitcount(metric1,\"15s\")", // Test having a smaller interval than the data's step
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 5*30}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: now32, Until: now32 + 5*30}: {types.MakeMetricData("metric1", []float64{
 					11, 7, 19, 32, 23}, 30, now32)},
 			},
 			Want:  []float64{165, 165, 105, 105, 285, 285, 480, 480, 345, 345},

--- a/expr/functions/holtWintersAberration/function_test.go
+++ b/expr/functions/holtWintersAberration/function_test.go
@@ -32,11 +32,11 @@ func TestHoltWintersAberration(t *testing.T) {
 		{
 			Target: "holtWintersAberration(metric*)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", startTime, startTime + step*points}: {
+				{Metric: "metric*", From: startTime, Until: startTime + step*points}: {
 					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
 					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
 				},
-				{"metric*", startTime - holtwinters.DefaultBootstrapInterval, startTime + step*points}: {
+				{Metric: "metric*", From: startTime - holtwinters.DefaultBootstrapInterval, Until: startTime + step*points}: {
 					types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 0), step, startTime-holtwinters.DefaultBootstrapInterval),
 					types.MakeMetricData("metric2", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 10), step, startTime-holtwinters.DefaultBootstrapInterval),
 				},
@@ -51,11 +51,11 @@ func TestHoltWintersAberration(t *testing.T) {
 		{
 			Target: "holtWintersAberration(metric*,4,'4d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", startTime, startTime + step*points}: {
+				{Metric: "metric*", From: startTime, Until: startTime + step*points}: {
 					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
 					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
 				},
-				{"metric*", startTime - 4*seconds, startTime + step*points}: {
+				{Metric: "metric*", From: startTime - 4*seconds, Until: startTime + step*points}: {
 					types.MakeMetricData("metric1", generateHwRange(0, ((4*seconds/step)+points)*step, step, 0), step, startTime-4*seconds),
 					types.MakeMetricData("metric2", generateHwRange(0, ((4*seconds/step)+points)*step, step, 10), step, startTime-4*seconds),
 				},
@@ -70,11 +70,11 @@ func TestHoltWintersAberration(t *testing.T) {
 		{
 			Target: "holtWintersAberration(metric*,4,'1d','2d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", startTime, startTime + step*points}: {
+				{Metric: "metric*", From: startTime, Until: startTime + step*points}: {
 					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
 					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
 				},
-				{"metric*", startTime - seconds, startTime + step*points}: {
+				{Metric: "metric*", From: startTime - seconds, Until: startTime + step*points}: {
 					types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step, 0), step, startTime-seconds),
 					types.MakeMetricData("metric2", generateHwRange(0, ((seconds/step)+points)*step, step, 10), step, startTime-seconds),
 				},
@@ -89,11 +89,11 @@ func TestHoltWintersAberration(t *testing.T) {
 		{
 			Target: "holtWintersAberration(metric*)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", startTime, startTime + step*points}: {
+				{Metric: "metric*", From: startTime, Until: startTime + step*points}: {
 					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
 					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
 				},
-				{"metric*", startTime - holtwinters.DefaultBootstrapInterval, startTime + step*points}: {
+				{Metric: "metric*", From: startTime - holtwinters.DefaultBootstrapInterval, Until: startTime + step*points}: {
 					types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 0), step, startTime-holtwinters.DefaultBootstrapInterval),
 					types.MakeMetricData("metric2", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 10), step, startTime-holtwinters.DefaultBootstrapInterval),
 					types.MakeMetricData("metric3", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 20), step, startTime-holtwinters.DefaultBootstrapInterval), // Verify that metrics that don't match those fetched with the unadjusted start time are not included in the results

--- a/expr/functions/holtWintersConfidenceArea/function_test.go
+++ b/expr/functions/holtWintersConfidenceArea/function_test.go
@@ -34,7 +34,7 @@ func TestHoltWintersConfidenceArea(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceArea(metric1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - holtwinters.DefaultBootstrapInterval, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step), step, startTime-holtwinters.DefaultBootstrapInterval)},
+				{Metric: "metric1", From: startTime - holtwinters.DefaultBootstrapInterval, Until: startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step), step, startTime-holtwinters.DefaultBootstrapInterval)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{0.2841206166091448, 1.0581027098774411, 0.3338172102994683, 0.5116859493263242, -0.18199175514936972, 0.2366173792019426, -1.2941554508809152, -0.513426806531049, -0.7970905542723132, 0.09868900726536012}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
@@ -46,7 +46,7 @@ func TestHoltWintersConfidenceArea(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceArea(metric1,4,'6d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - 6*holtwinters.SecondsPerDay, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-6*holtwinters.SecondsPerDay)},
+				{Metric: "metric1", From: startTime - 6*holtwinters.SecondsPerDay, Until: startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-6*holtwinters.SecondsPerDay)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{-0.6535362793382391, -0.26554972418633316, -1.1060549683277792, -0.5788026852576289, -1.4594446935142829, -0.6933311085203409, -1.6566119269969288, -1.251651025511391, -1.7938581852717226, -1.1791817117029604}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
@@ -58,7 +58,7 @@ func TestHoltWintersConfidenceArea(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceArea(metric1,4,'1d','2d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - holtwinters.SecondsPerDay, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-holtwinters.SecondsPerDay)},
+				{Metric: "metric1", From: startTime - holtwinters.SecondsPerDay, Until: startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-holtwinters.SecondsPerDay)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{4.106587168490873, 3.8357974803355406, 3.564589629688576, 3.421354957735917, 3.393696278743315, 3.470415673952413, 3.2748850646377368, 3.3539750816574316, 3.5243322056965765, 3.7771201010598134}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),

--- a/expr/functions/holtWintersConfidenceBands/function_test.go
+++ b/expr/functions/holtWintersConfidenceBands/function_test.go
@@ -31,7 +31,7 @@ func TestHoltWintersConfidenceBands(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceBands(metric1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - holtwinters.DefaultBootstrapInterval, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, (((holtwinters.DefaultBootstrapInterval)/step)+points)*step, step), step, startTime-(holtwinters.DefaultBootstrapInterval))},
+				{Metric: "metric1", From: startTime - holtwinters.DefaultBootstrapInterval, Until: startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, (((holtwinters.DefaultBootstrapInterval)/step)+points)*step, step), step, startTime-(holtwinters.DefaultBootstrapInterval))},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{0.2841206166091448, 1.0581027098774411, 0.3338172102994683, 0.5116859493263242, -0.18199175514936972, 0.2366173792019426, -1.2941554508809152, -0.513426806531049, -0.7970905542723132, 0.09868900726536012}, step, startTime).SetTag("holtWintersConfidenceLower", "1"),
@@ -43,7 +43,7 @@ func TestHoltWintersConfidenceBands(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceBands(metric1,4,'6d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - 6*holtwinters.SecondsPerDay, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-6*holtwinters.SecondsPerDay)},
+				{Metric: "metric1", From: startTime - 6*holtwinters.SecondsPerDay, Until: startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-6*holtwinters.SecondsPerDay)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{-0.6535362793382391, -0.26554972418633316, -1.1060549683277792, -0.5788026852576289, -1.4594446935142829, -0.6933311085203409, -1.6566119269969288, -1.251651025511391, -1.7938581852717226, -1.1791817117029604}, step, startTime).SetTag("holtWintersConfidenceLower", "1"),
@@ -55,7 +55,7 @@ func TestHoltWintersConfidenceBands(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceBands(metric1,4,'1d','2d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - holtwinters.SecondsPerDay, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-holtwinters.SecondsPerDay)},
+				{Metric: "metric1", From: startTime - holtwinters.SecondsPerDay, Until: startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-holtwinters.SecondsPerDay)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{4.106587168490873, 3.8357974803355406, 3.564589629688576, 3.421354957735917, 3.393696278743315, 3.470415673952413, 3.2748850646377368, 3.3539750816574316, 3.5243322056965765, 3.7771201010598134}, step, startTime).SetTag("holtWintersConfidenceLower", "1"),
@@ -81,7 +81,7 @@ func TestNoPanicOnBigStep(t *testing.T) {
 	test := th.EvalTestItem{
 		"holtWintersConfidenceBands(metric1,3)",
 		map[parser.MetricRequest][]*types.MetricData{
-			{"metric1", -604800, 1}: {types.MakeMetricData("metric1", []float64{1}, 604800, -604800)},
+			{Metric: "metric1", From: -604800, Until: 1}: {types.MakeMetricData("metric1", []float64{1}, 604800, -604800)},
 		},
 		[]*types.MetricData{
 			types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{}, 604800, 0).SetTag("holtWintersConfidenceLower", "1"),

--- a/expr/functions/holtWintersForecast/function_test.go
+++ b/expr/functions/holtWintersForecast/function_test.go
@@ -30,7 +30,7 @@ func TestHoltWintersForecast(t *testing.T) {
 		{
 			Target: "holtWintersForecast(metric1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - 7*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((7*seconds/step)+points)*step, step), step, startTime-7*seconds)},
+				{Metric: "metric1", From: startTime - 7*seconds, Until: startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((7*seconds/step)+points)*step, step), step, startTime-7*seconds)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersForecast(metric1)", []float64{4.354532587468384, 5.233762480879125, 5.470443699760628, 5.400062907182546, 4.654782553991797, 4.85560658189784, 3.639077513586465, 4.192121821282148, 4.072238207117917, 4.754208902522321}, step, startTime).SetTag("holtWintersForecast", "1"),
@@ -41,7 +41,7 @@ func TestHoltWintersForecast(t *testing.T) {
 		{
 			Target: "holtWintersForecast(metric1,'6d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - 6*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*seconds/step)+points)*step, step), step, startTime-6*seconds)},
+				{Metric: "metric1", From: startTime - 6*seconds, Until: startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*seconds/step)+points)*step, step), step, startTime-6*seconds)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersForecast(metric1)", []float64{3.756495938587323, 4.246729557688366, 4.0724537420914375, 4.707653738003789, 4.526243518254055, 5.324901822037504, 5.491471359733914, 5.360475158485411, 4.56317918291436, 4.719755423132087}, step, startTime).SetTag("holtWintersForecast", "1"),
@@ -52,7 +52,7 @@ func TestHoltWintersForecast(t *testing.T) {
 		{
 			Target: "holtWintersForecast(metric1,'1d','2d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step), step, startTime-seconds)},
+				{Metric: "metric1", From: startTime - seconds, Until: startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step), step, startTime-seconds)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersForecast(metric1)", []float64{4.177645280818122, 4.168426771668243, 4.260421164063269, 4.443824969811369, 4.709783056245225, 5.0502969099660096, 5.458141774396228, 4.923291802762386, 4.540553676160961, 4.2952001684330225}, step, startTime).SetTag("holtWintersForecast", "1"),

--- a/expr/functions/integral/function_test.go
+++ b/expr/functions/integral/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"integral(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 0, 2, 3, 4, 5, math.NaN(), 7, 8}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 0, 2, 3, 4, 5, math.NaN(), 7, 8}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("integral(metric1)",
 				[]float64{1, 1, 3, 6, 10, 15, math.NaN(), 22, 30}, 1, now32).SetTag("integral", "1").SetNameTag("integral(metric1)")},

--- a/expr/functions/integralByInterval/function_test.go
+++ b/expr/functions/integralByInterval/function_test.go
@@ -25,7 +25,7 @@ func TestFunction(t *testing.T) {
 		{
 			"integralByInterval(10s,'10s')",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"10s", 0, 1}: {
+				{Metric: "10s", From: 0, Until: 1}: {
 					types.MakeMetricData("10s", []float64{1, 0, 2, 3, 4, 5, 0, 7, 8, 9, 10}, 2, 0),
 				},
 			},

--- a/expr/functions/integralWithReset/function_test.go
+++ b/expr/functions/integralWithReset/function_test.go
@@ -30,11 +30,11 @@ func TestIntegralWithResetMultiReturn(t *testing.T) {
 		{
 			"integralWithReset(metric[12], reset)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[12]", 0, 1}: {
+				{Metric: "metric[12]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 1, 3, 5, 8, 13, 21}, 1, now32),
 					types.MakeMetricData("metric2", []float64{1, 1, 1, 1, 1, 1, 1}, 1, now32),
 				},
-				{"reset", 0, 1}: {
+				{Metric: "reset", From: 0, Until: 1}: {
 					types.MakeMetricData("reset", []float64{0, 0, 0, 1, 1, 0, 0}, 1, now32),
 				},
 			},
@@ -71,8 +71,8 @@ func TestIntegralWithReset(t *testing.T) {
 		{
 			"integralWithReset(metric1, metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 15}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{0, math.NaN(), 0, math.NaN(), 0, 6, 0}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 15}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{0, math.NaN(), 0, math.NaN(), 0, 6, 0}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("integralWithReset(metric1,metric2)",
 				[]float64{1, math.NaN(), math.NaN(), 4, 8, 0, 15}, 1, now32)},

--- a/expr/functions/invert/function_test.go
+++ b/expr/functions/invert/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"invert(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{-4, -2, -1, 0, 1, 2, 4}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{-4, -2, -1, 0, 1, 2, 4}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("invert(metric1)",
 				[]float64{-0.25, -0.5, -1, math.NaN(), 1, 0.5, 0.25}, 1, now32).SetTag("invert", "1").SetNameTag("invert(metric1)")},

--- a/expr/functions/isNotNull/function_test.go
+++ b/expr/functions/isNotNull/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"isNonNull(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("isNonNull(metric1)",
 				[]float64{0, 1, 0, 1, 1, 1}, 1, now32).SetTag("isNonNull", "1").SetNameTag("isNonNull(metric1)")},
@@ -37,7 +37,7 @@ func TestFunction(t *testing.T) {
 		{
 			"isNonNull(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricFoo", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32),
 					types.MakeMetricData("metricBaz", []float64{1, -1, math.NaN(), -3, 4, 5}, 1, now32),
 				},

--- a/expr/functions/join/function_test.go
+++ b/expr/functions/join/function_test.go
@@ -29,16 +29,16 @@ func TestFunction(t *testing.T) {
 		{
 			"join(metric1, metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{1, 2, 3, -3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{1, 2, 3, -3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{},
 		},
 		{
 			"join(metric1, metric2, \"OR\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{1, 2, 3, -3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{1, 2, 3, -3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32),
@@ -48,8 +48,8 @@ func TestFunction(t *testing.T) {
 		{
 			"join(metric1, metric2, \"XOR\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{1, 2, 3, -3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{1, 2, 3, -3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32),
@@ -59,8 +59,8 @@ func TestFunction(t *testing.T) {
 		{
 			"join(metric1, metric2, \"SUB\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{1, 2, 3, -3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{1, 2, 3, -3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("metric1", []float64{math.NaN(), -1, math.NaN(), -3, 4, 5}, 1, now32),

--- a/expr/functions/keepLastValue/function_test.go
+++ b/expr/functions/keepLastValue/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"keepLastValue(metric1,3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("keepLastValue(metric1,3)", []float64{math.NaN(), 2, 2, 2, 2, math.NaN(), 4, 5}, 1, now32)},
 		},
@@ -37,7 +37,7 @@ func TestFunction(t *testing.T) {
 			"keepLastValue(metric1)",
 
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("keepLastValue(metric1)", []float64{math.NaN(), 2, 2, 2, 2, 2, 4, 5}, 1, now32)},
 		},
@@ -45,7 +45,7 @@ func TestFunction(t *testing.T) {
 			"keepLastValue(metric1,inf)",
 
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("keepLastValue(metric1,inf)", []float64{math.NaN(), 2, 2, 2, 2, 2, 4, 5}, 1, now32)},
 		},
@@ -53,14 +53,14 @@ func TestFunction(t *testing.T) {
 			"keepLastValue(metric1,'INF')",
 
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("keepLastValue(metric1,inf)", []float64{math.NaN(), 2, 2, 2, 2, 2, 4, 5}, 1, now32)},
 		},
 		{
 			"keepLastValue(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32),
 				},

--- a/expr/functions/legendValue/function_test.go
+++ b/expr/functions/legendValue/function_test.go
@@ -28,7 +28,7 @@ func TestFunction(t *testing.T) {
 		{
 			"legendValue(metric1,\"avg\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1 (avg: 3)",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetNameTag("metric1")},
@@ -36,7 +36,7 @@ func TestFunction(t *testing.T) {
 		{
 			"legendValue(metric1,\"sum\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1 (sum: 15)",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetNameTag("metric1")},
@@ -44,7 +44,7 @@ func TestFunction(t *testing.T) {
 		{
 			"legendValue(metric1,\"total\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1 (total: 15)",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetNameTag("metric1")},
@@ -52,7 +52,7 @@ func TestFunction(t *testing.T) {
 		{
 			"legendValue(metric1,\"sum\",\"avg\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1 (sum: 15) (avg: 3)",
 				[]float64{1, 2, 3, 4, 5}, 1, now32).SetNameTag("metric1")},
@@ -60,7 +60,7 @@ func TestFunction(t *testing.T) {
 		{
 			"legendValue(metric1,\"sum\",\"si\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1 (sum: -40.00K )",
 				[]float64{0, 10000, 20000, -30000, -40000}, 1, now32).SetNameTag("metric1")},
@@ -68,7 +68,7 @@ func TestFunction(t *testing.T) {
 		{
 			"legendValue(metric1,\"avg\",\"total\",\"si\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1 (avg: -8.00K ) (total: -40.00K )",
 				[]float64{0, 10000, 20000, -30000, -40000}, 1, now32).SetNameTag("metric1")},
@@ -76,7 +76,7 @@ func TestFunction(t *testing.T) {
 		{
 			"legendValue(metric1,\"sum\",\"binary\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1 (sum: -39.06Ki )",
 				[]float64{0, 10000, 20000, -30000, -40000}, 1, now32).SetNameTag("metric1")},
@@ -84,7 +84,7 @@ func TestFunction(t *testing.T) {
 		{
 			"legendValue(metric1,\"avg\",\"total\",\"binary\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1 (avg: -7.81Ki ) (total: -39.06Ki )",
 				[]float64{0, 10000, 20000, -30000, -40000}, 1, now32).SetNameTag("metric1")},

--- a/expr/functions/limit/function_test.go
+++ b/expr/functions/limit/function_test.go
@@ -28,7 +28,7 @@ func TestLimit(t *testing.T) {
 		{
 			"limit(metric1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 1, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{0, 0, 1, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricC", []float64{0, 0, 0, 1, 0, 0}, 1, now32),
@@ -45,7 +45,7 @@ func TestLimit(t *testing.T) {
 		{
 			"limit(metric1,20)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 1, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{0, 0, 1, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricC", []float64{0, 0, 0, 1, 0, 0}, 1, now32),

--- a/expr/functions/linearRegression/function_test.go
+++ b/expr/functions/linearRegression/function_test.go
@@ -27,7 +27,7 @@ func TestLinearRegression(t *testing.T) {
 		{
 			"linearRegression(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{1, 2, math.NaN(), math.NaN(), 5, 6}, 1, 123),
 				},
@@ -52,7 +52,7 @@ func TestLinearRegression(t *testing.T) {
 func BenchmarkLinearRegression(b *testing.B) {
 	target := "linearRegression(metric1)"
 	metrics := map[parser.MetricRequest][]*types.MetricData{
-		{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), math.NaN(), 5, 6}, 1, 1)},
+		{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), math.NaN(), 5, 6}, 1, 1)},
 	}
 
 	eval := th.EvaluatorFromFunc(md[0].F)

--- a/expr/functions/logarithm/function_test.go
+++ b/expr/functions/logarithm/function_test.go
@@ -29,7 +29,7 @@ func TestLogarithm(t *testing.T) {
 		{
 			"logarithm(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 10, 100, 1000, 10000}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 10, 100, 1000, 10000}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("logarithm(metric1)",
 				[]float64{0, 1, 2, 3, 4}, 1, now32).SetTag("log", "10")},
@@ -37,7 +37,7 @@ func TestLogarithm(t *testing.T) {
 		{
 			"logarithm(metric1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 4, 8, 16, 32}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 4, 8, 16, 32}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("logarithm(metric1,2)",
 				[]float64{0, 1, 2, 3, 4, 5}, 1, now32).SetTag("log", "2")},
@@ -62,13 +62,13 @@ func BenchmarkLogarithm(b *testing.B) {
 		{
 			target: "logarithm(metric1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 10, 100, 1000, 10000}, 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 10, 100, 1000, 10000}, 1, 1)},
 			},
 		},
 		{
 			target: "logarithm(metric1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 4, 8, 16, 32}, 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 4, 8, 16, 32}, 1, 1)},
 			},
 		},
 	}

--- a/expr/functions/logit/function_test.go
+++ b/expr/functions/logit/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"logit(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0.5, math.NaN(), 0.8, 0.25, 0.1, 1}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0.5, math.NaN(), 0.8, 0.25, 0.1, 1}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("logit(metric1)",
 				[]float64{0, math.NaN(), 1.3862943611198908, -1.0986122886681098, -2.197224577336219, math.NaN()}, 1, now32).SetTag("logit", "logit")},

--- a/expr/functions/lowPass/function_test.go
+++ b/expr/functions/lowPass/function_test.go
@@ -29,7 +29,7 @@ func TestLowPass(t *testing.T) {
 		{
 			"lowPass(metric1,40)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("lowPass(metric1,40)", []float64{0, 1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 8, 9}, 1, now32)},
 		},

--- a/expr/functions/mapSeries/function_test.go
+++ b/expr/functions/mapSeries/function_test.go
@@ -28,7 +28,7 @@ func TestFunction(t *testing.T) {
 		{
 			"mapSeries(servers.*.cpu.*, 1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"servers.*.cpu.*", 0, 1}: {
+				{Metric: "servers.*.cpu.*", From: 0, Until: 1}: {
 					types.MakeMetricData("servers.server1.cpu.valid", []float64{1, 2, 3}, 1, now32),
 					types.MakeMetricData("servers.server2.cpu.valid", []float64{6, 7, 8}, 1, now32),
 					types.MakeMetricData("servers.server1.cpu.total", []float64{1, 2, 4}, 1, now32),

--- a/expr/functions/minMax/function_test.go
+++ b/expr/functions/minMax/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"minMax(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{10, 20, 30, math.NaN(), 40, 50}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{10, 20, 30, math.NaN(), 40, 50}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("minMax(metric1)",
 				[]float64{0.0, 0.25, 0.50, math.NaN(), 0.75, 1.0}, 1, now32)},
@@ -37,7 +37,7 @@ func TestFunction(t *testing.T) {
 		{
 			"minMax(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{10, 10, 10, math.NaN(), 10, 10}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{10, 10, 10, math.NaN(), 10, 10}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("minMax(metric1)",
 				[]float64{0, 0, 0, math.NaN(), 0, 0}, 1, now32)},

--- a/expr/functions/mostDeviant/function_test.go
+++ b/expr/functions/mostDeviant/function_test.go
@@ -28,7 +28,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"mostDeviant(2,metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
@@ -45,7 +45,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"mostDeviant(metric*,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -32,8 +32,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingAverage(metric1,10)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 20, 25}: {types.MakeMetricData("metric1", th.GenerateValues(10, 25, 1), 1, 20)},
-				{"metric1", 10, 25}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 10)},
+				{Metric: "metric1", From: 20, Until: 25}: {types.MakeMetricData("metric1", th.GenerateValues(10, 25, 1), 1, 20)},
+				{Metric: "metric1", From: 10, Until: 25}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 10)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,10)`,
 				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 20).SetTag("movingAverage", "10").SetNameTag(`movingAverage(metric1,10)`)},
@@ -43,8 +43,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingAverage(metric1,10)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 20, 30}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 20)},
-				{"metric1", 10, 30}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, 10)},
+				{Metric: "metric1", From: 20, Until: 30}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 20)},
+				{Metric: "metric1", From: 10, Until: 30}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, 10)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,10)`,
 				[]float64{0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5}, 1, 20).SetTag("movingAverage", "10").SetNameTag(`movingAverage(metric1,10)`)},
@@ -54,8 +54,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingAverage(metric1,60)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
-				{"metric1", 550, 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
+				{Metric: "metric1", From: 550, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,60)`,
 				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingAverage", "60").SetNameTag(`movingAverage(metric1,60)`)},
@@ -65,8 +65,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingAverage(metric1,'-1min')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
-				{"metric1", 550, 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
+				{Metric: "metric1", From: 550, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'-1min')`,
 				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingAverage", "'-1min'").SetNameTag(`movingAverage(metric1,'-1min')`)},
@@ -76,8 +76,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingMedian(metric1,10)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 20, 30}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 20)},
-				{"metric1", 10, 30}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, 10)},
+				{Metric: "metric1", From: 20, Until: 30}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 20)},
+				{Metric: "metric1", From: 10, Until: 30}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, 10)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,10)`,
 				[]float64{0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5}, 1, 20).SetTag("movingMedian", "10").SetNameTag(`movingMedian(metric1,10)`)},
@@ -87,8 +87,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingMedian(metric1,10)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 20, 25}: {types.MakeMetricData("metric1", th.GenerateValues(10, 25, 1), 1, 20)},
-				{"metric1", 10, 25}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 10)},
+				{Metric: "metric1", From: 20, Until: 25}: {types.MakeMetricData("metric1", th.GenerateValues(10, 25, 1), 1, 20)},
+				{Metric: "metric1", From: 10, Until: 25}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 10)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,10)`,
 				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 20).SetTag("movingMedian", "10").SetNameTag(`movingMedian(metric1,10)`)},
@@ -98,8 +98,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingMedian(metric1,60)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
-				{"metric1", 550, 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
+				{Metric: "metric1", From: 550, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,60)`,
 				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingMedian", "60").SetNameTag(`movingMedian(metric1,60)`)},
@@ -109,8 +109,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingMedian(metric1,'1min')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
-				{"metric1", 550, 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
+				{Metric: "metric1", From: 550, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,'1min')`,
 				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingMedian", "'1min'").SetNameTag(`movingMedian(metric1,'1min')`)},
@@ -120,8 +120,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingMedian(metric1,'-1min')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
-				{"metric1", 550, 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(10, 110, 1), 1, 610)},
+				{Metric: "metric1", From: 550, Until: 710}: {types.MakeMetricData("metric1", th.GenerateValues(0, 100, 1), 1, 600)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingMedian(metric1,'-1min')`,
 				[]float64{30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5, 45.5, 46.5, 47.5, 48.5, 49.5, 50.5, 51.5, 52.5, 53.5, 54.5, 55.5, 56.5, 57.5, 58.5, 59.5, 60.5, 61.5, 62.5, 63.5, 64.5, 65.5, 66.5, 67.5, 68.5, 69.5}, 1, 660).SetTag("movingMedian", "'-1min'").SetNameTag(`movingMedian(metric1,'-1min')`)},
@@ -131,8 +131,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'3sec','average')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 610)},
-				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 607)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 610)},
+				{Metric: "metric1", From: 607, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
 				[]float64{2, 2, 2}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
@@ -142,8 +142,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'3sec','avg_zero')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 610)},
-				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 607)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 610)},
+				{Metric: "metric1", From: 607, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
 				[]float64{1, 0.3333333333333333, 1.3333333333333333}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
@@ -153,8 +153,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'3sec','count')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 610)},
-				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 607)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 610)},
+				{Metric: "metric1", From: 607, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
 				[]float64{2, 1, 2}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
@@ -164,8 +164,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'3sec','diff')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
-				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
+				{Metric: "metric1", From: 607, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
 				[]float64{-1, 3, -5}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
@@ -175,8 +175,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'3sec','range')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
-				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
+				{Metric: "metric1", From: 607, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
 				[]float64{3, 3, 5}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)},
@@ -186,8 +186,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'3sec','stddev')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
-				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
+				{Metric: "metric1", From: 607, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
 				[]float64{1.247219128924647, 1.5, 2.5}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
@@ -197,8 +197,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'3sec','last')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
-				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 610)},
+				{Metric: "metric1", From: 607, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
 				[]float64{0, math.NaN(), 5}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
@@ -208,8 +208,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'3sec')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 610)},
-				{"metric1", 607, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 607)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 610)},
+				{Metric: "metric1", From: 607, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingWindow(metric1,'3sec')`,
 				[]float64{2, 2, 2}, 1, 610).SetTag("movingWindow", "'3sec'").SetNameTag(`movingWindow(metric1,'3sec')`)}, // StartTime = from
@@ -219,8 +219,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingAverage(metric1,4)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, 610)},
-				{"metric1", 606, 710}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, 606)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, 610)},
+				{Metric: "metric1", From: 606, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, 606)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,4)`,
 				[]float64{1.25, 1.5, 1.75, 2.5, 3.5, 4.0, 5.0, 6.0}, 1, 610).SetTag("movingAverage", "4").SetNameTag(`movingAverage(metric1,4)`)}, // StartTime = from
@@ -230,8 +230,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingAverage(metric1,'5s')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 610)}, // step > windowSize
-				{"metric1", 605, 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 605)},
+				{Metric: "metric1", From: 610, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 610)}, // step > windowSize
+				{Metric: "metric1", From: 605, Until: 710}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 605)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'5s')`,
 				[]float64{math.NaN(), math.NaN(), math.NaN()}, 10, 610).SetTag("movingAverage", "'5s'").SetNameTag(`movingAverage(metric1,'5s')`)}, // StartTime = from
@@ -241,8 +241,8 @@ func TestMoving(t *testing.T) {
 		{
 			Target: "movingAverage(metric1,10)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 700}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 30, 610)}, // step > windowSize
-				{"metric1", 310, 700}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 30, 310)},
+				{Metric: "metric1", From: 610, Until: 700}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 30, 610)}, // step > windowSize
+				{Metric: "metric1", From: 310, Until: 700}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 30, 310)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,10)`,
 				[]float64{}, 30, 610).SetTag("movingAverage", "10").SetNameTag(`movingAverage(metric1,10)`)},
@@ -265,8 +265,8 @@ func TestMovingXFilesFactor(t *testing.T) {
 		{
 			Target: "movingSum(metric1,'3sec',0.5)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 618}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, math.NaN(), 2, math.NaN(), 3}, 1, 610)},
-				{"metric1", 607, 618}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, math.NaN(), 2, math.NaN(), 3}, 1, 607)},
+				{Metric: "metric1", From: 610, Until: 618}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, math.NaN(), 2, math.NaN(), 3}, 1, 610)},
+				{Metric: "metric1", From: 607, Until: 618}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, math.NaN(), 2, math.NaN(), 3}, 1, 607)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingSum(metric1,'3sec')`,
 				[]float64{6, 4, 3, math.NaN(), 5}, 1, 610).SetTag("movingSum", "'3sec'").SetNameTag(`movingSum(metric1,'3sec')`)},
@@ -276,8 +276,8 @@ func TestMovingXFilesFactor(t *testing.T) {
 		{
 			Target: "movingAverage(metric1,4,0.6)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 622}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, math.NaN(), 2, 4, math.NaN(), 4, 6, 8}, 1, 610)},
-				{"metric1", 606, 622}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, math.NaN(), 2, 4, math.NaN(), 4, 6, 8}, 1, 606)},
+				{Metric: "metric1", From: 610, Until: 622}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, math.NaN(), 2, 4, math.NaN(), 4, 6, 8}, 1, 610)},
+				{Metric: "metric1", From: 606, Until: 622}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, math.NaN(), 2, 4, math.NaN(), 4, 6, 8}, 1, 606)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,4)`,
 				[]float64{1.25, 1.3333333333333333, 1.6666666666666667, 2.6666666666666665, math.NaN(), 3.3333333333333335, 4.666666666666667, 6}, 1, 610).SetTag("movingAverage", "4").SetNameTag(`movingAverage(metric1,4)`)},
@@ -287,8 +287,8 @@ func TestMovingXFilesFactor(t *testing.T) {
 		{
 			Target: "movingMax(metric1,2,0.5)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 610, 616}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), 0}, 1, 610)},
-				{"metric1", 608, 616}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), 0}, 1, 608)},
+				{Metric: "metric1", From: 610, Until: 616}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), 0}, 1, 610)},
+				{Metric: "metric1", From: 608, Until: 616}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), 0}, 1, 608)},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingMax(metric1,2)`,
 				[]float64{3, 3, math.NaN(), 0}, 1, 610).SetTag("movingMax", "2").SetNameTag(`movingMax(metric1,2)`)},
@@ -313,28 +313,28 @@ func TestMovingError(t *testing.T) {
 		{
 			Target: "movingWindow(metric1,'','average')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 0)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 0)},
 			},
 			Error: parser.ErrBadType,
 		},
 		{
 			Target: "movingWindow(metric1,'-','average')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 0)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 0)},
 			},
 			Error: parser.ErrBadType,
 		},
 		{
 			Target: "movingWindow(metric1,'+','average')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 0)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, 0)},
 			},
 			Error: parser.ErrBadType,
 		},
 		{
 			Target: "movingWindow(metric1,'-s1','average')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
 			},
 			Error: parser.ErrBadType,
 		},
@@ -358,61 +358,61 @@ func BenchmarkMoving(b *testing.B) {
 		{
 			target: "movingAverage(metric1,'5s')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -5, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 1)}, // step > windowSize
+				{Metric: "metric1", From: -5, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 1)}, // step > windowSize
 			},
 		},
 		{
 			target: "movingAverage(metric1,4)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingAverage(metric1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingSum(metric1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingMin(metric1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingMax(metric1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingAverage(metric1,600)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingSum(metric1,600)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingMin(metric1,600)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingMax(metric1,600)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 	}

--- a/expr/functions/moving/moving_refetch/function_test.go
+++ b/expr/functions/moving/moving_refetch/function_test.go
@@ -19,11 +19,11 @@ var (
 
 	M = map[parser.MetricRequest][]*types.MetricData{
 		// for refetch
-		{"metric*", 10, 25}: {
+		{Metric: "metric*", From: 10, Until: 25}: {
 			types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), 2, math.NaN(), 4, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 10).
 				SetNameTag(`movingAverage(metric1,10)`).SetPathExpression("metric*"),
 		},
-		{"metric1", 10, 25}: {
+		{Metric: "metric1", From: 10, Until: 25}: {
 			types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 10).
 				SetNameTag(`movingAverage(metric1,10)`).SetPathExpression("metric1"),
 		},
@@ -41,7 +41,7 @@ func TestMovingRefetch(t *testing.T) {
 		{
 			Target: "movingAverage(metric*,10)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 20, 25}: {types.MakeMetricData("metric1", th.GenerateValues(10, 25, 1), 1, 20).SetPathExpression("metric*")},
+				{Metric: "metric*", From: 20, Until: 25}: {types.MakeMetricData("metric1", th.GenerateValues(10, 25, 1), 1, 20).SetPathExpression("metric*")},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,10)`,
 				[]float64{3, 3, 4, 4, math.NaN()}, 1, 20).SetTag("movingAverage", "10").
@@ -53,7 +53,7 @@ func TestMovingRefetch(t *testing.T) {
 		{
 			Target: "movingAverage(metric1,10)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 20, 25}: {types.MakeMetricData("metric1", th.GenerateValues(10, 25, 1), 1, 20).SetPathExpression("metric1")},
+				{Metric: "metric1", From: 20, Until: 25}: {types.MakeMetricData("metric1", th.GenerateValues(10, 25, 1), 1, 20).SetPathExpression("metric1")},
 			},
 			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,10)`,
 				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 20).SetTag("movingAverage", "10").SetNameTag(`movingAverage(metric1,10)`)},

--- a/expr/functions/moving/moving_refetch/function_test.go
+++ b/expr/functions/moving/moving_refetch/function_test.go
@@ -65,7 +65,7 @@ func TestMovingRefetch(t *testing.T) {
 	for n, tt := range tests {
 		testName := tt.Target
 		t.Run(testName+"#"+strconv.Itoa(n), func(t *testing.T) {
-			eval, err := expr.NewEvaluator(nil, th.NewTestZipper(M))
+			eval, err := expr.NewEvaluator(nil, th.NewTestZipper(M), false)
 			if err == nil {
 				th.TestEvalExprWithRange(t, eval, &tt)
 			} else {

--- a/expr/functions/movingMedian/function_test.go
+++ b/expr/functions/movingMedian/function_test.go
@@ -31,7 +31,7 @@ func TestMovingMedian(t *testing.T) {
 		{
 			"movingMedian(metric1,4)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,4)", []float64{math.NaN(), math.NaN(), math.NaN(), 1, 1, 1.5, 2, 2, 3, 4, 5, 6},
 				1, 0).SetTag("movingMedian", "4").SetNameTag("movingMedian(metric1,4)")}, // StartTime = from
@@ -39,7 +39,7 @@ func TestMovingMedian(t *testing.T) {
 		{
 			"movingMedian(metric1,5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,5)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1, 2, 2, 2, 4, 4, 6, 6, 4, 2},
 				1, 0).SetTag("movingMedian", "5").SetNameTag("movingMedian(metric1,5)")}, // StartTime = from
@@ -47,7 +47,7 @@ func TestMovingMedian(t *testing.T) {
 		{
 			"movingMedian(metric1,\"1s\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -1, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2, 0}, 1, now32)},
+				{Metric: "metric1", From: -1, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2, 0}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,'1s')", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2, 0},
 				1, 0).SetTag("movingMedian", "'1s'").SetNameTag("movingMedian(metric1,'1s')")}, // StartTime = from
@@ -55,7 +55,7 @@ func TestMovingMedian(t *testing.T) {
 		{
 			"movingMedian(metric1,\"3s\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2}, 1, now32)},
+				{Metric: "metric1", From: -3, Until: 1}: {types.MakeMetricData("metric1", []float64{0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, 1, 2}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,'3s')", []float64{0, 1, 1, 1, 1, 2, 2, 2, 4, 4, 6, 6, 6, 2},
 				1, 0).SetTag("movingMedian", "'3s'").SetNameTag("movingMedian(metric1,'3s')")}, // StartTime = from
@@ -63,7 +63,7 @@ func TestMovingMedian(t *testing.T) {
 		{
 			"movingMedian(metric1,\"5s\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -5, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, now32)}, // step > windowSize
+				{Metric: "metric1", From: -5, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, now32)}, // step > windowSize
 			},
 			[]*types.MetricData{types.MakeMetricData("movingMedian(metric1,'5s')", []float64{math.NaN(), math.NaN(), math.NaN()},
 				10, now32).SetTag("movingMedian", "'5s'").SetNameTag("movingMedian(metric1,'5s')")}, // StartTime = from
@@ -88,25 +88,25 @@ func BenchmarkMovingMedian(b *testing.B) {
 		{
 			target: "movingMedian(metric1,'5s')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", -5, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 1)}, // step > windowSize
+				{Metric: "metric1", From: -5, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 10, 1)}, // step > windowSize
 			},
 		},
 		{
 			target: "movingMedian(metric1,4)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingMedian(metric1,2)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 		{
 			target: "movingMedian(metric1,600)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", compare.GenerateMetrics(1024, 1.0, 9.0, 1.0), 1, 1)},
 			},
 		},
 	}

--- a/expr/functions/nPercentile/function_test.go
+++ b/expr/functions/nPercentile/function_test.go
@@ -29,7 +29,7 @@ func TestNPercentile(t *testing.T) {
 		{
 			`nPercentile(metric1,50)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 10, 14, 20, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 10, 14, 20, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("nPercentile(metric1,50)", []float64{8, 8, 8, 8, 8, 8, 8}, 1, now32).SetTag("nPercentile", "50")},
 		},

--- a/expr/functions/nonNegativeDerivative/function_test.go
+++ b/expr/functions/nonNegativeDerivative/function_test.go
@@ -29,35 +29,35 @@ func TestNonNegativeDerivative(t *testing.T) {
 		{
 			"nonNegativeDerivative(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 10, 14, 20}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 10, 14, 20}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("nonNegativeDerivative(metric1)", []float64{math.NaN(), 2, 2, 4, 4, 6}, 1, now32).SetTag("nonNegativeDerivative", "1")},
 		},
 		{
 			"nonNegativeDerivative(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 1, 4, math.NaN(), 8}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 1, 4, math.NaN(), 8}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("nonNegativeDerivative(metric1)", []float64{math.NaN(), 2, 2, math.NaN(), 3, math.NaN(), math.NaN()}, 1, now32).SetTag("nonNegativeDerivative", "1")},
 		},
 		{
 			"nonNegativeDerivative(metric1,32)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 0, 10, 1, math.NaN(), 8, 40, 37}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{2, 4, 0, 10, 1, math.NaN(), 8, 40, 37}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("nonNegativeDerivative(metric1,32)", []float64{math.NaN(), 2, 29, 10, 24, math.NaN(), math.NaN(), 32, math.NaN()}, 1, now32).SetTag("nonNegativeDerivative", "1")},
 		},
 		{
 			"nonNegativeDerivative(metric1,minValue=1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 2, 10, 1, math.NaN(), 8, 40, 37}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{2, 4, 2, 10, 1, math.NaN(), 8, 40, 37}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("nonNegativeDerivative(metric1,minValue=1)", []float64{math.NaN(), 2, 1, 8, 0, math.NaN(), math.NaN(), 32, 36}, 1, now32).SetTag("nonNegativeDerivative", "1")},
 		},
 		{
 			"nonNegativeDerivative(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("nonNegativeDerivative(metric1)", []float64{}, 1, now32).SetTag("nonNegativeDerivative", "1")},
 		},

--- a/expr/functions/offset/function_test.go
+++ b/expr/functions/offset/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"offset(metric1,10)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("offset(metric1,10)",
 				[]float64{103, 104, 105, math.NaN(), 107, 108, 109, 110, 111}, 1, now32).SetTag("offset", "10")},
@@ -37,7 +37,7 @@ func TestFunction(t *testing.T) {
 		{
 			"offset(metric1,'10')", // Verify string input can be parsed into int or float
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("offset(metric1,10)",
 				[]float64{103, 104, 105, math.NaN(), 107, 108, 109, 110, 111}, 1, now32).SetTag("offset", "10")},
@@ -45,7 +45,7 @@ func TestFunction(t *testing.T) {
 		{
 			"add(metric*,-10)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32),
 					types.MakeMetricData("metric2", []float64{193, 194, 195, math.NaN(), 197, 198, 199, 200, 201}, 1, now32),
 				},
@@ -58,7 +58,7 @@ func TestFunction(t *testing.T) {
 		{
 			"add(metric*,'-10')", // Verify string input can be parsed into int or float
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32),
 					types.MakeMetricData("metric2", []float64{193, 194, 195, math.NaN(), 197, 198, 199, 200, 201}, 1, now32),
 				},

--- a/expr/functions/offsetToZero/function_test.go
+++ b/expr/functions/offsetToZero/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"offsetToZero(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("offsetToZero(metric1)",
 				[]float64{0, 1, 2, math.NaN(), 4, 5, 6, 7, 8}, 1, now32).SetTag("offsetToZero", "93").SetNameTag("offsetToZero(metric1)")},

--- a/expr/functions/pearson/function_test.go
+++ b/expr/functions/pearson/function_test.go
@@ -29,8 +29,8 @@ func TestFunction(t *testing.T) {
 		{
 			"pearson(metric1,metric2,6)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{43, 21, 25, 42, 57, 59}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{99, 65, 79, 75, 87, 81}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{43, 21, 25, 42, 57, 59}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{99, 65, 79, 75, 87, 81}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("pearson(metric1,metric2,6)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0.5298089018901744}, 1, 0)}, // StartTime = from
 		},

--- a/expr/functions/pearsonClosest/function_test.go
+++ b/expr/functions/pearsonClosest/function_test.go
@@ -29,10 +29,10 @@ func TestFunction(t *testing.T) {
 		{
 			"pearsonClosest(metric1,metric2,1,direction=\"abs\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricX", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 				},
-				{"metric2", 0, 1}: {
+				{Metric: "metric2", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, math.NaN(), 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
@@ -60,14 +60,14 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"pearsonClosest(metricC,metric*,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 					types.MakeMetricData("metricD", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 					types.MakeMetricData("metricE", []float64{4, 7, 7, 7, 7, 1}, 1, now32),
 				},
-				{"metricC", 0, 1}: {
+				{Metric: "metricC", From: 0, Until: 1}: {
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 				},
 			},
@@ -80,14 +80,14 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"pearsonClosest(metricC,metric*,3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 					types.MakeMetricData("metricD", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 					types.MakeMetricData("metricE", []float64{4, 7, 7, 7, 7, 1}, 1, now32),
 				},
-				{"metricC", 0, 1}: {
+				{Metric: "metricC", From: 0, Until: 1}: {
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 				},
 			},

--- a/expr/functions/perSecond/function_test.go
+++ b/expr/functions/perSecond/function_test.go
@@ -29,28 +29,28 @@ func TestPerSecond(t *testing.T) {
 		{
 			"perSecond(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{27, 19, math.NaN(), 10, 1, 100, 1.5, 10.20}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{27, 19, math.NaN(), 10, 1, 100, 1.5, 10.20}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("perSecond(metric1)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 99, math.NaN(), 8.7}, 1, now32).SetTag("perSecond", "1")},
 		},
 		{
 			"perSecond(metric1,32)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 1, 2, 3, 4, 30, 0, 32, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 1, 2, 3, 4, 30, 0, 32, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("perSecond(metric1,32)", []float64{math.NaN(), math.NaN(), 1, 1, 1, 26, 3, 32, math.NaN()}, 1, now32).SetTag("perSecond", "1")},
 		},
 		{
 			"perSecond(metric1,minValue=1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 1, 2, 3, 4, 30, 3, 32, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 1, 2, 3, 4, 30, 3, 32, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("perSecond(metric1,minValue=1)", []float64{math.NaN(), math.NaN(), 1, 1, 1, 26, 2, 29, math.NaN()}, 1, now32).SetTag("perSecond", "1")},
 		},
 		{
 			"perSecond(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("perSecond(metric1)", []float64{}, 1, now32).SetTag("perSecond", "1")},
 		},

--- a/expr/functions/percentileOfSeries/function_test.go
+++ b/expr/functions/percentileOfSeries/function_test.go
@@ -32,21 +32,21 @@ func TestPercentileOfSeries(t *testing.T) {
 		{
 			`percentileOfSeries(metric1.empty,4)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.empty", 0, 1}: {},
+				{Metric: "metric1.empty", From: 0, Until: 1}: {},
 			},
 			[]*types.MetricData{},
 		},
 		{
 			`percentileOfSeries(metric1,4)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("percentileOfSeries(metric1,4)", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, math.NaN()}, 1, now32)},
 		},
 		{
 			`percentileOfSeries(metric1.foo.*.*,50)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15, math.NaN()}, 1, now32),
@@ -58,7 +58,7 @@ func TestPercentileOfSeries(t *testing.T) {
 		{
 			`percentileOfSeries(metric1.foo.*.*,50,interpolate=true)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15, math.NaN()}, 1, now32),
@@ -70,7 +70,7 @@ func TestPercentileOfSeries(t *testing.T) {
 		{
 			`percentileOfSeries(metric1.foo.*.*,95,false)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.*.*", 0, 1}: {
+				{Metric: "metric1.foo.*.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar1.qux", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar2.qux", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32),
 					types.MakeMetricData("metric1.foo.bar3.qux", []float64{0, 0, 0, 100500, 100501, 1005002}, 1, now32),
@@ -84,7 +84,7 @@ func TestPercentileOfSeries(t *testing.T) {
 		{
 			`percentileOfSeries(seriesByTag('tag2=value*', 'name=metric'),95,false)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+				{Metric: "seriesByTag('tag2=value*', 'name=metric')", From: 0, Until: 1}: {
 					types.MakeMetricData("metric;tag1=value1;tag2=value21;tag3=value3", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric;tag2=value21", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32),
 					types.MakeMetricData("metric;tag1=value1;tag2=value21", []float64{0, 0, 0, 100500, 100501, 1005002}, 1, now32),
@@ -116,7 +116,7 @@ func TestPercentileOfSeriesExtractSeriesByTag(t *testing.T) {
 		{
 			`percentileOfSeries(seriesByTag('tag2=value*', 'name=metric'),95,false)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('tag2=value*', 'name=metric')", 0, 1}: {
+				{Metric: "seriesByTag('tag2=value*', 'name=metric')", From: 0, Until: 1}: {
 					types.MakeMetricData("metric;tag1=value1;tag2=value21;tag3=value3", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric;tag2=value22", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32),
 					types.MakeMetricData("metric;tag1=value1;tag2=value23", []float64{0, 0, 0, 100500, 100501, 1005002}, 1, now32),

--- a/expr/functions/polyfit/function_test.go
+++ b/expr/functions/polyfit/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"polyfit(metric1,3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 				},
@@ -42,7 +42,7 @@ func TestFunction(t *testing.T) {
 		{
 			"polyfit(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{7.79, 7.7, 7.92, 5.25, 6.24, 7.25, 7.15, 8.56, 7.82, 8.52}, 1, now32),
 				},
@@ -56,7 +56,7 @@ func TestFunction(t *testing.T) {
 		{
 			"polyfit(metric1,2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{7.79, 7.7, 7.92, 5.25, 6.24, math.NaN(), 7.15, 8.56, 7.82, 8.52}, 1, now32),
 				},
@@ -70,7 +70,7 @@ func TestFunction(t *testing.T) {
 		{
 			"polyfit(metric1,3,'5sec')",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1",
 						[]float64{7.79, 7.7, 7.92, 5.25, 6.24, 7.25, 7.15, 8.56, 7.82, 8.52}, 1, now32),
 				},

--- a/expr/functions/pow/function_test.go
+++ b/expr/functions/pow/function_test.go
@@ -29,14 +29,14 @@ func TestFunction(t *testing.T) {
 		{
 			"pow(metric1,3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{5, 1, math.NaN(), 0, 12, 125, 10.4, 1.1}, 60, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{5, 1, math.NaN(), 0, 12, 125, 10.4, 1.1}, 60, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("pow(metric1,3)", []float64{125, 1, math.NaN(), 0, 1728, 1953125, 1124.864, 1.331}, 60, now32).SetTag("pow", "3")},
 		},
 		{
 			"pow(metric1,0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 60, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 60, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("pow(metric1,0)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 60, now32).SetTag("pow", "0")},
 		},

--- a/expr/functions/powSeries/function_test.go
+++ b/expr/functions/powSeries/function_test.go
@@ -29,8 +29,8 @@ var (
 		{
 			"powSeries(collectd.test-db1.load.value, collectd.test-db2.load.value)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"collectd.test-db1.load.value", 0, 1}: {types.MakeMetricData("collectd.test-db1.load.value", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 312.1}, 1, now)},
-				{"collectd.test-db2.load.value", 0, 1}: {types.MakeMetricData("collectd.test-db1.load.value", []float64{1, 3, 5, 7, math.NaN(), 6, 4, 8, 0, 10, 234.2}, 1, now)},
+				{Metric: "collectd.test-db1.load.value", From: 0, Until: 1}: {types.MakeMetricData("collectd.test-db1.load.value", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 312.1}, 1, now)},
+				{Metric: "collectd.test-db2.load.value", From: 0, Until: 1}: {types.MakeMetricData("collectd.test-db1.load.value", []float64{1, 3, 5, 7, math.NaN(), 6, 4, 8, 0, 10, 234.2}, 1, now)},
 			},
 			[]*types.MetricData{types.MakeMetricData("powSeries(collectd.test-db1.load.value, collectd.test-db2.load.value)",
 				[]float64{1.0, 8.0, 243.0, 16384.0, math.NaN(), 46656.0, 2401.0, 16777216.0, 1.0, 0.0, math.NaN()}, 1, now).SetNameTag("powSeries(collectd.test-db1.load.value, collectd.test-db2.load.value)")},
@@ -38,8 +38,8 @@ var (
 		{
 			"powSeries(collectd.test-db3.load.value, collectd.test-db4.load.value)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"collectd.test-db3.load.value", 0, 1}: {types.MakeMetricData("collectd.test-db3.load.value", []float64{1, 2, 666}, 1, now)},
-				{"collectd.test-db4.load.value", 0, 1}: {types.MakeMetricData("collectd.test-db4.load.value", []float64{1, 2}, 1, now)},
+				{Metric: "collectd.test-db3.load.value", From: 0, Until: 1}: {types.MakeMetricData("collectd.test-db3.load.value", []float64{1, 2, 666}, 1, now)},
+				{Metric: "collectd.test-db4.load.value", From: 0, Until: 1}: {types.MakeMetricData("collectd.test-db4.load.value", []float64{1, 2}, 1, now)},
 			},
 			[]*types.MetricData{types.MakeMetricData("powSeries(collectd.test-db3.load.value, collectd.test-db4.load.value)",
 				[]float64{1.0, 4.0, math.NaN()}, 1, now).SetNameTag("powSeries(collectd.test-db3.load.value, collectd.test-db4.load.value)")},
@@ -47,8 +47,8 @@ var (
 		{
 			"powSeries(collectd.test-db5.load.value, collectd.test-db6.load.value)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"collectd.test-db5.load.value", 0, 1}: {types.MakeMetricData("collectd.test-db5.load.value", []float64{1, 2}, 1, now)},
-				{"collectd.test-db6.load.value", 0, 1}: {types.MakeMetricData("collectd.test-db6.load.value", []float64{1, 2, 666}, 1, now)},
+				{Metric: "collectd.test-db5.load.value", From: 0, Until: 1}: {types.MakeMetricData("collectd.test-db5.load.value", []float64{1, 2}, 1, now)},
+				{Metric: "collectd.test-db6.load.value", From: 0, Until: 1}: {types.MakeMetricData("collectd.test-db6.load.value", []float64{1, 2, 666}, 1, now)},
 			},
 			[]*types.MetricData{types.MakeMetricData("powSeries(collectd.test-db5.load.value, collectd.test-db6.load.value)",
 				[]float64{1.0, 4.0, math.NaN()}, 1, now).SetNameTag("powSeries(collectd.test-db5.load.value, collectd.test-db6.load.value)")},

--- a/expr/functions/rangeOfSeries/function_test.go
+++ b/expr/functions/rangeOfSeries/function_test.go
@@ -29,14 +29,14 @@ func TestRangeOfSeries(t *testing.T) {
 		{
 			"rangeOfSeries(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {},
+				{Metric: "metric*", From: 0, Until: 1}: {},
 			},
 			[]*types.MetricData{},
 		},
 		{
 			"rangeOfSeries(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), 3, 4, 12, -10}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), math.NaN(), 15, 0, 6, 10}, 1, now32),
 					types.MakeMetricData("metric3", []float64{1, 2, math.NaN(), 4, 5, 6, 7}, 1, now32),

--- a/expr/functions/reduce/function.go
+++ b/expr/functions/reduce/function.go
@@ -80,7 +80,7 @@ func (f *reduce) Do(ctx context.Context, eval interfaces.Evaluator, e parser.Exp
 		}
 
 		reduceGroups[aliasName][reduceNodeKey] = series
-		valueKey := parser.MetricRequest{series.Name, from, until}
+		valueKey := parser.MetricRequest{Metric: series.Name, From: from, Until: until}
 		reducedValues[valueKey] = append(reducedValues[valueKey], series)
 	}
 AliasLoop:

--- a/expr/functions/removeBelowSeries/function_test.go
+++ b/expr/functions/removeBelowSeries/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeBelowValue(metric1, 0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("removeBelowValue(metric1, 0)",
 				[]float64{1, 2, math.NaN(), 7, 8, 20, 30, math.NaN()}, 1, now32).SetTag("removeBelowSeries", "0")},
@@ -37,7 +37,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeAboveValue(metric1, 10)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("removeAboveValue(metric1, 10)",
 				[]float64{1, 2, -1, 7, 8, math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("removeBelowSeries", "10")},
@@ -45,7 +45,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeBelowPercentile(metric1, 50)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("removeBelowPercentile(metric1, 50)",
 				[]float64{math.NaN(), math.NaN(), math.NaN(), 7, 8, 20, 30, math.NaN()}, 1, now32).SetTag("removeBelowSeries", "7")},
@@ -53,7 +53,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeAbovePercentile(metric1, 50)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("removeAbovePercentile(metric1, 50)",
 				[]float64{1, 2, -1, 7, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("removeBelowSeries", "7")},

--- a/expr/functions/removeBetweenPercentile/function_test.go
+++ b/expr/functions/removeBetweenPercentile/function_test.go
@@ -28,7 +28,7 @@ func TestFunction(t *testing.T) {
 		{
 			`removeBetweenPercentile(metric[1234], 30)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{7, 7, 7, 7, 7, 7}, 1, now32),
 					types.MakeMetricData("metric2", []float64{5, 5, 5, 5, 5, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{10, 10, 10, 10, 10, 10}, 1, now32),

--- a/expr/functions/removeEmptySeries/function_test.go
+++ b/expr/functions/removeEmptySeries/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeEmptySeries(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric2", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric3", []float64{0, 0, 0, 0, 0, 0, 0, 0}, 1, now32),
@@ -43,7 +43,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeZeroSeries(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric2", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric3", []float64{0, 0, 0, 0, 0, 0, 0, 0}, 1, now32),
@@ -56,7 +56,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeEmptySeries(metric*,0.00001)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric2", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric3", []float64{0, 0, 0, 0, 0, 0, 0, 0}, 1, now32),
@@ -70,7 +70,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeZeroSeries(metric*,0.000001)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric2", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric3", []float64{0, 0, 0, 0, 0, 0, 0, 0}, 1, now32),
@@ -83,7 +83,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeEmptySeries(metric*,0.8)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric2", []float64{1, 2, -1, 7, 8, 20, 23, 12, math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric3", []float64{1, 2, -1, 7, 8, 20, 23, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
@@ -100,7 +100,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeZeroSeries(metric*,0.8)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, math.NaN()}, 1, now32),
 					types.MakeMetricData("metric2", []float64{1, 2, -1, 7, 8, 20, 23, 12, math.NaN(), math.NaN()}, 1, now32),
 					types.MakeMetricData("metric3", []float64{1, 2, -1, 7, 8, 20, 23, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
@@ -116,7 +116,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeEmptySeries(metric*,1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, -2.3}, 1, now32),
 					types.MakeMetricData("metric2", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, math.NaN()}, 1, now32),
 				},
@@ -128,7 +128,7 @@ func TestFunction(t *testing.T) {
 		{
 			"removeZeroSeries(metric*,1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, -2.3}, 1, now32),
 					types.MakeMetricData("metric2", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, 0}, 1, now32),
 				},

--- a/expr/functions/round/function_test.go
+++ b/expr/functions/round/function_test.go
@@ -29,42 +29,42 @@ func TestRound(t *testing.T) {
 		{
 			"round(metric1, 3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 245}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 245}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("round(metric1,3)", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 245}, 1, now32).SetTag("round", "3")},
 		},
 		{
 			"round(metric1, 1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 245}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 245}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("round(metric1,1)", []float64{0.5, 2.3, math.NaN(), 91.0, -524.8, 245}, 1, now32).SetTag("round", "1")},
 		},
 		{
 			"round(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0.5, 1.5, 2.298, math.NaN(), 91.019, -524.82, 245}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0.5, 1.5, 2.298, math.NaN(), 91.019, -524.82, 245}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("round(metric1)", []float64{0, 2, 2, math.NaN(), 91, -525, 245}, 1, now32).SetTag("round", "0")},
 		},
 		{
 			"round(metric1, -2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 275}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 275}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("round(metric1,-2)", []float64{0, 0, math.NaN(), 100, -500, 300}, 1, now32).SetTag("round", "-2")},
 		},
 		{
 			"round(metric1, precision=-2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 275}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 275}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("round(metric1,-2)", []float64{0, 0, math.NaN(), 100, -500, 300}, 1, now32).SetTag("round", "-2")},
 		},
 		{
 			"round(metric1, -10)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 245}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0.5, 2.298, math.NaN(), 91.019, -524.82, 245}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("round(metric1,-10)", []float64{0, 0, math.NaN(), 0, 0, 0}, 1, now32).SetTag("round", "-10")},
 		},

--- a/expr/functions/scale/function_test.go
+++ b/expr/functions/scale/function_test.go
@@ -30,7 +30,7 @@ func TestFunction(t *testing.T) {
 		{
 			"scale(metric1,2.5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 4, 5}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("scale(metric1,2.5)", []float64{2.5, 5.0, math.NaN(), 10.0, 12.5}, 1, now32).SetTag("scale", "2.5")},
 		},

--- a/expr/functions/scaleToSeconds/function_test.go
+++ b/expr/functions/scaleToSeconds/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"scaleToSeconds(metric1,5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{60, 120, math.NaN(), 120, 120}, 60, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{60, 120, math.NaN(), 120, 120}, 60, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("scaleToSeconds(metric1,5)", []float64{5, 10, math.NaN(), 10, 10}, 60, now32).SetTag("scaleToSeconds", "5")},
 		},

--- a/expr/functions/seriesList/function_test.go
+++ b/expr/functions/seriesList/function_test.go
@@ -29,8 +29,8 @@ func TestFunction(t *testing.T) {
 		{
 			"diffSeriesLists(metric1,metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("diffSeries(metric1,metric2)",
 				[]float64{-1, math.NaN(), math.NaN(), math.NaN(), 4, 6}, 1, now32)},
@@ -38,8 +38,8 @@ func TestFunction(t *testing.T) {
 		{
 			"sumSeriesLists(metric1,metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
-				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
+				{Metric: "metric2", From: 0, Until: 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(metric1,metric2)",
 				[]float64{3, math.NaN(), math.NaN(), math.NaN(), 4, 18}, 1, now32)},
@@ -62,7 +62,7 @@ func TestSeriesListMultiReturn(t *testing.T) {
 		{
 			"divideSeriesLists(metric[12],metric[12])",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[12]", 0, 1}: {
+				{Metric: "metric[12]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
 				},
@@ -76,7 +76,7 @@ func TestSeriesListMultiReturn(t *testing.T) {
 		{
 			"multiplySeriesLists(metric[12],metric[12])",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[12]", 0, 1}: {
+				{Metric: "metric[12]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
 				},
@@ -90,7 +90,7 @@ func TestSeriesListMultiReturn(t *testing.T) {
 		{
 			"diffSeriesLists(metric[12],metric[12])",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[12]", 0, 1}: {
+				{Metric: "metric[12]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
 				},
@@ -104,11 +104,11 @@ func TestSeriesListMultiReturn(t *testing.T) {
 		{
 			"diffSeriesLists(metric[12],metric[134])",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[12]", 0, 1}: {
+				{Metric: "metric[12]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
 				},
-				{"metric[134]", 0, 1}: {
+				{Metric: "metric[134]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric3", []float64{2, 4, 6, 8, 10}, 1, now32),
 					types.MakeMetricData("metric4", []float64{2, 4, 6, 8, 10}, 1, now32),
@@ -122,7 +122,7 @@ func TestSeriesListMultiReturn(t *testing.T) {
 		{
 			"sumSeriesLists(metric[12],metric[12])",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[12]", 0, 1}: {
+				{Metric: "metric[12]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
 				},

--- a/expr/functions/setXFilesFactor/function_test.go
+++ b/expr/functions/setXFilesFactor/function_test.go
@@ -28,7 +28,7 @@ func TestSetXFilesFactor(t *testing.T) {
 		{
 			"setXFilesFactor(metric1,0.6)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now64)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now64)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1",
 				[]float64{1, 2, 3, 4, 5}, 1, now64).SetXFilesFactor(0.6).SetTag("xFilesFactor", "0.6")},

--- a/expr/functions/sigmoid/function_test.go
+++ b/expr/functions/sigmoid/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"sigmoid(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{5, 1, math.NaN(), 0, 12, 125, 10.4, 1.1}, 60, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{5, 1, math.NaN(), 0, 12, 125, 10.4, 1.1}, 60, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("sigmoid(metric1)",
 				[]float64{0.9933071490757153, 0.7310585786300049, math.NaN(), 0.5, 0.9999938558253978, 1, 0.9999695684430994, 0.7502601055951177}, 60, now32).SetTag("sigmoid", "sigmoid")},

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -27,7 +27,7 @@ func TestSummarizeEmptyData(t *testing.T) {
 		{
 			"smartSummarize(metric1,'1hour','sum','1y')",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"foo.bar", 0, 1}: {},
+				{Metric: "foo.bar", From: 0, Until: 1}: {},
 			},
 			[]*types.MetricData{},
 		},
@@ -48,7 +48,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','sum','1y')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{6478200, 19438200, 32398200, 45358200},
 			From:  0,
@@ -61,7 +61,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','sum','y')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{6478200, 19438200, 32398200, 45358200},
 			Name:  "smartSummarize(metric1,'1hour','sum','y')",
@@ -74,7 +74,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','sum','month')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{6478200, 19438200, 32398200, 45358200},
 			Name:  "smartSummarize(metric1,'1hour','sum','month')",
@@ -87,7 +87,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','sum','1month')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{6478200, 19438200, 32398200, 45358200},
 			Name:  "smartSummarize(metric1,'1hour','sum','1month')",
@@ -100,7 +100,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','sum','minute')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{1770, 5370, 8970, 12570},
 			From:  0,
@@ -113,7 +113,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','sum','1minute')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{1770, 5370, 8970, 12570},
 			Name:  "smartSummarize(metric1,'1minute','sum','1minute')",
@@ -126,7 +126,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','avg','minute')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{29.5, 89.5, 149.5, 209.5},
 			From:  0,
@@ -139,7 +139,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','last','minute')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{59, 119, 179, 239},
 			From:  0,
@@ -152,7 +152,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1d','sum','days')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
+				{Metric: "metric1", From: 0, Until: 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
 			},
 			Want:  []float64{62164800},
 			From:  0,
@@ -165,7 +165,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','sum','seconds')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{1770, 5370, 8970, 12570},
 			From:  0,
@@ -178,7 +178,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','max','hours')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{3599, 7199, 10799, 14399},
 			From:  0,
@@ -191,7 +191,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'6m','sum', 'minutes')", // Test having a smaller interval than the data's step
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 1410345000, 1410345000 + 3*600}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: 1410345000, Until: 1410345000 + 3*600}: {types.MakeMetricData("metric1", []float64{
 					2, 4, 6}, 600, 1410345000)},
 			},
 			Want:  []float64{2, 4, math.NaN(), 6, math.NaN()},
@@ -205,7 +205,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "smartSummarize(metric2,'2minute','sum')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric2", 0, 300}: {types.MakeMetricData("metric2", []float64{1, 2, 3, 4}, 60, 0)},
+				{Metric: "metric2", From: 0, Until: 300}: {types.MakeMetricData("metric2", []float64{1, 2, 3, 4}, 60, 0)},
 			},
 			Want:  []float64{3, 7},
 			From:  0,
@@ -220,7 +220,7 @@ func TestEvalSummarize(t *testing.T) {
 			// if it is smaller than the final bucket's upper bound
 			Target: "smartSummarize(metric1,'5s','sum')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 243}: {types.MakeMetricData("metric1", generateValues(0, 243, 3), 3, 0)},
+				{Metric: "metric1", From: 0, Until: 243}: {types.MakeMetricData("metric1", generateValues(0, 243, 3), 3, 0)},
 			},
 			Want:  []float64{3, 15, 12, 33, 45, 27, 63, 75, 42, 93, 105, 57, 123, 135, 72, 153, 165, 87, 183, 195, 102, 213, 225, 117, 243, 255, 132, 273, 285, 147, 303, 315, 162, 333, 345, 177, 363, 375, 192, 393, 405, 207, 423, 435, 222, 453, 465, 237, 240},
 			Name:  "smartSummarize(metric1,'5s','sum')",
@@ -243,7 +243,7 @@ func TestSmartSummarizeAlignTo1Year(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','sum','1y')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{6478200, 19438200, 32398200, 45358200},
 			From:  1800,
@@ -256,7 +256,7 @@ func TestSmartSummarizeAlignTo1Year(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','avg','1y')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{1799.5, 5399.5, 8999.5, 12599.5},
 			From:  1800,
@@ -269,7 +269,7 @@ func TestSmartSummarizeAlignTo1Year(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','last','1y')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{3599, 7199, 10799, 14399},
 			From:  1800,
@@ -282,7 +282,7 @@ func TestSmartSummarizeAlignTo1Year(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','max','1y')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{3599, 7199, 10799, 14399},
 			From:  1800,
@@ -295,7 +295,7 @@ func TestSmartSummarizeAlignTo1Year(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','min','1y')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{0, 3600, 7200, 10800},
 			From:  1800,
@@ -318,7 +318,7 @@ func TestSmartSummarizeAlignToMonths(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','sum','months')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{6478200, 19438200, 32398200, 45358200},
 			From:  1800,
@@ -331,7 +331,7 @@ func TestSmartSummarizeAlignToMonths(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','avg','months')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{1799.5, 5399.5, 8999.5, 12599.5},
 			Name:  "smartSummarize(metric1,'1hour','avg','months')",
@@ -344,7 +344,7 @@ func TestSmartSummarizeAlignToMonths(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','last','months')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{3599, 7199, 10799, 14399},
 			From:  1800,
@@ -357,7 +357,7 @@ func TestSmartSummarizeAlignToMonths(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','max','months')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{3599, 7199, 10799, 14399},
 			From:  1800,
@@ -370,7 +370,7 @@ func TestSmartSummarizeAlignToMonths(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','min','months')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{0, 3600, 7200, 10800},
 			From:  1800,
@@ -393,7 +393,7 @@ func TestSmartSummarizeAlignToWeeksThursday(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'4hours','sum','weeks4')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{103672800},
 			From:  174600,
@@ -406,7 +406,7 @@ func TestSmartSummarizeAlignToWeeksThursday(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'4hours','avg','weeks4')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{7199.5},
 			From:  174600,
@@ -419,7 +419,7 @@ func TestSmartSummarizeAlignToWeeksThursday(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'4hours','last','weeks4')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{14399},
 			From:  174600,
@@ -432,7 +432,7 @@ func TestSmartSummarizeAlignToWeeksThursday(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'4hours','max','weeks4')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{14399},
 			From:  174600,
@@ -445,7 +445,7 @@ func TestSmartSummarizeAlignToWeeksThursday(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'4hours','min','weeks4')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{0},
 			From:  174600,
@@ -468,7 +468,7 @@ func TestSmartSummarizeAlignToDays(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1day','sum','days')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
+				{Metric: "metric1", From: 0, Until: 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
 			},
 			Want:  []float64{62164800},
 			From:  86399,
@@ -481,7 +481,7 @@ func TestSmartSummarizeAlignToDays(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1day','avg','days')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
+				{Metric: "metric1", From: 0, Until: 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
 			},
 			Want:  []float64{43170.0},
 			From:  86399,
@@ -494,7 +494,7 @@ func TestSmartSummarizeAlignToDays(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1day','last','days')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
+				{Metric: "metric1", From: 0, Until: 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
 			},
 			Want:  []float64{86340},
 			From:  86399,
@@ -507,7 +507,7 @@ func TestSmartSummarizeAlignToDays(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1day','max','days')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
+				{Metric: "metric1", From: 0, Until: 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
 			},
 			Want:  []float64{86340},
 			From:  86399,
@@ -520,7 +520,7 @@ func TestSmartSummarizeAlignToDays(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1day','min','days')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
+				{Metric: "metric1", From: 0, Until: 86400}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
 			},
 			Want:  []float64{0},
 			From:  86399,
@@ -543,7 +543,7 @@ func TestSmartSummarizeAlignToHours(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','sum','hours')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{6478200, 19438200, 32398200, 45358200},
 			From:  1800,
@@ -556,7 +556,7 @@ func TestSmartSummarizeAlignToHours(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','avg','hours')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{1799.5, 5399.5, 8999.5, 12599.5},
 			From:  1800,
@@ -569,7 +569,7 @@ func TestSmartSummarizeAlignToHours(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','last','hours')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{3599, 7199, 10799, 14399},
 			From:  1800,
@@ -582,7 +582,7 @@ func TestSmartSummarizeAlignToHours(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','max','hours')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{3599, 7199, 10799, 14399},
 			From:  1800,
@@ -595,7 +595,7 @@ func TestSmartSummarizeAlignToHours(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1hour','min','hours')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 14400}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
 			},
 			Want:  []float64{0, 3600, 7200, 10800},
 			From:  1800,
@@ -618,7 +618,7 @@ func TestSmartSummarizeAlignToMinutes(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','sum','minutes')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{1770, 5370, 8970, 12570},
 			From:  59,
@@ -631,7 +631,7 @@ func TestSmartSummarizeAlignToMinutes(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','avg','minutes')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{29.5, 89.5, 149.5, 209.5},
 			From:  59,
@@ -644,7 +644,7 @@ func TestSmartSummarizeAlignToMinutes(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','last','minutes')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{59, 119, 179, 239},
 			From:  59,
@@ -657,7 +657,7 @@ func TestSmartSummarizeAlignToMinutes(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','max','minutes')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{59, 119, 179, 239},
 			From:  59,
@@ -670,7 +670,7 @@ func TestSmartSummarizeAlignToMinutes(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','min','minutes')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{0, 60, 120, 180},
 			From:  59,
@@ -693,7 +693,7 @@ func TestSmartSummarizeAlignToSeconds(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','sum','seconds')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{1770, 5370, 8970, 12570},
 			From:  0,
@@ -706,7 +706,7 @@ func TestSmartSummarizeAlignToSeconds(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','avg','seconds')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{29.5, 89.5, 149.5, 209.5},
 			From:  0,
@@ -719,7 +719,7 @@ func TestSmartSummarizeAlignToSeconds(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','last','seconds')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{59, 119, 179, 239},
 			From:  0,
@@ -732,7 +732,7 @@ func TestSmartSummarizeAlignToSeconds(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','max','seconds')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{59, 119, 179, 239},
 			From:  0,
@@ -745,7 +745,7 @@ func TestSmartSummarizeAlignToSeconds(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'1minute','min','seconds')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{0, 60, 120, 180},
 			From:  0,
@@ -768,7 +768,7 @@ func TestFunctionUseNameWithWildcards(t *testing.T) {
 		{
 			"smartSummarize(metric1.*,'1minute','last')",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.*", 0, 1}: {
+				{Metric: "metric1.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo", generateValues(0, 240, 1), 1, 0),
 					types.MakeMetricData("metric1.bar", generateValues(0, 240, 1), 1, 0),
 				},
@@ -797,7 +797,7 @@ func TestSmartSummarizeErrors(t *testing.T) {
 		{
 			Target: "smartSummarize(metric1,'-1minute','sum','minute')", // Test to make sure error occurs when a negative interval is used
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Error: parser.ErrInvalidInterval,
 		},

--- a/expr/functions/sortBy/function_test.go
+++ b/expr/functions/sortBy/function_test.go
@@ -30,7 +30,7 @@ func TestFunction(t *testing.T) {
 		{
 			"sortByTotal(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{5, 5, 5, 5, 5, 5}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 4, 4}, 1, now32),
@@ -45,7 +45,7 @@ func TestFunction(t *testing.T) {
 		{
 			"sortByMaxima(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{5, 5, 5, 5, 5, 5}, 1, now32),
 					types.MakeMetricData("metricC", []float64{2, 2, 10, 5, 2, 2}, 1, now32),
@@ -60,7 +60,7 @@ func TestFunction(t *testing.T) {
 		{
 			"sortByMinima(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
@@ -75,7 +75,7 @@ func TestFunction(t *testing.T) {
 		{
 			"sortBy(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{1, 2, 3, 4, 5, 6}, 1, now32),
@@ -90,7 +90,7 @@ func TestFunction(t *testing.T) {
 		{
 			"sortBy(metric*, 'median')",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 					types.MakeMetricData("metricC", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
@@ -106,7 +106,7 @@ func TestFunction(t *testing.T) {
 		{
 			"sortBy(metric*, 'max', true)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
@@ -137,7 +137,7 @@ func TestErrorInvalidConsolidationFunction(t *testing.T) {
 		{
 			"sortBy(metric*, 'test')",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 					types.MakeMetricData("metricC", []float64{3, 4, 5, 6, 7, 8}, 1, now32),

--- a/expr/functions/sortByName/function_test.go
+++ b/expr/functions/sortByName/function_test.go
@@ -29,7 +29,7 @@ func TestSortByName(t *testing.T) {
 		{
 			"sortByName(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricX", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricA", []float64{0, 1, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{0, 0, 2, 0, 0, 0}, 1, now32),
@@ -46,7 +46,7 @@ func TestSortByName(t *testing.T) {
 		{
 			"sortByName(metric*,natural=true)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metric12", []float64{0, 1, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metric1234567890", []float64{0, 0, 0, 5, 0, 0}, 1, now32),

--- a/expr/functions/squareRoot/function_test.go
+++ b/expr/functions/squareRoot/function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 		{
 			"squareRoot(metric1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("squareRoot(metric1)",
 				[]float64{1, 1.4142135623730951, 0, 2.6457513110645907, 2.8284271247461903, 4.47213595499958, 5.477225575051661, math.NaN()}, 1, now32).SetTag("squareRoot", "1")},

--- a/expr/functions/stdev/function_test.go
+++ b/expr/functions/stdev/function_test.go
@@ -29,7 +29,7 @@ func TestStdev(t *testing.T) {
 		{
 			"stdev(metric1, 2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("stdev(metric1,2)",
 				[]float64{0.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5}, 1, now32).SetTag("stdev", "2")},
@@ -37,7 +37,7 @@ func TestStdev(t *testing.T) {
 		{
 			"stdev(metric1, 2)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("stdev(metric1,2)",
 				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("stdev", "2")},

--- a/expr/functions/substr/function_test.go
+++ b/expr/functions/substr/function_test.go
@@ -44,7 +44,7 @@ func TestSubstr(t *testing.T) {
 		{
 			"substr(metric1.foo.bar.baz, 1, 3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("foo.bar",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -52,7 +52,7 @@ func TestSubstr(t *testing.T) {
 		{
 			"substr(metric1.foo.bar.baz, -3, -1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("foo.bar",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -60,7 +60,7 @@ func TestSubstr(t *testing.T) {
 		{
 			"substr(metric1.foo.bar.baz, -3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("foo.bar.baz",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -68,7 +68,7 @@ func TestSubstr(t *testing.T) {
 		{
 			"substr(metric1.foo.bar.baz, -6, -1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1.foo.bar",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -76,7 +76,7 @@ func TestSubstr(t *testing.T) {
 		{
 			"substr(metric1.foo.bar.baz,0, -1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1.foo.bar",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -84,7 +84,7 @@ func TestSubstr(t *testing.T) {
 		{
 			"substr(metric1.foo.bar.baz, 0, 10)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric1.foo.bar.baz",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -92,7 +92,7 @@ func TestSubstr(t *testing.T) {
 		{
 			"substr(metric1.foo.bar.baz, 2, 4)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("bar.baz",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -100,7 +100,7 @@ func TestSubstr(t *testing.T) {
 		{
 			"substr(metric1.foo.bar.baz, 2, 6)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("bar.baz",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
@@ -108,7 +108,7 @@ func TestSubstr(t *testing.T) {
 		{
 			"substr(metric1.foo.bar.baz, -2, -1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.foo.bar.baz", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				{Metric: "metric1.foo.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("bar",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},

--- a/expr/functions/summarize/function_test.go
+++ b/expr/functions/summarize/function_test.go
@@ -29,7 +29,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 35}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: now32, Until: now32 + 35}: {types.MakeMetricData("metric1", []float64{
 					1, 1, 1, 1, 1,
 					2, 2, 2, 2, 2,
 					3, 3, 3, 3, 3,
@@ -50,7 +50,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 50}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: now32, Until: now32 + 50}: {types.MakeMetricData("metric1", []float64{
 					1, 2, 3, 4, 5,
 				}, 10, now32)},
 			},
@@ -65,7 +65,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s','avg')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 35}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 35}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 			},
 			Want:  []float64{1, 2, 3, 4, 5, 2, math.NaN(), math.NaN()},
 			From:  now32,
@@ -78,7 +78,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s','max')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
 			},
 			Want:  []float64{1, 2, 3, 4.5, 5, math.NaN()},
 			From:  now32,
@@ -91,7 +91,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s','min')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
 			},
 			Want:  []float64{0, 1, 1.5, 2, 5, math.NaN()},
 			From:  now32,
@@ -104,7 +104,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s','last')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
 			},
 			Want:  []float64{1, 2, 3, 4.5, 5, math.NaN()},
 			From:  now32,
@@ -117,7 +117,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s','count')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 35}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 1, 1, math.NaN(), math.NaN(), 2, 2, 2, 2, 3, math.NaN(), math.NaN(), 3, 3, 4, 4, 4, math.NaN(), 4, 5, 5, math.NaN(), 5, 5, 1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 35}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), 1, 1, math.NaN(), math.NaN(), 2, 2, 2, 2, 3, math.NaN(), math.NaN(), 3, 3, 4, 4, 4, math.NaN(), 4, 5, 5, math.NaN(), 5, 5, 1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 			},
 			Want:  []float64{3, 4, 3, 4, 4, 3, math.NaN(), math.NaN()},
 			From:  now32,
@@ -130,7 +130,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s','p50')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
 			},
 			Want:  []float64{0.5, 1.5, 2, 3, 5, math.NaN()},
 			From:  now32,
@@ -143,7 +143,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s','p25')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
 			},
 			Want:  []float64{0, 1, 2, 3, 5, math.NaN()},
 			From:  now32,
@@ -156,7 +156,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s','p99.9')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
 			},
 			Want:  []float64{1, 2, 3, 4.498, 5, math.NaN()},
 			From:  now32,
@@ -169,7 +169,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'5s','p100.1')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
 			},
 			Want:  []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()},
 			From:  now32,
@@ -182,7 +182,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1s','p50')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", now32, now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
+				{Metric: "metric1", From: now32, Until: now32 + 25*1}: {types.MakeMetricData("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
 			},
 			Want:  []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5, math.NaN()},
 			From:  now32,
@@ -195,7 +195,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'10min')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", tenThirtyTwo, tenThirty + 30*60}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: tenThirtyTwo, Until: tenThirty + 30*60}: {types.MakeMetricData("metric1", []float64{
 					1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
 					3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
 					5, 5, 5, 5, 5}, 60, tenThirtyTwo)},
@@ -211,7 +211,7 @@ func TestEvalSummarize(t *testing.T) {
 		{
 			Target: "summarize(metric1,'10min','sum',true)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", tenThirtyTwo, tenThirtyTwo + 25*60}: {types.MakeMetricData("metric1", []float64{
+				{Metric: "metric1", From: tenThirtyTwo, Until: tenThirtyTwo + 25*60}: {types.MakeMetricData("metric1", []float64{
 					1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
 					3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
 					5, 5, 5, 5, 5}, 60, tenThirtyTwo)},
@@ -237,7 +237,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','sum')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{1770, 5370, 8970, 12570, math.NaN()},
 			From:  0,
@@ -250,7 +250,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','avg')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{29.5, 89.5, 149.5, 209.5, math.NaN()},
 			From:  0,
@@ -263,7 +263,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','last')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{59, 119, 179, 239, math.NaN()},
 			From:  0,
@@ -276,7 +276,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','max')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{59, 119, 179, 239, math.NaN()},
 			From:  0,
@@ -289,7 +289,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','min')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{0, 60, 120, 180, math.NaN()},
 			From:  0,
@@ -302,7 +302,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','sum',true)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{1770, 5370, 8970, 12570},
 			From:  0,
@@ -315,7 +315,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','avg',true)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{29.5, 89.5, 149.5, 209.5},
 			From:  0,
@@ -328,7 +328,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','last',true)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{59, 119, 179, 239},
 			From:  0,
@@ -341,7 +341,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','max',true)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{59, 119, 179, 239},
 			From:  0,
@@ -354,7 +354,7 @@ func TestEvalSummarize1Minute(t *testing.T) {
 		{
 			Target: "summarize(metric1,'1min','min',true)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+				{Metric: "metric1", From: 0, Until: 240}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
 			},
 			Want:  []float64{0, 60, 120, 180},
 			From:  0,

--- a/expr/functions/timeShiftByMetric/function_test.go
+++ b/expr/functions/timeShiftByMetric/function_test.go
@@ -34,12 +34,12 @@ func TestTimeShift(t *testing.T) {
 		{
 			"timeShiftByMetric(apps.*.metric, apps.mark.*, 1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"apps.*.metric", 0, 1}: {
+				parser.MetricRequest{Metric: "apps.*.metric", From: 0, Until: 1}: {
 					types.MakeMetricData("apps.1_3.metric", []float64{1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, nan, nan}, 1, now32),
 					types.MakeMetricData("apps.2.metric", []float64{nan, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, nan}, 1, now32),
 					types.MakeMetricData("apps.3.metric", []float64{nan, nan, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9}, 1, now32),
 				},
-				parser.MetricRequest{"apps.mark.*", 0, 1}: {
+				parser.MetricRequest{Metric: "apps.mark.*", From: 0, Until: 1}: {
 					// leading versions
 					types.MakeMetricData("apps.mark.1_3", []float64{nan, nan, nan, 1, nan, nan, nan, nan, nan, nan, nan}, 1, now32),
 					types.MakeMetricData("apps.mark.2_2", []float64{nan, nan, nan, nan, nan, nan, 1, nan, nan, nan, nan}, 1, now32),
@@ -65,11 +65,11 @@ func TestTimeShift(t *testing.T) {
 		{
 			"timeShiftByMetric(*.metric, apps.mark.*, 0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"*.metric", 0, 1}: {
+				parser.MetricRequest{Metric: "*.metric", From: 0, Until: 1}: {
 					types.MakeMetricData("1_1.metric", []float64{1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7}, 1, now32),
 					types.MakeMetricData("2_0.metric", []float64{2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7}, 1, now32),
 				},
-				parser.MetricRequest{"apps.mark.*", 0, 1}: {
+				parser.MetricRequest{Metric: "apps.mark.*", From: 0, Until: 1}: {
 					// leading versions
 					types.MakeMetricData("apps.mark.1_1", []float64{nan, nan, 1, nan, nan, nan, nan}, 1, now32),
 					types.MakeMetricData("apps.mark.2_0", []float64{nan, nan, nan, nan, nan, nan, 1}, 1, now32),
@@ -102,12 +102,12 @@ func TestBadMarks(t *testing.T) {
 		{
 			"timeShiftByMetric(apps.*.metric, apps.mark.*, 1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"apps.*.metric", 0, 1}: {
+				parser.MetricRequest{Metric: "apps.*.metric", From: 0, Until: 1}: {
 					types.MakeMetricData("apps.1.metric", []float64{1, 2, 3}, 1, now32),
 					types.MakeMetricData("apps.2.metric", []float64{1, 2, 3}, 1, now32),
 					types.MakeMetricData("apps.3.metric", []float64{1, 2, 3}, 1, now32),
 				},
-				parser.MetricRequest{"apps.mark.*", 0, 1}: {
+				parser.MetricRequest{Metric: "apps.mark.*", From: 0, Until: 1}: {
 					types.MakeMetricData("apps.mark.1_0", []float64{1, nan, nan}, 1, now32),
 					types.MakeMetricData("apps.mark.1_1", []float64{nan, 1, nan}, 1, now32),
 					types.MakeMetricData("apps.mark.1_2", []float64{nan, nan, 1}, 1, now32),
@@ -147,8 +147,8 @@ func TestNotEnoughSeries(t *testing.T) {
 		testCases = append(testCases, th.EvalTestItemWithError{
 			"timeShiftByMetric(apps.*.metric, apps.mark.*, 1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"apps.*.metric", 0, 1}: metricsData,
-				parser.MetricRequest{"apps.mark.*", 0, 1}:   marksData,
+				parser.MetricRequest{Metric: "apps.*.metric", From: 0, Until: 1}: metricsData,
+				parser.MetricRequest{Metric: "apps.mark.*", From: 0, Until: 1}:   marksData,
 			},
 			nil,
 			errTooFewDatasets,
@@ -170,8 +170,8 @@ func TestNotEnoughSeries(t *testing.T) {
 		testCases = append(testCases, th.EvalTestItemWithError{
 			"timeShiftByMetric(apps.*.metric, apps.mark.*, 1)",
 			map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"apps.*.metric", 0, 1}: metricsData,
-				parser.MetricRequest{"apps.mark.*", 0, 1}:   marksData,
+				parser.MetricRequest{Metric: "apps.*.metric", From: 0, Until: 1}: metricsData,
+				parser.MetricRequest{Metric: "apps.mark.*", From: 0, Until: 1}:   marksData,
 			},
 			nil,
 			errTooFewDatasets,
@@ -201,12 +201,12 @@ func BenchmarkTimeShift(b *testing.B) {
 		{
 			target: "timeShiftByMetric(apps.*.metric, apps.mark.*, 1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"apps.*.metric", 0, 1}: {
+				parser.MetricRequest{Metric: "apps.*.metric", From: 0, Until: 1}: {
 					types.MakeMetricData("apps.1_3.metric", []float64{1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, nan, nan}, 1, now32),
 					types.MakeMetricData("apps.2.metric", []float64{nan, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, nan}, 1, now32),
 					types.MakeMetricData("apps.3.metric", []float64{nan, nan, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9}, 1, now32),
 				},
-				parser.MetricRequest{"apps.mark.*", 0, 1}: {
+				parser.MetricRequest{Metric: "apps.mark.*", From: 0, Until: 1}: {
 					// leading versions
 					types.MakeMetricData("apps.mark.1_3", []float64{nan, nan, nan, 1, nan, nan, nan, nan, nan, nan, nan}, 1, now32),
 					types.MakeMetricData("apps.mark.2_2", []float64{nan, nan, nan, nan, nan, nan, 1, nan, nan, nan, nan}, 1, now32),
@@ -227,11 +227,11 @@ func BenchmarkTimeShift(b *testing.B) {
 		{
 			target: "timeShiftByMetric(*.metric, apps.mark.*, 0)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				parser.MetricRequest{"*.metric", 0, 1}: {
+				{Metric: "*.metric", From: 0, Until: 1}: {
 					types.MakeMetricData("1_1.metric", []float64{1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7}, 1, now32),
 					types.MakeMetricData("2_0.metric", []float64{2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7}, 1, now32),
 				},
-				parser.MetricRequest{"apps.mark.*", 0, 1}: {
+				{Metric: "apps.mark.*", From: 0, Until: 1}: {
 					// leading versions
 					types.MakeMetricData("apps.mark.1_1", []float64{nan, nan, 1, nan, nan, nan, nan}, 1, now32),
 					types.MakeMetricData("apps.mark.2_0", []float64{nan, nan, nan, nan, nan, nan, 1}, 1, now32),

--- a/expr/functions/toLowerCase/function_test.go
+++ b/expr/functions/toLowerCase/function_test.go
@@ -29,7 +29,7 @@ func TestToLowerCaseFunction(t *testing.T) {
 		{
 			"lower(METRIC.TEST.FOO)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "METRIC.TEST.FOO", From: 0, Until: 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric.test.foo",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
@@ -37,7 +37,7 @@ func TestToLowerCaseFunction(t *testing.T) {
 		{
 			"lower(METRIC.TEST.FOO,7)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "METRIC.TEST.FOO", From: 0, Until: 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("METRIC.tEST.FOO",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
@@ -45,7 +45,7 @@ func TestToLowerCaseFunction(t *testing.T) {
 		{
 			"lower(METRIC.TEST.FOO,-3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "METRIC.TEST.FOO", From: 0, Until: 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("METRIC.TEST.fOO",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
@@ -53,7 +53,7 @@ func TestToLowerCaseFunction(t *testing.T) {
 		{
 			"lower(METRIC.TEST.FOO,0,7,12)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "METRIC.TEST.FOO", From: 0, Until: 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("mETRIC.tEST.fOO",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
@@ -61,7 +61,7 @@ func TestToLowerCaseFunction(t *testing.T) {
 		{
 			"toLowerCase(METRIC.TEST.FOO)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"METRIC.TEST.FOO", 0, 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "METRIC.TEST.FOO", From: 0, Until: 1}: {types.MakeMetricData("METRIC.TEST.FOO", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric.test.foo",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},

--- a/expr/functions/toUpperCase/function_test.go
+++ b/expr/functions/toUpperCase/function_test.go
@@ -29,7 +29,7 @@ func TestToUpperCaseFunction(t *testing.T) {
 		{
 			"upper(metric.test.foo)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric.test.foo", From: 0, Until: 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("METRIC.TEST.FOO",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
@@ -37,7 +37,7 @@ func TestToUpperCaseFunction(t *testing.T) {
 		{
 			"upper(metric.test.foo,7)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric.test.foo", From: 0, Until: 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric.Test.foo",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
@@ -45,7 +45,7 @@ func TestToUpperCaseFunction(t *testing.T) {
 		{
 			"upper(metric.test.foo,-3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric.test.foo", From: 0, Until: 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("metric.test.Foo",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
@@ -53,7 +53,7 @@ func TestToUpperCaseFunction(t *testing.T) {
 		{
 			"upper(metric.test.foo,0,7,12)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric.test.foo", From: 0, Until: 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("Metric.Test.Foo",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
@@ -61,7 +61,7 @@ func TestToUpperCaseFunction(t *testing.T) {
 		{
 			"toUpperCase(metric.test.foo)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric.test.foo", 0, 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
+				{Metric: "metric.test.foo", From: 0, Until: 1}: {types.MakeMetricData("metric.test.foo", []float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("METRIC.TEST.FOO",
 				[]float64{1, 2, 0, 7, 8, 20, 30, math.NaN()}, 1, now32)},

--- a/expr/functions/transformNull/function_test.go
+++ b/expr/functions/transformNull/function_test.go
@@ -29,7 +29,7 @@ func TestTransformNull(t *testing.T) {
 		{
 			`transformNull(metric1)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now)},
 			},
 			[]*types.MetricData{types.MakeMetricData("transformNull(metric1)",
 				[]float64{1, 0, 0, 3, 4, 12}, 1, now).SetTag("transformNull", "0").SetNameTag("metric1")},
@@ -37,7 +37,7 @@ func TestTransformNull(t *testing.T) {
 		{
 			`transformNull(metric1, default=5)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now)},
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now)},
 			},
 			[]*types.MetricData{types.MakeMetricData("transformNull(metric1,5)",
 				[]float64{1, 5, 5, 3, 4, 12}, 1, now).SetTag("transformNull", "5").SetNameTag("metric1")},
@@ -45,8 +45,8 @@ func TestTransformNull(t *testing.T) {
 		{
 			`transformNull(metric1, default=5, referenceSeries=metric2.*)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), math.NaN(), 4, 12}, 1, now)},
-				{"metric2.*", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), math.NaN(), 4, 12}, 1, now)},
+				{Metric: "metric2.*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric2.foo", []float64{math.NaN(), 3, math.NaN(), 3, math.NaN(), 12}, 1, now),
 					types.MakeMetricData("metric2.bar", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now)},
 			},
@@ -63,7 +63,7 @@ func TestTransformNull(t *testing.T) {
 		{
 			`transformNull(seriesByTag('name=metric1'), 0)`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"seriesByTag('name=metric1')", 0, 1}: {types.MakeMetricData("metric1;env=prod", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now)},
+				{Metric: "seriesByTag('name=metric1')", From: 0, Until: 1}: {types.MakeMetricData("metric1;env=prod", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now)},
 			},
 			[]*types.MetricData{types.MakeMetricData("transformNull(metric1;env=prod,0)",
 				[]float64{1, 0, 0, 3, 4, 12}, 1, now).SetTag("transformNull", "0").SetNameTag("metric1").SetTag("env", "prod")},

--- a/expr/functions/tukey/function_test.go
+++ b/expr/functions/tukey/function_test.go
@@ -28,7 +28,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"tukeyAbove(metric*,1.5,5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32),
 					types.MakeMetricData("metricB", []float64{20, 18, 21, 19, 20, 20}, 1, now32),
 					types.MakeMetricData("metricC", []float64{19, 19, 21, 17, 23, 20}, 1, now32),
@@ -47,7 +47,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"tukeyAbove(metric*, 3, 5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32),
 					types.MakeMetricData("metricB", []float64{20, 18, 21, 19, 20, 20}, 1, now32),
 					types.MakeMetricData("metricC", []float64{19, 19, 21, 17, 23, 20}, 1, now32),
@@ -64,7 +64,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"tukeyAbove(metric*, 1.5, 5, 6)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{20, 20, 20, 20, 21, 17, 20, 20, 10, 29}, 1, now32),
 					types.MakeMetricData("metricB", []float64{20, 20, 20, 20, 20, 18, 21, 19, 20, 20}, 1, now32),
 					types.MakeMetricData("metricC", []float64{20, 20, 20, 20, 19, 19, 21, 17, 23, 20}, 1, now32),
@@ -83,7 +83,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"tukeyAbove(metric*,1.5,5,\"6s\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{20, 20, 20, 20, 21, 17, 20, 20, 10, 29}, 1, now32),
 					types.MakeMetricData("metricB", []float64{20, 20, 20, 20, 20, 18, 21, 19, 20, 20}, 1, now32),
 					types.MakeMetricData("metricC", []float64{20, 20, 20, 20, 19, 19, 21, 17, 23, 20}, 1, now32),
@@ -102,7 +102,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"tukeyBelow(metric*,1.5,5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32),
 					types.MakeMetricData("metricB", []float64{20, 18, 21, 19, 20, 20}, 1, now32),
 					types.MakeMetricData("metricC", []float64{19, 19, 21, 17, 23, 20}, 1, now32),
@@ -120,7 +120,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"tukeyBelow(metric*,1.5,5,-4)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{21, 17, 20, 20, 10, 29, 20, 20, 20, 20}, 1, now32),
 					types.MakeMetricData("metricB", []float64{20, 18, 21, 19, 20, 20, 20, 20, 20, 20}, 1, now32),
 					types.MakeMetricData("metricC", []float64{19, 19, 21, 17, 23, 20, 20, 20, 20, 20}, 1, now32),
@@ -138,7 +138,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"tukeyBelow(metric*,1.5,5,\"-4s\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{21, 17, 20, 20, 10, 29, 20, 20, 20, 20}, 1, now32),
 					types.MakeMetricData("metricB", []float64{20, 18, 21, 19, 20, 20, 20, 20, 20, 20}, 1, now32),
 					types.MakeMetricData("metricC", []float64{19, 19, 21, 17, 23, 20, 20, 20, 20, 20}, 1, now32),
@@ -156,7 +156,7 @@ func TestFunctionMultiReturn(t *testing.T) {
 		{
 			"tukeyBelow(metric*,3,5)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32),
 					types.MakeMetricData("metricB", []float64{20, 18, 21, 19, 20, 20}, 1, now32),
 					types.MakeMetricData("metricC", []float64{19, 19, 21, 17, 23, 20}, 1, now32),

--- a/expr/functions/unique/function_test.go
+++ b/expr/functions/unique/function_test.go
@@ -29,7 +29,7 @@ func TestUnique(t *testing.T) {
 		{
 			`unique(metric[1234])`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric[1234]", 0, 1}: {
+				{Metric: "metric[1234]", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.foo.bar.baz", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2.foo.bar.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
 					types.MakeMetricData("metric3.foo.bar.baz", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),

--- a/expr/functions/verticalLine/function_test.go
+++ b/expr/functions/verticalLine/function_test.go
@@ -47,7 +47,7 @@ func TestFunction(t *testing.T) {
 		{
 			"verticalLine(\"-5m\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"foo", from, nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
+				{Metric: "foo", From: from, Until: nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
 			},
 			[]*types.MetricData{makeMetricData("", []float64{1.0, 1.0}, 1, wantedTs, wantedTs)},
 			from,
@@ -56,7 +56,7 @@ func TestFunction(t *testing.T) {
 		{
 			"verticalLine(\"-5m\", \"label\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"foo", from, nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
+				{Metric: "foo", From: from, Until: nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
 			},
 			[]*types.MetricData{makeMetricData("label", []float64{1.0, 1.0}, 1, wantedTs, wantedTs)},
 			from,
@@ -86,7 +86,7 @@ func TestFunctionErrors(t *testing.T) {
 		{
 			"verticalLine(\"-50m\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"foo", from, nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
+				{Metric: "foo", From: from, Until: nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
 			},
 			[]*types.MetricData{},
 			TsOutOfRangeError,
@@ -94,7 +94,7 @@ func TestFunctionErrors(t *testing.T) {
 		{
 			"verticalLine(\"+5m\")",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"foo", from, nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
+				{Metric: "foo", From: from, Until: nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
 			},
 			[]*types.MetricData{},
 			TsOutOfRangeError,

--- a/expr/functions/weightedAverage/function_test.go
+++ b/expr/functions/weightedAverage/function_test.go
@@ -32,14 +32,14 @@ func TestWeightedAverage(t *testing.T) {
 		{
 			"weightedAverage(metric*, metric*, 0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {},
+				{Metric: "metric*", From: 0, Until: 1}: {},
 			},
 			[]*types.MetricData{},
 		},
 		{
 			"weightedAverage(metric*, metric*, 0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 					types.MakeMetricData("metric2", []float64{None, 2, None, 4, None, 6, None, 8, None, 10, None, 12, None, 14, None, 16, None, 18, None, 20}, 1, now32),
 					types.MakeMetricData("metric3", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None, None, None}, 1, now32),
@@ -54,13 +54,13 @@ func TestWeightedAverage(t *testing.T) {
 		{
 			"weightedAverage(metric*.dividend, metric*.divisor, 0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*.dividend", 0, 1}: {
+				{Metric: "metric*.dividend", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.dividend", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 					types.MakeMetricData("metric2.dividend", []float64{None, 2, None, 4, None, 6, None, 8, None, 10, None, 12, None, 14, None, 16, None, 18, None, 20}, 1, now32),
 					types.MakeMetricData("metric3.dividend", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None, None, None}, 1, now32),
 					types.MakeMetricData("metric5.dividend", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, None, None}, 1, now32),
 				},
-				{"metric*.divisor", 0, 1}: {
+				{Metric: "metric*.divisor", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.divisor", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 					types.MakeMetricData("metric3.divisor", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None, None, None}, 1, now32),
 					types.MakeMetricData("metric4.divisor", []float64{1, 2, 3, 4, None, 6, None, None, 9, 10, 11, None, 13, None, None, None, None, 18, 19, 20}, 1, now32),
@@ -76,10 +76,10 @@ func TestWeightedAverage(t *testing.T) {
 		{
 			"weightedAverage(metric1.dividend, metric2.divisor, 0)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.dividend", 0, 1}: {
+				{Metric: "metric1.dividend", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.dividend", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 				},
-				{"metric2.divisor", 0, 1}: {
+				{Metric: "metric2.divisor", From: 0, Until: 1}: {
 					types.MakeMetricData("metric2.divisor", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 				},
 			},
@@ -107,7 +107,7 @@ func BenchmarkWeightedAverage(b *testing.B) {
 		{
 			target: "weightedAverage(metric*, metric*, 0)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric*", 0, 1}: {
+				{Metric: "metric*", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 					types.MakeMetricData("metric2", []float64{None, 2, None, 4, None, 6, None, 8, None, 10, None, 12, None, 14, None, 16, None, 18, None, 20}, 1, now32),
 					types.MakeMetricData("metric3", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None, None, None}, 1, now32),
@@ -119,13 +119,13 @@ func BenchmarkWeightedAverage(b *testing.B) {
 		{
 			target: "weightedAverage(metric*.dividend, metric*.divisor, 0)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric*.dividend", 0, 1}: {
+				{Metric: "metric*.dividend", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.dividend", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 					types.MakeMetricData("metric2.dividend", []float64{None, 2, None, 4, None, 6, None, 8, None, 10, None, 12, None, 14, None, 16, None, 18, None, 20}, 1, now32),
 					types.MakeMetricData("metric3.dividend", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None, None, None}, 1, now32),
 					types.MakeMetricData("metric5.dividend", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, None, None}, 1, now32),
 				},
-				{"metric*.divisor", 0, 1}: {
+				{Metric: "metric*.divisor", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.divisor", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 					types.MakeMetricData("metric3.divisor", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None, None, None}, 1, now32),
 					types.MakeMetricData("metric4.divisor", []float64{1, 2, 3, 4, None, 6, None, None, 9, 10, 11, None, 13, None, None, None, None, 18, 19, 20}, 1, now32),
@@ -137,10 +137,10 @@ func BenchmarkWeightedAverage(b *testing.B) {
 			// empty result
 			target: "weightedAverage(metric1.dividend, metric2.divisor, 0)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1.dividend", 0, 1}: {
+				{Metric: "metric1.dividend", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.dividend", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 				},
-				{"metric2.divisor", 0, 1}: {
+				{Metric: "metric2.divisor", From: 0, Until: 1}: {
 					types.MakeMetricData("metric2.divisor", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 				},
 			},

--- a/expr/rewrite/aboveSeries/function_test.go
+++ b/expr/rewrite/aboveSeries/function_test.go
@@ -71,7 +71,7 @@ func TestDiffSeries(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			eval, err := expr.NewEvaluator(nil, th.NewTestZipper(nil))
+			eval, err := expr.NewEvaluator(nil, th.NewTestZipper(nil), false)
 			if err == nil {
 				th.TestRewriteExpr(t, eval, &tt)
 			} else {

--- a/expr/rewrite/aboveSeries/function_test.go
+++ b/expr/rewrite/aboveSeries/function_test.go
@@ -25,7 +25,7 @@ func TestDiffSeries(t *testing.T) {
 		{
 			`aboveSeries(metric1, 7, "Kotik", "Bog")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricSobaka", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricKotik", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricHomyak", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
@@ -40,7 +40,7 @@ func TestDiffSeries(t *testing.T) {
 		{
 			`aboveSeries(metric1, 7, ".*Ko.ik$", "Bog")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {
+				{Metric: "metric1", From: 0, Until: 1}: {
 					types.MakeMetricData("metricSobaka", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricKotik", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricHomyak", []float64{4, 4, 5, 5, 6, 8}, 1, now32),
@@ -55,7 +55,7 @@ func TestDiffSeries(t *testing.T) {
 		{
 			`aboveSeries(statsd.timers.metric.rate, 1000, 'rate', 'median')`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"statsd.timers.metric.rate", 0, 1}: {
+				{Metric: "statsd.timers.metric.rate", From: 0, Until: 1}: {
 					types.MakeMetricData("statsd.timers.metric.rate", []float64{500, 1500}, 1, now32),
 					types.MakeMetricData("statsd.timers.metric.median", []float64{50, 55}, 1, now32),
 				},

--- a/expr/rewrite/applyByNode/function_test.go
+++ b/expr/rewrite/applyByNode/function_test.go
@@ -24,7 +24,7 @@ func TestApplyByNode(t *testing.T) {
 		{
 			`applyByNode(test.metric*.name, 1, "%.transform")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"test.metric*.name", 0, 1}: {
+				{Metric: "test.metric*.name", From: 0, Until: 1}: {
 					types.MakeMetricData("test.metric1.name", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("test.metric2.name", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 				},
@@ -42,7 +42,7 @@ func TestApplyByNode(t *testing.T) {
 			// overflow
 			`applyByNode(metric*.name, 2, "%.transform")`,
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric*.name", 0, 1}: {
+				{Metric: "metric*.name", From: 0, Until: 1}: {
 					types.MakeMetricData("metric1.name", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 				},
 			},

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -8,9 +8,10 @@ import (
 
 // MetricRequest contains all necessary data to request a metric.
 type MetricRequest struct {
-	Metric string
-	From   int64
-	Until  int64
+	Metric            string
+	ConsolidationFunc string // explicitly use function for consolidation. Check https://graphite.readthedocs.io/en/latest/functions.html?highlight=consolidateBy#graphite.render.functions.consolidateBy
+	From              int64
+	Until             int64
 }
 
 // ExprType defines a type for expression types constants (e.x. functions, values, constants, parameters, strings)
@@ -50,7 +51,7 @@ var (
 	ErrUnknownTimeUnits = errors.New("unknown time units")
 	// ErrInvalidArg is eval error for invalid or mismatch function arg
 	ErrInvalidArg = errors.New("invalid function arg")
-	//ErrInvalidInterval is an eval error returned when an interval is set to 0
+	// ErrInvalidInterval is an eval error returned when an interval is set to 0
 	ErrInvalidInterval = errors.New("invalid interval arg")
 )
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -3,13 +3,14 @@ package parser
 import (
 	"bytes"
 	"fmt"
-	"github.com/go-graphite/carbonapi/expr/holtwinters"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/go-graphite/carbonapi/expr/holtwinters"
 
 	"github.com/ansel1/merry"
 )
@@ -157,6 +158,14 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 			referenceSeriesExpr := e.GetNamedArg("referenceSeries")
 			if !referenceSeriesExpr.IsInterfaceNil() {
 				r = append(r, referenceSeriesExpr.Metrics(from, until)...)
+			}
+		case "consolidateBy":
+			function, err := e.GetStringArg(1)
+			if err != nil {
+				break
+			}
+			for i := range r {
+				r[i].ConsolidationFunc = function
 			}
 		case "timeShift":
 			offs, err := e.GetIntervalArg(1, -1)


### PR DESCRIPTION
This PR is mostly a copy of #793.
Passes consolidateBy with its argument to the backend through the FilteringFunctions field. Only works with carbonapi_v3_pb protocol.
Fixes broken tests and removes passing ConsolidationFunc field further after parsing the target in Fetch. This is needed since this field is empty during evaluation and "values" map will not return anything.
In addition I added an option to the config to enable this behavior.