### PR TITLE
Check interval arg is within int32 bounds

### DIFF
--- a/expr/functions/summarize/function_test.go
+++ b/expr/functions/summarize/function_test.go
@@ -2,6 +2,7 @@ package summarize
 
 import (
 	"context"
+	"errors"
 	"math"
 	"testing"
 
@@ -388,8 +389,12 @@ func TestEvalSummarizeOverflow(t *testing.T) {
 	}
 
 	eval := th.EvaluatorFromFunc(md[0].F)
-	if _, err := eval.Eval(context.Background(), exp, now32, now32+5, m); err == nil {
+	_, err = eval.Eval(context.Background(), exp, now32, now32+5, m)
+	if err == nil {
 		t.Fatalf("expected error for interval overflow, got nil")
+	}
+	if !errors.Is(err, parser.ErrBadType) {
+		t.Errorf("expected error wrapping parser.ErrBadType, got %v", err)
 	}
 }
 

--- a/expr/functions/summarize/function_test.go
+++ b/expr/functions/summarize/function_test.go
@@ -1,6 +1,7 @@
 package summarize
 
 import (
+	"context"
 	"math"
 	"testing"
 
@@ -369,6 +370,26 @@ func TestEvalSummarize1Minute(t *testing.T) {
 	for _, tt := range tests {
 		eval := th.EvaluatorFromFunc(md[0].F)
 		th.TestSummarizeEvalExpr(t, eval, &tt)
+	}
+}
+
+func TestEvalSummarizeOverflow(t *testing.T) {
+	_, _, tenThirty := th.InitTestSummarize()
+	now32 := tenThirty
+
+	target := "summarize(metric1,'100y','sum',true)"
+	m := map[parser.MetricRequest][]*types.MetricData{
+		{Metric: "metric1", From: now32, Until: now32 + 5}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+	}
+
+	exp, _, err := parser.ParseExpr(target)
+	if err != nil {
+		t.Fatalf("failed to parse %v: %+v", target, err)
+	}
+
+	eval := th.EvaluatorFromFunc(md[0].F)
+	if _, err := eval.Eval(context.Background(), exp, now32, now32+5, m); err == nil {
+		t.Fatalf("expected error for interval overflow, got nil")
 	}
 }
 

--- a/pkg/parser/interval.go
+++ b/pkg/parser/interval.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"fmt"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -15,6 +17,7 @@ func IntervalString(s string, defaultSign int) (int32, error) {
 		return 0, ErrUnknownTimeUnits
 	}
 
+	original := s
 	sign := defaultSign
 
 	switch s[0] {
@@ -26,7 +29,7 @@ func IntervalString(s string, defaultSign int) (int32, error) {
 		s = s[1:]
 	}
 
-	var totalInterval int32
+	var totalInterval int64
 	for len(s) > 0 {
 		var j int
 		for j < len(s) && '0' <= s[j] && s[j] <= '9' {
@@ -42,7 +45,7 @@ func IntervalString(s string, defaultSign int) (int32, error) {
 		var unitStr string
 		unitStr, s = s[:j], s[j:]
 
-		var units int
+		var units int64
 		switch strings.ToLower(unitStr) {
 		case "s", "sec", "secs", "second", "seconds":
 			units = 1
@@ -66,10 +69,13 @@ func IntervalString(s string, defaultSign int) (int32, error) {
 		if err != nil {
 			return 0, err
 		}
-		totalInterval += int32(sign * offset * units)
+		totalInterval += int64(sign) * int64(offset) * units
 	}
 
-	return totalInterval, nil
+	if totalInterval > math.MaxInt32 || totalInterval < math.MinInt32 {
+		return 0, fmt.Errorf("interval %q out of range", original)
+	}
+	return int32(totalInterval), nil
 }
 
 func TruthyBool(s string) bool {

--- a/pkg/parser/interval_test.go
+++ b/pkg/parser/interval_test.go
@@ -24,6 +24,8 @@ func TestInterval(t *testing.T) {
 		{"+2d", 2 * 60 * 60 * 24, -1},
 		{"-10hours", -60 * 60 * 10, -1},
 		{"-360h2min", -360*60*60 - 2*60, -1},
+
+		{"68y", 68 * 365 * 24 * 60 * 60, 1},
 	}
 
 	for _, tt := range tests {
@@ -43,13 +45,18 @@ func TestInterval(t *testing.T) {
 		{"+", 0, "unknown time units", 1},
 		{"10x10s", 0, "unknown time units", 1},
 		{"10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000y", 0, "value out of range", 1},
+		{"100y", 0, "out of range", 1},
+		{"-100y", 0, "out of range", 1},
+		{"69y", 0, "out of range", 1},
 	}
 	for _, tt := range exceptTests {
 		secs, err := IntervalString(tt.t, tt.sign)
 		if secs != tt.seconds {
 			t.Errorf("intervalString(%q)=%d, want %d\n", tt.t, secs, tt.seconds)
 		}
-		if !strings.Contains(err.Error(), tt.err) {
+		if err == nil {
+			t.Errorf("Actual error for intervalString(%q) is nil, expected to contain %v\n", tt.t, tt.err)
+		} else if !strings.Contains(err.Error(), tt.err) {
 			t.Errorf("Error of intervalString(%q)=%v, expected to contain %v\n", tt.t, err.Error(), tt.err)
 		}
 	}


### PR DESCRIPTION
Currently `IntervalString` is parsed as an `int` and then casted to an `int32`, which could result in an overflow. This was spotted when a `summarize()` query was run with a `100y` interval - in this case, the cast caused a negative value to be returned, and then caused a panic within `summarize.Do` as it caused a negative index to be accessed in a slice.

Proposing to fix by erroring if the parsed value is out of the int32 bounds instead of silently returning a possibly incorrect value.