### PR TITLE
MaxDataPoints consolidation improvements: support nudging for consistent bucketing

### DIFF
--- a/cmd/carbonapi/config/config.go
+++ b/cmd/carbonapi/config/config.go
@@ -113,6 +113,9 @@ type ConfigType struct {
 	MaxQueryLength              uint64 `mapstructure:"maxQueryLength"`
 	CombineMultipleTargetsInOne bool   `mapstructure:"combineMultipleTargetsInOne"`
 
+	NudgeStartTimeOnAggregation             bool `mapstructure:"nudgeStartTimeOnAggregation"`
+	UseBucketsHighestTimestampOnAggregation bool `mapstructure:"useBucketsHighestTimestampOnAggregation"`
+
 	ResponseCache cache.BytesCache `mapstructure:"-" json:"-"`
 	BackendCache  cache.BytesCache `mapstructure:"-" json:"-"`
 

--- a/cmd/carbonapi/config/init.go
+++ b/cmd/carbonapi/config/init.go
@@ -26,6 +26,7 @@ import (
 	fconfig "github.com/go-graphite/carbonapi/expr/functions/config"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/rewrite"
+	tconfig "github.com/go-graphite/carbonapi/expr/types/config"
 	"github.com/go-graphite/carbonapi/limiter"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	zipperTypes "github.com/go-graphite/carbonapi/zipper/types"
@@ -257,6 +258,9 @@ func SetUpConfig(logger *zap.Logger, BuildVersion string) {
 		)
 	}
 
+	tconfig.Config.NudgeStartTimeOnAggregation = Config.NudgeStartTimeOnAggregation
+	tconfig.Config.UseBucketsHighestTimestampOnAggregation = Config.UseBucketsHighestTimestampOnAggregation
+
 	if Config.Listen != "" {
 		listeners := make(map[string]struct{})
 		for _, l := range Config.Listeners {
@@ -401,6 +405,9 @@ func SetUpViper(logger *zap.Logger, configPath *string, exactConfig bool, viperP
 	viper.SetDefault("useCachingDNSResolver", false)
 	viper.SetDefault("logger", map[string]string{})
 	viper.SetDefault("combineMultipleTargetsInOne", false)
+	viper.SetDefault("nudgeStartTimeOnAggregation", false)
+	viper.SetDefault("useBucketsHighestTimestampOnAggregation", false)
+
 	viper.AutomaticEnv()
 
 	var err error

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -56,6 +56,8 @@ Table of Contents
       * [For IRONdb](#for-irondb)
   * [expireDelaySec](#expiredelaysec)
     * [Example](#example-21)
+  * [nudgeStartTimeOnAggregation](#nudgestarttimeonaggregation)
+  * [useBucketsHighestTimestampOnAggregation](#usebucketshighesttimestamponaggregation)
 
 # General configuration for carbonapi
 
@@ -939,4 +941,29 @@ Default: 600 (10 minutes)
 ### Example
 ```yaml
 expireDelaySec: 10
+```
+
+***
+## nudgeStartTimeOnAggregation
+Enables nudging the start time of metrics  when aggregating to honor MaxDataPoints.
+The start time is nudged in such way that timestamps always fall in the same bucket.
+This is done by GraphiteWeb, and is useful to avoid jitter in graphs when refreshing the page.
+
+Default: false
+
+### Example
+```yaml
+nudgeStartTimeOnAggregation: true
+```
+
+***
+## useBucketsHighestTimestampOnAggregation
+Enables using the highest timestamp of the buckets when aggregating to honor MaxDataPoints, instead of the lowest timestamp.
+This prevents results to appear to predict the future.
+
+Default: false
+
+### Example
+```yaml
+useBucketsHighestTimestampOnAggregation: true
 ```

--- a/expr/types/config/config.go
+++ b/expr/types/config/config.go
@@ -1,0 +1,16 @@
+package config
+
+type ConfigType = struct {
+	// NudgeStartTimeOnAggregation enables nudging the start time of metrics
+	// when aggregated. The start time is nudged in such way that timestamps
+	// always fall in the same bucket. This is done by GraphiteWeb, and is
+	// useful to avoid jitter in graphs when refreshing the page.
+	NudgeStartTimeOnAggregation bool
+
+	// UseBucketsHighestTimestampOnAggregation enables using the highest timestamp of the
+	// buckets when aggregating to honor MaxDataPoints, instead of the lowest timestamp.
+	// This prevents results to appear to predict the future.
+	UseBucketsHighestTimestampOnAggregation bool
+}
+
+var Config = ConfigType{}

--- a/expr/types/types_test.go
+++ b/expr/types/types_test.go
@@ -1,0 +1,222 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/types/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAggregatedValuesNudgedAndHighestTimestamp(t *testing.T) {
+
+	config.Config.NudgeStartTimeOnAggregation = true
+	config.Config.UseBucketsHighestTimestampOnAggregation = true
+
+	tests := []struct {
+		name      string
+		values    []float64
+		step      int64
+		start     int64
+		mdp       int64
+		want      []float64
+		wantStep  int64
+		wantStart int64
+	}{
+		{
+			name:      "empty",
+			values:    []float64{},
+			step:      60,
+			mdp:       100,
+			want:      []float64{},
+			wantStep:  60,
+			wantStart: 0,
+		},
+		{
+			name:      "one point",
+			values:    []float64{1, 2, 3, 4},
+			start:     10,
+			step:      10,
+			mdp:       1,
+			want:      []float64{10},
+			wantStep:  40,
+			wantStart: 40,
+		},
+		{
+			name:      "no nudge if few points",
+			values:    []float64{1, 2, 3, 4},
+			step:      10,
+			start:     20,
+			mdp:       1,
+			want:      []float64{10},
+			wantStep:  40,
+			wantStart: 50,
+		},
+
+		{
+			name:      "should nudge the first point",
+			values:    []float64{1, 2, 3, 4, 5, 6},
+			start:     20,
+			step:      10,
+			mdp:       3,
+			want:      []float64{5, 9, 6},
+			wantStep:  20,
+			wantStart: 40,
+		},
+		{
+			name:      "should be stable with previous",
+			values:    []float64{2, 3, 4, 5, 6, 7},
+			start:     30,
+			step:      10,
+			mdp:       3,
+			want:      []float64{5, 9, 13},
+			wantStep:  20,
+			wantStart: 40,
+		},
+		{
+			name:      "more data",
+			values:    []float64{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},
+			start:     20,
+			step:      10,
+			mdp:       3,
+			want:      []float64{40, 50},
+			wantStep:  50,
+			wantStart: 100,
+		},
+		{
+			name:      "even more data",
+			values:    []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10.0, 11, 12, 13, 14},
+			start:     10,
+			step:      10,
+			mdp:       3,
+			want:      []float64{15, 40, 50},
+			wantStep:  50,
+			wantStart: 50,
+		},
+		{
+			name:      "skewed start time",
+			values:    []float64{2, 3, 4, 5, 6, 7, 8, 9, 10},
+			start:     21,
+			step:      10,
+			mdp:       5,
+			want:      []float64{2 + 3, 4 + 5, 6 + 7, 8 + 9, 10}, // no points discarded, bucket starts at 20
+			wantStep:  20,
+			wantStart: 31,
+		},
+		{
+			name:      "skewed start time 2",
+			values:    []float64{2, 3, 4, 5, 6, 7, 8, 9, 10},
+			start:     29,
+			step:      10,
+			mdp:       5,
+			want:      []float64{2 + 3, 4 + 5, 6 + 7, 8 + 9, 10}, // no points discarded, bucket starts at 20
+			wantStep:  20,
+			wantStart: 39,
+		},
+		{
+			name:      "skewed start time 3",
+			values:    []float64{2, 3, 4, 5, 6, 7, 8, 9, 10},
+			start:     31,
+			step:      10,
+			mdp:       5,
+			want:      []float64{3 + 4, 5 + 6, 7 + 8, 9 + 10}, // 1st point discarded, it belongs to the incomplete bucket (20,40)
+			wantStep:  20,
+			wantStart: 51,
+		},
+		{
+			name:      "skewed start time no aggregation",
+			values:    []float64{1, 2, 3, 4},
+			start:     31,
+			step:      10,
+			mdp:       4,
+			want:      []float64{1, 2, 3, 4},
+			wantStep:  10,
+			wantStart: 31,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := MakeMetricData("test", tt.values, tt.step, tt.start)
+			input.ConsolidationFunc = "sum"
+			ConsolidateJSON(tt.mdp, []*MetricData{input})
+
+			got := input.AggregatedValues()
+			gotStep := input.AggregatedTimeStep()
+			gotStart := input.AggregatedStartTime()
+
+			assert.Equal(t, tt.want, got, "bad values")
+			assert.Equal(t, tt.wantStep, gotStep, "bad step")
+			assert.Equal(t, tt.wantStart, gotStart, "bad start")
+		})
+	}
+}
+
+func TestAggregatedValuesConfigVariants(t *testing.T) {
+	const start = 20
+	const step = 10
+	const mdp = 3
+	values := []float64{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
+	const expectedStep = int64(50)
+	/*
+		ts:                |    | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100 | 110 | 120 | 130 | 140 |
+		vals:              |    | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10  | 11  | 12  | 13  | 14  |
+		unaligned buckets:      |                        |                          |
+		aligned buckets:   |                        |                         |
+	*/
+
+	tests := []struct {
+		name             string
+		nudge            bool
+		highestTimestamp bool
+		want             []float64
+		wantStart        int64
+	}{
+		{
+			name:             "nudge start and highest timestamp",
+			nudge:            true,
+			highestTimestamp: true,
+			want:             []float64{40, 50},
+			wantStart:        100,
+		},
+		{
+			name:             "nudge start and not highest timestamp",
+			nudge:            true,
+			highestTimestamp: false,
+			want:             []float64{40, 50},
+			wantStart:        60,
+		},
+		{
+			name:             "not nudge start and highest timestamp",
+			nudge:            false,
+			highestTimestamp: true,
+			want:             []float64{20, 45, 39},
+			wantStart:        60,
+		},
+		{
+			name:             "not nudge start and not highest timestamp",
+			nudge:            false,
+			highestTimestamp: false,
+			want:             []float64{20, 45, 39},
+			wantStart:        20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.Config.NudgeStartTimeOnAggregation = tt.nudge
+			config.Config.UseBucketsHighestTimestampOnAggregation = tt.highestTimestamp
+
+			input := MakeMetricData("test", values, step, start)
+			input.ConsolidationFunc = "sum"
+			ConsolidateJSON(mdp, []*MetricData{input})
+
+			got := input.AggregatedValues()
+			gotStep := input.AggregatedTimeStep()
+			gotStart := input.AggregatedStartTime()
+
+			assert.Equal(t, tt.want, got, "bad values")
+			assert.Equal(t, expectedStep, gotStep, "bad step")
+			assert.Equal(t, tt.wantStart, gotStart, "bad start")
+		})
+	}
+}


### PR DESCRIPTION
Brings in these features: https://github.com/grafana/carbonapi/pull/146

________________________

## NudgeStartTimeOnAggregation

I've described the purpose of this in the code. Here's a copy of the relevant parts:

```
// NudgeStartTimeOnAggregation enables nudging the start time of metrics
// when aggregated. The start time is nudged in such way that timestamps
// always fall in the same bucket. This is done by GraphiteWeb, and is
// useful to avoid jitter in graphs when refreshing the page.

[ ... ]

// nudgePointsCount returns the number of points to discard at the beginning of
// the series when aggregating. This is done if NudgeStartTimeOnAggregation is
// enabled, and has the purpose of assigning timestamps of a series to buckets
// consistently across different time ranges. To simplifiy the aggregation
// logic, we discard points at the beginning of the series so that a bucket
// starts right at the beginning. This function calculates how many points to
// discard.

```

 TLDR: if the consolidation is done naively (as it is being done now) , the same data point can be assigned to different buckets depending on the start time of the series. This can cause jitter in graphs when refreshing constantly.

This is done by graphite web here: https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/views.py#L225

and by Metrictank here: https://github.com/grafana/metrictank/blob/309ba74749c4fd8c60950929ff0719af8abc0799/consolidation/consolidate.go#L26

My implementation and tests are mainly inspired on Metrictank.

## UseBucketsHighestTimestampOnAggregation

Additionally, `UseBucketsHighestTimestampOnAggregation` let's the user configure the bucket's timestimes in such way that the upper bound is used instead of the lower bound. This was also done by Metrictank, and its purpose is to avoid results from appearing to predict the future (i.e. a spike in "real time" ts=6 could be moved to a ts=4). 


Both of these features are disabled by default for now to avoid unexpected changes on upgrades.

_______________________________

Some videos showing this:


#### CarbonAPI with nudging disabled


https://github.com/grafana/carbonapi/assets/32206519/1d285484-3e4b-4551-bed4-cd82908241ab

Notice the sudden change when the values change buckets

#### CarbonAPI with nudging enabled


https://github.com/grafana/carbonapi/assets/32206519/4d57699b-318b-41c0-a367-0643d7496d4c

#### Metrictank's version (which was my ground truth here)

https://github.com/grafana/carbonapi/assets/32206519/860cd2f6-85b2-42e8-ab8e-07cb30a7e121