### PR TITLE
In date.DateParamToEpoch handle tz parameter

### DIFF
--- a/date/date_test.go
+++ b/date/date_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDateParamToEpoch(t *testing.T) {
 
-	defaultTimeZone := time.Local
+	defaultTimeZone := time.UTC
 	timeNow = func() time.Time {
 		//16 Aug 1994 15:30
 		return time.Date(1994, time.August, 16, 15, 30, 0, 100, defaultTimeZone)
@@ -20,22 +20,22 @@ func TestDateParamToEpoch(t *testing.T) {
 		input  string
 		output string
 	}{
-		{"midnight", "00:00 1994-Aug-16"},
-		{"noon", "12:00 1994-Aug-16"},
-		{"teatime", "16:00 1994-Aug-16"},
-		{"tomorrow", "00:00 1994-Aug-17"},
+		{"midnight", "07:00 1994-Aug-16"},
+		{"noon", "19:00 1994-Aug-16"},
+		{"teatime", "23:00 1994-Aug-16"},
+		{"tomorrow", "07:00 1994-Aug-17"},
 
-		{"noon 08/12/94", "12:00 1994-Aug-12"},
-		{"midnight 20060812", "00:00 2006-Aug-12"},
-		{"noon tomorrow", "12:00 1994-Aug-17"},
+		{"noon 08/12/94", "19:00 1994-Aug-12"},
+		{"midnight 20060812", "07:00 2006-Aug-12"},
+		{"noon tomorrow", "19:00 1994-Aug-17"},
 
-		{"17:04 19940812", "17:04 1994-Aug-12"},
+		{"17:04 19940812", "00:04 1994-Aug-13"},
 		{"-1day", "15:30 1994-Aug-15"},
-		{"19940812", "00:00 1994-Aug-12"},
+		{"19940812", "07:00 1994-Aug-12"},
 	}
 
 	for _, tt := range tests {
-		got := DateParamToEpoch(tt.input, "Local", 0, defaultTimeZone)
+		got := DateParamToEpoch(tt.input, "America/Los_Angeles", 0, defaultTimeZone)
 		ts, err := time.ParseInLocation(shortForm, tt.output, defaultTimeZone)
 		if err != nil {
 			panic(fmt.Sprintf("error parsing time: %q: %v", tt.output, err))


### PR DESCRIPTION
The current implementation does not respect the tz query parameter.

The check of the err value of time.LoadLocation is backwards, so it only attempts to use the query tz when it's invalid.  Flip that logic to set the tz value when it's a valid TZ Identifier (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).

Adjust all places that compute a Unix timestamp to respect the query tz parameter.

Adjust tests to do date tests with a TZ offset.

