### PR TITLE
bugfix: reduceSeries honors aliased names

### DIFF
--- a/expr/functions/reduce/function.go
+++ b/expr/functions/reduce/function.go
@@ -68,7 +68,7 @@ func (f *reduce) Do(ctx context.Context, eval interfaces.Evaluator, e parser.Exp
 	var aliasNames []string
 
 	for _, series := range seriesList {
-		metric := series.Tags["name"]
+		metric := series.Name
 		nodes := strings.Split(metric, ".")
 		reduceNodeKey := nodes[reduceNode]
 		nodes[reduceNode] = "reduce." + reduceFunction
@@ -104,7 +104,10 @@ AliasLoop:
 			return nil, err
 		}
 
-		results = append(results, result...)
+		for _, r := range result {
+			renamed := r.CopyNameWithVal(aliasName)
+			results = append(results, renamed)
+		}
 	}
 
 	return results, nil

--- a/expr/functions/reduce/function.go
+++ b/expr/functions/reduce/function.go
@@ -104,10 +104,7 @@ AliasLoop:
 			return nil, err
 		}
 
-		for _, r := range result {
-			renamed := r.CopyNameWithVal(aliasName)
-			results = append(results, renamed)
-		}
+		results = append(results, result...)
 	}
 
 	return results, nil

--- a/expr/functions/reduce/function.go
+++ b/expr/functions/reduce/function.go
@@ -68,7 +68,7 @@ func (f *reduce) Do(ctx context.Context, eval interfaces.Evaluator, e parser.Exp
 	var aliasNames []string
 
 	for _, series := range seriesList {
-		metric := series.Name
+		metric := types.ExtractName(series.Name)
 		nodes := strings.Split(metric, ".")
 		reduceNodeKey := nodes[reduceNode]
 		nodes[reduceNode] = "reduce." + reduceFunction


### PR DESCRIPTION
**Describe the bug**
Applying reduce() function after any alias* family function results in an empty result. reduceSeries derives the grouping keys from series.Tags["name"] instead of series.Name, but alias function intentionally operate on (as far as I am able to understand) series.Name. 
This causes the matchers to match against the original series name, and not the aliased series name, which in turn produce an empty (or in some corner cases) straight up wrong result.

AFAIU this behaviour is not in line with graphite-web and is a correctness bug. The bug was introduced in this refactor: https://github.com/go-graphite/carbonapi/commit/0d4ebf3feb206eef72033baafea1de0f42461d94


**CarbonAPI Version**
master

**Simplified query (if applicable)**

assume series like:


```
servers.us.dc1.host01.cpu.raw_used
servers.us.dc1.host01.cpu.raw_total
servers.us.dc1.host02.cpu.raw_used
servers.us.dc1.host02.cpu.raw_total
...
```

use the following query:
```
group(
  aliasSub(aliasByNode(servers.us.dc1.host[0-9]*.cpu.raw_used,  3, 5), 'raw_used',  'cpu.actual'),
  aliasSub(aliasByNode(servers.us.dc1.host[0-9]*.cpu.raw_total, 3, 5), 'raw_total', 'cpu.max')
) | reduceSeries('asPercent', 2, 'actual', 'max')
```

expected result is two reduced series.
actual result is empty due to the bug.

**Additional context**
The patch works for me, because I am not using tags. But I am unsure on how to handle them in this function. 

Should you be able to reduce on tags? Any input on this would be appreciated.

For now, I used ExtractName utility function and I think it should work in the general case for matching on metric name, but not on tags. 
