### PR TITLE
Add dependabot configuration for golang dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: '10:00'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This commits add configuration for the github depedanbot to check weekly for newer versions of the golang dependencies which are used in this project.
This should help with maintenance, since it is easier to do some occasional update with small changes then doing a big one when there is a known security problem or something like that.