### PR TITLE
fix(parser): check for extra symbols in expression

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -651,6 +651,12 @@ func ParseExpr(e string) (Expr, string, error) {
 	if err != nil {
 		return exp, e, err
 	}
+
+  // all symbols should be parsed, otherwise we have an syntax error
+  if e != "" {
+    return nil, "", ErrUnexpectedCharacter
+  }
+
 	exp, err = defineMap.expandExpr(exp.(*expr))
 	return exp, e, err
 }


### PR DESCRIPTION
Hello! There is a small fix of expression parser.
Parser should throw an error by these cases:
- `func(metric))` - unexpected character `)` in the end of expression
- `metric)` - unexpected character `)`
- `func(func1(metric)), metric1)` - unexpected character

It looks like after parsing of expression in function `ParseExpr` input raw expression mutates and should be empty. In other cases, it should has a syntax error.