### PR TITLE
fix(timeShift): dont append nil results

### DIFF
--- a/expr/functions/timeShift/function.go
+++ b/expr/functions/timeShift/function.go
@@ -93,9 +93,9 @@ func (f *timeShift) Do(ctx context.Context, eval interfaces.Evaluator, e parser.
 	if err != nil {
 		return nil, err
 	}
-	results := make([]*types.MetricData, len(arg))
+	results := make([]*types.MetricData, 0, len(arg))
 
-	for n, a := range arg {
+	for _, a := range arg {
 		r := a.CopyLink()
 		r.Name = "timeShift(" + a.Name + ",'" + offsStr + "'," + resetEndStr + ")"
 		r.StartTime = a.StartTime - int64(offs)
@@ -110,7 +110,7 @@ func (f *timeShift) Do(ctx context.Context, eval interfaces.Evaluator, e parser.
 		r.Values = r.Values[:length]
 
 		r.Tags["timeshift"] = fmt.Sprintf("%d", offs)
-		results[n] = r
+		results = append(results, r)
 
 	}
 

--- a/expr/functions/timeShift/function_test.go
+++ b/expr/functions/timeShift/function_test.go
@@ -95,6 +95,16 @@ func TestTimeShift(t *testing.T) {
 			From:  startTime,
 			Until: startTime + 6,
 		},
+		{
+			// Data starts at 205 but fetch requests 200-202, so we have no data for the series, expecting an empty result
+			Target: `timeShift(metric1, "+100s", true)`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 200, Until: 202}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5}, 1, 205)},
+			},
+			Want:  []*types.MetricData{},
+			From:  100,
+			Until: 102,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The check

```go
	if length < 0 {
		continue
	}
```

 was leaving `nil` entries in the slice under some circumstances.