### PR TITLE
fix(aggregateWithWildcards): make position argument optional

### DIFF
--- a/expr/functions/aggregateWithWildcards/function.go
+++ b/expr/functions/aggregateWithWildcards/function.go
@@ -28,7 +28,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *aggregateWithWildcards) Do(ctx context.Context, eval interfaces.Evaluator, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	if e.ArgsLen() < 2 {
+	if e.ArgsLen() < 1 {
 		return nil, parser.ErrMissingArgument
 	}
 
@@ -41,6 +41,9 @@ func (f *aggregateWithWildcards) Do(ctx context.Context, eval interfaces.Evaluat
 	fieldsArgsIx := 1
 	switch e.Target() {
 	case "aggregateWithWildcards":
+		if e.ArgsLen() < 2 {
+			return nil, parser.ErrMissingArgument
+		}
 		callback, err = e.GetStringArg(1)
 		if err != nil {
 			return nil, err

--- a/expr/functions/aggregateWithWildcards/function_test.go
+++ b/expr/functions/aggregateWithWildcards/function_test.go
@@ -157,6 +157,19 @@ func TestAggregateWithWildcards(t *testing.T) {
 			},
 		},
 		{
+			`averageSeriesWithWildcards(metric[])`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric[]", From: 0, Until: 1}: {
+					types.MakeMetricData("metric1.foo.bar.baz", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2.foo.bar.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1.foo.bar.baz", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32).SetNameTag(`metric[]`).SetTag("aggregatedBy", "average"),
+				types.MakeMetricData("metric2.foo.bar.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32).SetNameTag(`metric[]`).SetTag("aggregatedBy", "average"),
+			},
+		},
+		{
 			`aggregateWithWildcards(metric[123456],"stddev",0,1,2)`,
 			map[parser.MetricRequest][]*types.MetricData{
 				{Metric: "metric[123456]", From: 0, Until: 1}: {


### PR DESCRIPTION


`position` is optional-variadic in graphite-web. Only `aggregateWithWildcards` requires a second argument (`func`).

With no positions, every node is kept and each series groups alone, so aggregation returns the input unchanged, just like graphite-web ([`functions.py`](https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/functions.py)). This is arguably useless on its own, but makes sense if the query is being parametrized with variables and such 