### PR TITLE
fix(parser): correctly handle `|`, `=`, whitespace and multi-byte runes in metric names with a wide `RangeTables`

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -172,6 +172,20 @@ func TestEvalExpr(t *testing.T) {
 			from:     1437127020,
 			until:    1437127140,
 		},
+		"metric unicode name inside a function": {
+			metric:  "1Метрика",
+			request: "summarize(1Метрика,'1min')",
+			metricRequest: parser.MetricRequest{
+				Metric: "1Метрика",
+				From:   1437127020,
+				Until:  1437127140,
+			},
+			values:   []float64{343, 407, 385},
+			isAbsent: []bool{false, false, false},
+			stepTime: 60,
+			from:     1437127020,
+			until:    1437127140,
+		},
 	}
 
 	parser.RangeTables = append(parser.RangeTables, unicode.Cyrillic)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -847,10 +847,14 @@ var disallowedCharactersInMetricName = map[rune]struct{}{
 	'\'': struct{}{},
 	' ':  struct{}{},
 	'/':  struct{}{},
+	'|':  struct{}{},
 }
 
 func unicodeRuneAllowedInName(r rune) bool {
 	if _, ok := disallowedCharactersInMetricName[r]; ok {
+		return false
+	}
+	if unicode.IsSpace(r) {
 		return false
 	}
 
@@ -920,6 +924,10 @@ FOR:
 				if len(s) < i+2 || s[i+1] == '=' || s[i+1] == ',' || s[i+1] == ')' {
 					continue
 				}
+				// we are here: `key=value`
+				//                  ^
+				// even if '=' is a valid character for metric name, it's a separator for a named arg or tag
+				break FOR
 			}
 			fallthrough
 		/* */

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -937,6 +937,10 @@ FOR:
 		if isDefault {
 			r, w = utf8.DecodeRuneInString(s[i:])
 			if unicodeRuneAllowedInName(r) && unicode.In(r, RangeTables...) {
+				// this may be a multi-byte rune, but we only wrote the first byte
+				if w > 1 {
+					buf.WriteString(s[i+1 : i+w])
+				}
 				continue
 			}
 			if !isEscape {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"testing"
+	"unicode"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -39,6 +40,12 @@ func TestSkipWhitespace(t *testing.T) {
 }
 
 func TestParseExpr(t *testing.T) {
+	// "Common" allows non-ASCII names but also contains '|', '\n', '=', etc.,
+	// which the grammar must still recognize as special characters depending on context.
+	orig := RangeTables
+	defer func() { RangeTables = orig }()
+	RangeTables = append(RangeTables, unicode.Scripts["Common"])
+
 	tests := []struct {
 		s string
 		e *expr
@@ -179,6 +186,18 @@ func TestParseExpr(t *testing.T) {
 					"key": {etype: EtString, valStr: "value"},
 				},
 				argString: "metric, key='value'",
+			},
+		},
+		{
+			"func(metric, true\n)",
+			&expr{
+				target: "func",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric"},
+					{etype: EtBool, target: "true", valStr: "true"},
+				},
+				argString: "metric, true\n",
 			},
 		},
 		{

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -40,11 +40,13 @@ func TestSkipWhitespace(t *testing.T) {
 }
 
 func TestParseExpr(t *testing.T) {
-	// "Common" allows non-ASCII names but also contains '|', '\n', '=', etc.,
-	// which the grammar must still recognize as special characters depending on context.
+	// Widen RangeTables to every script so non-ASCII names are allowed.
+	// The grammar must still recognize '|', '\n', '=', etc. as special characters depending on context.
 	orig := RangeTables
 	defer func() { RangeTables = orig }()
-	RangeTables = append(RangeTables, unicode.Scripts["Common"])
+	for _, t := range unicode.Scripts {
+		RangeTables = append(RangeTables, t)
+	}
 
 	tests := []struct {
 		s string
@@ -52,6 +54,9 @@ func TestParseExpr(t *testing.T) {
 	}{
 		{"metric=",
 			&expr{target: "metric="},
+		},
+		{"métric.ñame",
+			&expr{target: "métric.ñame"},
 		},
 		{"metric",
 			&expr{target: "metric"},


### PR DESCRIPTION
## What

`|`, whitespace and the `=` kwarg separator were only reserved when `RangeTables` was empty. Widening it (e.g. `unicodeRangeTables: ["Common"]`) let them be swallowed into metric names, breaking pipes, whitespace-separated tokens and `key=value` args.

This fix reserves them unconditionally in `parseName`

`TestParseExpr` now runs under a widened `RangeTables` (all scripts) and failed for several cases before the fix. I added a trailing `\n` case for whitespace swallowing and a multi-byte non-ASCII case (`métric.ñame`) for the rune-corruption bug below.

Without the fix, 16 cases fail. Each operator gets absorbed into the name:

`=` swallowed

```
--- FAIL: TestParseExpr/func(metric,_key='value')
    unexpected character
    string_to_parse=`(metric, key='value')`, character_number=14, character=`'`
```

`|` swallowed

```
--- FAIL: TestParseExpr/...requestsHandled|keepLastValue()
    got  Target() = "company.server*.applicationInstance.requestsHandled|keepLastValue"
    want Target() = "keepLastValue"
```

whitespace swallowed

```
--- FAIL: TestParseExpr/foo.bar\n.baz\t
    got  Target() = "foo.bar\n.baz\t"
    want Target() = "foo.bar"
```

multi-byte rune corrupted (only the first byte of each rune is kept)

```
--- FAIL: TestParseExpr/métric.ñame
    got  Target() = "m\xc3tric.\xc3ame"
    want Target() = "métric.ñame"
```


## How

- `|` and whitespace are disallowed from metric names entirely, matching graphite web behavior.
- `parseName` now stops entirely when detecting a `key=value` separator, instead of consulting whether the char (`=`) is allowed
- `parseName` only wrote the first byte of each rune while advancing by the full rune width, corrupting multi-byte names; it now emits the continuation bytes.
