### PR TITLE
Remove unconditional error log in zipper

### DIFF
--- a/zipper/zipper.go
+++ b/zipper/zipper.go
@@ -153,7 +153,6 @@ func NewZipper(sender func(*types.Stats), cfg *config.Config, logger *zap.Logger
 		)
 	}
 
-	logger.Error("DEBUG ERROR LOGGGGG", zap.Any("cfg", cfg))
 	broadcastGroup, err := broadcast.NewBroadcastGroup(logger, "root", cfg.DoMultipleRequestsIfSplit, backends,
 		int32(cfg.InternalRoutingCache.Seconds()), cfg.ConcurrencyLimitPerServer, *cfg.MaxBatchSize, cfg.Timeouts, cfg.TLDCacheDisabled, cfg.RequireSuccessAll,
 	)


### PR DESCRIPTION
Hi, 

while working with carbonapi I noticed a strange error in the logs "DEBUG ERROR LOGGGGG"

Few lines below the removed line there's a debug with with the config, so I just removed the error logggggg.

```
	logger.Debug("zipper config",
		zap.Any("config", cfg),
	)
```

I assume this is something that was leftover from debugging something.

Regards
Markus