### PR TITLE
fix SummarizeValues to return last non-NaN value

### DIFF
--- a/expr/consolidations/consolidations.go
+++ b/expr/consolidations/consolidations.go
@@ -163,7 +163,7 @@ func SummarizeValues(f string, values []float64, XFilesFactor float32) float64 {
 				total++
 			}
 		}
-		if total == 0 {
+		if total > 0 {
 			rv /= float64(total)
 		}
 	case "max":

--- a/expr/consolidations/consolidations.go
+++ b/expr/consolidations/consolidations.go
@@ -188,7 +188,13 @@ func SummarizeValues(f string, values []float64, XFilesFactor float32) float64 {
 			}
 		}
 	case "last", "current":
-		rv = values[len(values)-1]
+		rv = math.NaN()
+		for i := len(values) - 1; i >= 0; i-- {
+			if !math.IsNaN(values[i]) {
+				rv = values[i]
+				break
+			}
+		}
 		total = notNans(values)
 	case "range", "rangeOf":
 		vMax := math.Inf(-1)

--- a/expr/consolidations/consolidations.go
+++ b/expr/consolidations/consolidations.go
@@ -164,9 +164,8 @@ func SummarizeValues(f string, values []float64, XFilesFactor float32) float64 {
 			}
 		}
 		if total == 0 {
-			return math.NaN()
+			rv /= float64(total)
 		}
-		rv /= float64(total)
 	case "max":
 		rv = math.Inf(-1)
 		for _, av := range values {


### PR DESCRIPTION
When `SummarizeValues` is called with `last` or `current` as the aggregation function, it returns the last value of the series, whether it is NaN or not. This causes `legendValue` to output "NaN" in the legend, even if there are non-NaN values the series.

This PR changes the behavior of `SummarizeValues` so that the last non-NaN value is returned.