### PR TITLE
Manual trigger for docker images build

### DIFF
--- a/.github/workflows/docker-ghcrio.yml
+++ b/.github/workflows/docker-ghcrio.yml
@@ -25,7 +25,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # create latest tag for branch events
           flavor: |
-            latest=auto
+            latest=${{ inputs.ref && 'false' || 'auto' }}
           tags: |
             type=semver,pattern={{version}},value=${{inputs.ref}}
             type=semver,pattern={{major}}.{{minor}},value=${{inputs.ref}}

--- a/.github/workflows/docker-ghcrio.yml
+++ b/.github/workflows/docker-ghcrio.yml
@@ -27,11 +27,9 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{version}},value=${{inputs.ref}}
+            type=semver,pattern={{major}}.{{minor}},value=${{inputs.ref}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{inputs.ref}}
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-ghcrio.yml
+++ b/.github/workflows/docker-ghcrio.yml
@@ -21,6 +21,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
+          context: ${{ inputs.ref && 'git' || 'workflow' }}
           images: ghcr.io/${{ github.repository }}
           # create latest tag for branch events
           flavor: |

--- a/.github/workflows/docker-ghcrio.yml
+++ b/.github/workflows/docker-ghcrio.yml
@@ -1,7 +1,13 @@
 name: Upload Docker images to ghcr.io
 on:
   release:
-    types: [published, edited]
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git tag to push the image'
+        required: true
+        type: string
 jobs:
   docker:
     name: Build image
@@ -9,6 +15,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Another attempt to fix the rebuild.

Unfortunately, `edited` doesn't relaunch existing releases since the `action` code must be there.

So, here are the automatic and manual launches for the following releases and tags:

- v0.17.1:
  - [automatic](https://github.com/Felixoid/carbonapi/actions/runs/11653115793/job/32445149106#step:3:42)
  - [manual](https://github.com/Felixoid/carbonapi/actions/runs/11653117652/job/32445153533#step:3:42)
- v0.17.1-1:
  - [automatic](https://github.com/Felixoid/carbonapi/actions/runs/11653116535/job/32445150604#step:3:42)
  - [manual](https://github.com/Felixoid/carbonapi/actions/runs/11653118893/job/32445156061#step:3:42)

Another point: `latest` will be published ONLY when the release is created, and it is semver compatible without `-some` suffuxes