### PR TITLE
fix(highest/lowest): guard against n larger than the series count

### DIFF
--- a/expr/functions/highestLowest/function.go
+++ b/expr/functions/highestLowest/function.go
@@ -45,11 +45,6 @@ func (f *highest) Do(ctx context.Context, eval interfaces.Evaluator, e parser.Ex
 		}
 	}
 
-	// we have fewer arguments than we want result series
-	if len(arg) < n {
-		return arg, nil
-	}
-
 	var mh types.MetricHeap
 
 	var compute func([]float64) float64
@@ -96,6 +91,11 @@ func (f *highest) Do(ctx context.Context, eval interfaces.Evaluator, e parser.Ex
 		compute = consolidations.MinValue
 	default:
 		return nil, fmt.Errorf("unsupported function %v", e.Target())
+	}
+
+	// we have fewer series than we want result series
+	if len(arg) < n {
+		return arg, nil
 	}
 
 	var results []*types.MetricData

--- a/expr/functions/highestLowest/function_test.go
+++ b/expr/functions/highestLowest/function_test.go
@@ -290,6 +290,17 @@ func TestHighest(t *testing.T) {
 			},
 		},
 		{
+			"lowest(metric1, 2, \"max\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 0, Until: 1}: {
+					types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 12, 11}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metricA", []float64{1, 1, 3, 3, 12, 11}, 1, now32),
+			},
+		},
+		{
 			"lowestCurrent(metric1,1)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{Metric: "metric1", From: 0, Until: 1}: {


### PR DESCRIPTION
Fixes an `index out of range` panic we found when `lowest(seriesList, n)` is called with fewer series than `n`.

A `len(arg) < n` guard already existed but did not cover all the different targets the function handles. Just moved it a few lines below, after the parsing for `n` runs for `highest`/`lowest` targets.