### PR TITLE
Remove tz, from, and until parameters from expand handler

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -102,8 +102,12 @@ _When `format=png`_ (default if not specified)
 * `jsonp` : ...
 * `query` : the metric or glob-pattern to find
 
+### /metrics/expand/?
 
-
+* `query` : the metric or glob-pattern to find
+* `jsonp` : ...
+* `groupByExpr`: (0 or 1)
+* `leavesOnly`: (0 or 1)
 
 ## Graphite-web 1.1.7 compatibility
 ### Unsupported functions

--- a/cmd/carbonapi/http/expand_handler.go
+++ b/cmd/carbonapi/http/expand_handler.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/go-graphite/carbonapi/carbonapipb"
 	"github.com/go-graphite/carbonapi/cmd/carbonapi/config"
-	"github.com/go-graphite/carbonapi/date"
 	utilctx "github.com/go-graphite/carbonapi/util/ctx"
 )
 
@@ -31,12 +30,6 @@ func expandHandler(w http.ResponseWriter, r *http.Request) {
 	jsonp := r.FormValue("jsonp")
 	groupByExpr := r.FormValue("groupByExpr")
 	leavesOnly := r.FormValue("leavesOnly")
-
-	qtz := r.FormValue("tz")
-	from := r.FormValue("from")
-	until := r.FormValue("until")
-	from64 := date.DateParamToEpoch(from, qtz, timeNow().Add(-time.Hour).Unix(), config.Config.DefaultTimeZone)
-	until64 := date.DateParamToEpoch(until, qtz, timeNow().Unix(), config.Config.DefaultTimeZone)
 
 	srcIP, srcPort := splitRemoteAddr(r.RemoteAddr)
 
@@ -84,8 +77,6 @@ func expandHandler(w http.ResponseWriter, r *http.Request) {
 
 	var pv3Request pbv3.MultiGlobRequest
 	pv3Request.Metrics = query
-	pv3Request.StartTime = from64
-	pv3Request.StopTime = until64
 
 	multiGlobs, stats, err := config.Config.ZipperInstance.Find(ctx, pv3Request)
 	if stats != nil {

--- a/cmd/carbonapi/http/helper.go
+++ b/cmd/carbonapi/http/helper.go
@@ -65,6 +65,8 @@ func (r responseFormat) String() string {
 
 func (r responseFormat) ValidExpandFormat() bool {
 	switch r {
+	case treejsonFormat:
+		return true
 	case jsonFormat:
 		return true
 	default:


### PR DESCRIPTION
Hi, 

I ran into some issues while working with the `metrics/expand` endpoint. This PR addresses this issues.

This should conclude the issue https://github.com/go-graphite/carbonapi/issues/245

1. The JSON format was not selected by default.

The treejsonFormat was used as the default if none was given, but it was missing as a valid format in the ValidExpandFormat helper.

```bash
#Before
curl "http://localhost:8081/metrics/expand?query=node1.value"
unsupported format:

# With the PR
curl "http://localhost:8081/metrics/expand?query=node1.value"
{"results":["node1.value"]}
```

2.  It had the parameters "tz", "from", and "until", which are not described in the Graphite API

I assume this was just a copy-paste artifact from the `findHandler`, not sure. I removed these parameters.

Regards,
Markus
