### PR TITLE
Takeover forceMinStepInterval from config to VictoriaMetricsGroup object

### DIFF
--- a/zipper/protocols/victoriametrics/victoriametrics_group.go
+++ b/zipper/protocols/victoriametrics/victoriametrics_group.go
@@ -211,6 +211,7 @@ func NewWithLimiter(logger *zap.Logger, config types.BackendV2, tldCacheDisabled
 		maxMetricsPerRequest: *config.MaxBatchSize,
 
 		step:                 step,
+		forceMinStepInterval: forceMinStepInterval,
 		maxPointsPerQuery:    maxPointsPerQuery,
 		vmClusterTenantID:    vmClusterTenantID,
 		startDelay:           delay,


### PR DESCRIPTION
This fixes  #856