### PR TITLE
fix(delay): guard against steps larger than the series length

### DIFF
--- a/expr/functions/delay/function.go
+++ b/expr/functions/delay/function.go
@@ -52,20 +52,27 @@ func (f *delay) Do(ctx context.Context, eval interfaces.Evaluator, e parser.Expr
 		result.Name = "delay(" + series.Name + "," + stepsStr + ")"
 		result.Tags["delay"] = stepsStr
 
-		var newValues []float64
 		if steps < 0 {
-			newValues = make([]float64, length)
-			copy(newValues, series.Values[-steps:])
-			for i := -steps; i < length; i++ {
+			shift := -steps
+			if shift > length {
+				shift = length
+			}
+			newValues := make([]float64, length)
+			copy(newValues, series.Values[shift:])
+			for i := length - shift; i < length; i++ {
 				newValues[i] = math.NaN()
 			}
 			result.Values = newValues
 		} else if steps != 0 {
-			newValues = make([]float64, length)
-			for i := 0; i < steps; i++ {
+			shift := steps
+			if shift > length {
+				shift = length
+			}
+			newValues := make([]float64, length)
+			for i := 0; i < shift; i++ {
 				newValues[i] = math.NaN()
 			}
-			copy(newValues[steps:], series.Values[:length-steps])
+			copy(newValues[shift:], series.Values[:length-shift])
 			result.Values = newValues
 		}
 

--- a/expr/functions/delay/function_test.go
+++ b/expr/functions/delay/function_test.go
@@ -52,6 +52,49 @@ func TestDelay(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("delay(metric1,0)",
 				[]float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("delay", "0").SetNameTag("metric1")},
 		},
+		{
+			// empty series must not panic
+			"delay(metric1,1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("delay(metric1,1)",
+				[]float64{}, 1, now32).SetTag("delay", "1").SetNameTag("metric1")},
+		},
+		{
+			// steps larger than the series length shifts everything out
+			"delay(metric1,5)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("delay(metric1,5)",
+				[]float64{math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("delay", "5").SetNameTag("metric1")},
+		},
+		{
+			"delay(metric1,-5)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("delay(metric1,-5)",
+				[]float64{math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("delay", "-5").SetNameTag("metric1")},
+		},
+		{
+			// steps equal to the series length shifts everything out
+			"delay(metric1,3)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("delay(metric1,3)",
+				[]float64{math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("delay", "3").SetNameTag("metric1")},
+		},
+		{
+			"delay(metric1,-3)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 0, Until: 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("delay(metric1,-3)",
+				[]float64{math.NaN(), math.NaN(), math.NaN()}, 1, now32).SetTag("delay", "-3").SetNameTag("metric1")},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This fixes a `index out of range` panic we found when `steps` is greater or equal to the number of points. Commonly seen for empty series (e.g. when a query's glob matches nothing).

The solution is to clamp the shift to the series length in both directions, matching python's (graphite-web) forgiving slicing.

Also adds regression tests.