### PR TITLE
Add handling for '+' char in metric names in queries

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -693,7 +693,7 @@ func IsNameChar(r byte) bool {
 		r == '<' || r == '>' ||
 		r == '&' || r == '#' ||
 		r == '/' || r == '%' ||
-		r == '@'
+		r == '@' || r == '+'
 }
 
 func IsDigit(r byte) bool {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -300,6 +300,13 @@ func TestParseExpr(t *testing.T) {
 			},
 		},
 		{
+			`foo.b[0-9]+.qux`,
+			&expr{
+				target: "foo.b[0-9]+.qux",
+				etype:  EtName,
+			},
+		},
+		{
 			`virt.v1.*.text-match:<foo.bar.qux>`,
 			&expr{
 				target: "virt.v1.*.text-match:<foo.bar.qux>",


### PR DESCRIPTION
Originally from our fork: https://github.com/grafana/carbonapi/pull/93

We've been running this for a while.

Here's proof that Graphite Web accepts `+`:

```
$ docker run -d --name graphite-web -p 8080:80 -p 2003:2003 graphiteapp/graphite-statsd
$ echo "test+metric.foo.bar 42 $(date +%s)" | nc -w 1 127.0.0.1 2003
$ curl --get "http://localhost:8080/render"  --data-urlencode "target=test+metric.foo.bar" --data-urlencode "from=-1min" --data-urlencode "format=json" --data-urlencode "pretty=true"

[
  {
    "target": "test+metric.foo.bar",
    "tags": {
      "name": "test+metric.foo.bar"
    },
    "datapoints": [
      [
        null,
        1764251420
      ],
      [
        null,
        1764251430
      ],
      [
        null,
        1764251440
      ],
      [
        null,
        1764251450
      ],
      [
        42.0,
        1764251460
      ],
      [
        null,
        1764251470
      ]
    ]
  }
]
```