### PR TITLE
Ignore boolean value for alignTo parameter in smartSummarize

### DIFF
--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -35,7 +35,7 @@ func (f *smartSummarize) Do(ctx context.Context, eval interfaces.Evaluator, e pa
 		return nil, parser.ErrMissingArgument
 	}
 
-	alignToInterval, err := e.GetStringNamedOrPosArgDefault("alignTo", 3, "")
+	alignToInterval, err := getAlignTo(e)
 	if err != nil {
 		return nil, err
 	}
@@ -117,6 +117,21 @@ func (f *smartSummarize) Do(ctx context.Context, eval interfaces.Evaluator, e pa
 		results[n] = &r
 	}
 	return results, nil
+}
+
+// smartSummarize previously accepted a boolean alignToFrom argument, which has
+// since been deprecated. In graphite-web, if a boolean value is passed in for
+// this parameter, it is ignored rather than erroring out. This same is done here for
+// compatibility.
+func getAlignTo(e parser.Expr) (string, error) {
+	alignToArg, ok := parser.NamedOrPosArg(e, "alignTo", 3)
+	if !ok || alignToArg.IsBool() {
+		return "", nil
+	}
+	if !alignToArg.IsString() {
+		return "", parser.ErrBadType
+	}
+	return alignToArg.StringValue(), nil
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -124,7 +124,7 @@ func (f *smartSummarize) Do(ctx context.Context, eval interfaces.Evaluator, e pa
 // this parameter, it is ignored rather than erroring out. This same is done here for
 // compatibility.
 func getAlignTo(e parser.Expr) (string, error) {
-	alignToArg, ok := parser.NamedOrPosArg(e, "alignTo", 3)
+	alignToArg, ok := e.NamedOrPosArg("alignTo", 3)
 	if !ok || alignToArg.IsBool() {
 		return "", nil
 	}

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -812,6 +812,55 @@ func TestSmartSummarizeErrors(t *testing.T) {
 	}
 }
 
+func TestSmartSummarizeAlignToBoolIgnored(t *testing.T) {
+	tests := []th.SummarizeEvalTestItem{
+		{
+			Target: "smartSummarize(metric2,'2minute','sum',True)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric2", From: 0, Until: 300}: {types.MakeMetricData("metric2", []float64{1, 2, 3, 4}, 60, 0)},
+			},
+			Want:  []float64{3, 7},
+			From:  0,
+			Until: 300,
+			Name:  "smartSummarize(metric2,'2minute','sum')",
+			Step:  120,
+			Start: 0,
+			Stop:  240,
+		},
+		{
+			Target: "smartSummarize(metric2,'2minute','sum',False)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric2", From: 0, Until: 300}: {types.MakeMetricData("metric2", []float64{1, 2, 3, 4}, 60, 0)},
+			},
+			Want:  []float64{3, 7},
+			From:  0,
+			Until: 300,
+			Name:  "smartSummarize(metric2,'2minute','sum')",
+			Step:  120,
+			Start: 0,
+			Stop:  240,
+		},
+		{
+			Target: "smartSummarize(metric2,'2minute','sum',alignTo=True)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric2", From: 0, Until: 300}: {types.MakeMetricData("metric2", []float64{1, 2, 3, 4}, 60, 0)},
+			},
+			Want:  []float64{3, 7},
+			From:  0,
+			Until: 300,
+			Name:  "smartSummarize(metric2,'2minute','sum')",
+			Step:  120,
+			Start: 0,
+			Stop:  240,
+		},
+	}
+
+	for _, tt := range tests {
+		eval := th.EvaluatorFromFunc(md[0].F)
+		th.TestSummarizeEvalExpr(t, eval, &tt)
+	}
+}
+
 func generateValues(start, stop, step int64) (values []float64) {
 	for i := start; i < stop; i += step {
 		values = append(values, float64(i))

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -112,6 +112,8 @@ type Expr interface {
 	NamedArgs() map[string]Expr
 	// NamedArg returns named argument and boolean flag for check arg exist.
 	NamedArg(string) (Expr, bool)
+	// NamedOrPosArg returns the named argument when present, otherwise the positional argument at pos.
+	NamedOrPosArg(name string, pos int) (Expr, bool)
 	// RawArgs returns string that contains all arguments of expression exactly the same order they appear
 	RawArgs() string
 	// SetRawArgs changes raw argument list for current expression.

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -141,6 +141,20 @@ func (e *expr) NamedArg(name string) (Expr, bool) {
 	return expr, exist
 }
 
+// NamedOrPosArg returns the named argument when present, otherwise the positional argument.
+func NamedOrPosArg(e Expr, name string, pos int) (Expr, bool) {
+	if e == nil || e.IsInterfaceNil() {
+		return nil, false
+	}
+	if arg, ok := e.NamedArg(name); ok {
+		return arg, true
+	}
+	if e.ArgsLen() > pos {
+		return e.Arg(pos), true
+	}
+	return nil, false
+}
+
 func (e *expr) Metrics(from, until int64) []MetricRequest {
 	switch e.etype {
 	case EtName:
@@ -290,9 +304,16 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 				return nil
 			}
 
-			alignToInterval, err := e.GetStringNamedOrPosArgDefault("alignTo", 3, "")
-			if err != nil {
-				return nil
+			// smartSummarize previously accepted a boolean alignToFrom argument, which has
+			// since been deprecated. In graphite-web, if a boolean value is passed in for
+			// this parameter, it is ignored rather than erroring out. This same is done here for
+			// compatibility
+			alignToInterval := ""
+			if arg, ok := NamedOrPosArg(e, "alignTo", 3); ok && !arg.IsBool() {
+				if !arg.IsString() {
+					return nil
+				}
+				alignToInterval = arg.StringValue()
 			}
 
 			if alignToInterval != "" {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -142,10 +142,7 @@ func (e *expr) NamedArg(name string) (Expr, bool) {
 }
 
 // NamedOrPosArg returns the named argument when present, otherwise the positional argument.
-func NamedOrPosArg(e Expr, name string, pos int) (Expr, bool) {
-	if e == nil || e.IsInterfaceNil() {
-		return nil, false
-	}
+func (e *expr) NamedOrPosArg(name string, pos int) (Expr, bool) {
 	if arg, ok := e.NamedArg(name); ok {
 		return arg, true
 	}
@@ -309,7 +306,7 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 			// this parameter, it is ignored rather than erroring out. This same is done here for
 			// compatibility
 			alignToInterval := ""
-			if arg, ok := NamedOrPosArg(e, "alignTo", 3); ok && !arg.IsBool() {
+			if arg, ok := e.NamedOrPosArg("alignTo", 3); ok && !arg.IsBool() {
 				if !arg.IsString() {
 					return nil
 				}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -558,6 +558,25 @@ func TestGetIntervalNamedOrPosArgDefault(t *testing.T) {
 	assert.Equal(t, int64(-60), val)
 }
 
+func TestNamedOrPosArg(t *testing.T) {
+	e, _, err := ParseExpr("func(metric, '1h', 'sum', true, alignTo='days')")
+	assert.NoError(t, err)
+
+	arg, ok := NamedOrPosArg(e, "alignTo", 3)
+	if assert.True(t, ok) {
+		assert.True(t, arg.IsString())
+		assert.Equal(t, "days", arg.StringValue())
+	}
+
+	arg, ok = NamedOrPosArg(e, "missing", 3)
+	if assert.True(t, ok) {
+		assert.True(t, arg.IsBool())
+	}
+
+	_, ok = NamedOrPosArg(e, "missing", 4)
+	assert.False(t, ok)
+}
+
 func TestDoGetFloatArg(t *testing.T) {
 	tests := []struct {
 		s string
@@ -919,6 +938,60 @@ func TestMetrics(t *testing.T) {
 					{valStr: "seconds", etype: EtString},
 				},
 				argString: "metric1, '1h', 'sum', 'seconds'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410346740,
+					Until:  1410346865,
+				},
+			},
+		},
+		// Ensure that smartSummarize is able to silently handle invalid bool
+		// value for last argument
+		{
+			"smartSummarize(metric1, '1h', 'sum', true)",
+			&expr{
+				target: "smartSummarize",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+					{valStr: "sum", etype: EtString},
+					{valStr: "true", etype: EtBool},
+				},
+				argString: "metric1, '1h', 'sum', true",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410346740,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
+			"smartSummarize(metric1, '1h', 'sum', alignTo=true)",
+			&expr{
+				target: "smartSummarize",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+					{valStr: "sum", etype: EtString},
+				},
+				namedArgs: map[string]*expr{
+					"alignTo": {
+						target: "true",
+						etype:  EtBool,
+						valStr: "true",
+					},
+				},
+				argString: "metric1, '1h', 'sum', alignTo=true",
 			},
 			1410346740,
 			1410346865,

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -562,18 +562,18 @@ func TestNamedOrPosArg(t *testing.T) {
 	e, _, err := ParseExpr("func(metric, '1h', 'sum', true, alignTo='days')")
 	assert.NoError(t, err)
 
-	arg, ok := NamedOrPosArg(e, "alignTo", 3)
+	arg, ok := e.NamedOrPosArg("alignTo", 3)
 	if assert.True(t, ok) {
 		assert.True(t, arg.IsString())
 		assert.Equal(t, "days", arg.StringValue())
 	}
 
-	arg, ok = NamedOrPosArg(e, "missing", 3)
+	arg, ok = e.NamedOrPosArg("missing", 3)
 	if assert.True(t, ok) {
 		assert.True(t, arg.IsBool())
 	}
 
-	_, ok = NamedOrPosArg(e, "missing", 4)
+	_, ok = e.NamedOrPosArg("missing", 4)
 	assert.False(t, ok)
 }
 


### PR DESCRIPTION
This PR updates the smartSummarize function, allowing it to ignore the alignTo parameter if a boolean value is passed in. This is for compatibility with graphite-web. For context, smartSummarize used to accept a boolean alignToFrom parameter, which has since been deprecated. However, graphite-web does not error out if a boolean is passed in to the smartSummarize function for the last argument/alignTo value. 

See: https://github.com/graphite-project/graphite-web/blob/b5d272be6abdf358aebe56d12df777c2c97de4c3/webapp/graphite/render/functions.py#L5280