### PR TITLE
fix(parser): allow whitespace between function name and argument list

### DIFF
--- a/expr/functions/groupByNode/function.go
+++ b/expr/functions/groupByNode/function.go
@@ -86,6 +86,9 @@ func (f *groupByNode) Do(ctx context.Context, eval interfaces.Evaluator, e parse
 		expr := callback + "(stub_" + k + ")"
 
 		// create a stub context to evaluate the callback in
+		// The callback must consume the whole stub expression. A callback like
+		// "sum (x)" parses fine as the call sum(x), but leaves "(stub_...)"
+		// unused in the remainder, so the stub series would never be evaluated.
 		nexpr, remainder, err := parser.ParseExpr(expr)
 		if err != nil {
 			return nil, err

--- a/expr/functions/groupByNode/function.go
+++ b/expr/functions/groupByNode/function.go
@@ -86,10 +86,10 @@ func (f *groupByNode) Do(ctx context.Context, eval interfaces.Evaluator, e parse
 		expr := callback + "(stub_" + k + ")"
 
 		// create a stub context to evaluate the callback in
-		nexpr, _, err := parser.ParseExpr(expr)
+		nexpr, remainder, err := parser.ParseExpr(expr)
 		if err != nil {
 			return nil, err
-		} else if nexpr.Type() != parser.EtFunc {
+		} else if nexpr.Type() != parser.EtFunc || remainder != "" {
 			err = merry.WithMessage(parser.ErrInvalidArg, "unsupported "+target+" callback function")
 			return nil, err
 		}

--- a/expr/functions/groupByNode/function_test.go
+++ b/expr/functions/groupByNode/function_test.go
@@ -261,18 +261,25 @@ func TestGroupByNodeError(t *testing.T) {
 
 	mr := parser.MetricRequest{Metric: "metric1.foo.*.*", From: 0, Until: 1}
 
+	m := map[parser.MetricRequest][]*types.MetricData{
+		mr: {
+			types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
+			types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, now32),
+			types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, now32),
+			types.MakeMetricData("metric1.foo.bar2.qux", []float64{7, 8, 9, 10, 11}, 1, now32),
+		},
+	}
+
 	tests := []th.EvalTestItemWithError{
 		{
 			Target: "groupByNode(metric1.foo.*.*,3,\"4\")",
-			M: map[parser.MetricRequest][]*types.MetricData{
-				mr: {
-					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
-					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, now32),
-					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, now32),
-					types.MakeMetricData("metric1.foo.bar2.qux", []float64{7, 8, 9, 10, 11}, 1, now32),
-				},
-			},
-			Error: parser.ErrInvalidArg,
+			M:      m,
+			Error:  parser.ErrInvalidArg,
+		},
+		{
+			Target: "groupByNode(metric1.foo.*.*,3,\"sum (x)\")",
+			M:      m,
+			Error:  parser.ErrInvalidArg,
 		},
 	}
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -636,32 +636,37 @@ func parseExprWithoutPipe(e string) (Expr, string, error) {
 		return &expr{valStr: nameLower, etype: EtBool, target: nameLower}, e, nil
 	}
 
-	// `function ('foo')` is equivalent to `function('foo')`, but a metric name may
-	// legitimately be followed by whitespace and a paren, so the whitespace is only
-	// consumed when the name could be a function name and its argument list parses.
-	if eTrimmed := skipWhitespace(e); eTrimmed != "" && eTrimmed[0] == '(' && isFunctionName(name) {
-		if _, _, _, _, err := parseArgList(eTrimmed); err == nil {
-			e = eTrimmed
-		}
+	if e != "" && e[0] == '(' {
+		return parseCall(name, e)
 	}
 
-	if e != "" && e[0] == '(' {
-		// TODO(civil): Tags: make it a proper Expression
-		if name == "seriesByTag" {
-			argString, _, _, e, err := parseArgList(e)
-			return &expr{target: name + "(" + argString + ")", etype: EtName}, e, err
+	// `function ('foo')` is equivalent to `function('foo')`, but a metric name may
+	// legitimately be followed by whitespace and a paren, so the call is only taken
+	// when the name could be a function name and its argument list parses.
+	if eTrimmed := skipWhitespace(e); eTrimmed != "" && eTrimmed[0] == '(' && isFunctionName(name) {
+		if exp, eAfterCall, err := parseCall(name, eTrimmed); err == nil {
+			return exp, eAfterCall, nil
 		}
-		exp := &expr{target: name, etype: EtFunc}
-
-		argString, posArgs, namedArgs, e, err := parseArgList(e)
-		exp.argString = argString
-		exp.args = posArgs
-		exp.namedArgs = namedArgs
-
-		return exp, e, err
 	}
 
 	return &expr{target: name}, e, nil
+}
+
+func parseCall(name, e string) (Expr, string, error) {
+	// TODO(civil): Tags: make it a proper Expression
+	if name == "seriesByTag" {
+		argString, _, _, e, err := parseArgList(e)
+		return &expr{target: name + "(" + argString + ")", etype: EtName}, e, err
+	}
+
+	exp := &expr{target: name, etype: EtFunc}
+
+	argString, posArgs, namedArgs, e, err := parseArgList(e)
+	exp.argString = argString
+	exp.args = posArgs
+	exp.namedArgs = namedArgs
+
+	return exp, e, err
 }
 
 // isFunctionName reports whether name matches graphite-web's funcname grammar,

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -640,9 +640,12 @@ func parseExprWithoutPipe(e string) (Expr, string, error) {
 		return parseCall(name, e)
 	}
 
-	// `function ('foo')` is equivalent to `function('foo')`, but a metric name may
-	// legitimately be followed by whitespace and a paren, so the call is only taken
-	// when the name could be a function name and its argument list parses.
+	// `function ('foo')` means the same as `function('foo')`. But a series name
+	// can also contain " (" — for example `metric1 (avg: 3)` produced by
+	// legendValue and later re-parsed by aliasQuery or applyByNode. So we only
+	// treat the name as a function call when it can be a function name and the
+	// text after the paren is a valid argument list; otherwise we return the
+	// plain name and leave the rest of the input untouched.
 	if eTrimmed := skipWhitespace(e); eTrimmed != "" && eTrimmed[0] == '(' && isFunctionName(name) {
 		if exp, eAfterCall, err := parseCall(name, eTrimmed); err == nil {
 			return exp, eAfterCall, nil

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -636,10 +636,13 @@ func parseExprWithoutPipe(e string) (Expr, string, error) {
 		return &expr{valStr: nameLower, etype: EtBool, target: nameLower}, e, nil
 	}
 
-	// ignores whitespace between function name and its argument list
-	// i.e. `function ('foo')` is equivalent to `function('foo')`.
-	if eTrimmed := skipWhitespace(e); eTrimmed != "" && eTrimmed[0] == '(' {
-		e = eTrimmed
+	// `function ('foo')` is equivalent to `function('foo')`, but a metric name may
+	// legitimately be followed by whitespace and a paren, so the whitespace is only
+	// consumed when the name could be a function name and its argument list parses.
+	if eTrimmed := skipWhitespace(e); eTrimmed != "" && eTrimmed[0] == '(' && isFunctionName(name) {
+		if _, _, _, _, err := parseArgList(eTrimmed); err == nil {
+			e = eTrimmed
+		}
 	}
 
 	if e != "" && e[0] == '(' {
@@ -659,6 +662,21 @@ func parseExprWithoutPipe(e string) (Expr, string, error) {
 	}
 
 	return &expr{target: name}, e, nil
+}
+
+// isFunctionName reports whether name matches graphite-web's funcname grammar,
+// Word(alphas+'_', alphanums+'_'), which notably excludes dots and wildcards.
+func isFunctionName(name string) bool {
+	for i := 0; i < len(name); i++ {
+		r := name[i]
+		switch {
+		case 'a' <= r && r <= 'z', 'A' <= r && r <= 'Z', r == '_':
+		case IsDigit(r) && i > 0:
+		default:
+			return false
+		}
+	}
+	return name != ""
 }
 
 func parseExprInner(e string) (Expr, string, error) {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -636,6 +636,12 @@ func parseExprWithoutPipe(e string) (Expr, string, error) {
 		return &expr{valStr: nameLower, etype: EtBool, target: nameLower}, e, nil
 	}
 
+	// ignores whitespace between function name and its argument list
+	// i.e. `function ('foo')` is equivalent to `function('foo')`.
+	if eTrimmed := skipWhitespace(e); eTrimmed != "" && eTrimmed[0] == '(' {
+		e = eTrimmed
+	}
+
 	if e != "" && e[0] == '(' {
 		// TODO(civil): Tags: make it a proper Expression
 		if name == "seriesByTag" {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -510,6 +510,36 @@ func TestParseExpr(t *testing.T) {
 				argString: "func2(func1(foo.bar),foo.baz),func4(asdf.zxcv.qwer)",
 			},
 		},
+		{
+			"someFunction (asd)",
+			&expr{
+				target:    "someFunction",
+				etype:     EtFunc,
+				args:      []*expr{{target: "asd"}},
+				argString: "asd",
+			},
+		},
+		{
+			"foo.bar | exclude ('baz') | groupByNode (1, 'sum')",
+			&expr{
+				target: "groupByNode",
+				etype:  EtFunc,
+				args: []*expr{
+					{
+						target: "exclude",
+						etype:  EtFunc,
+						args: []*expr{
+							{target: "foo.bar"},
+							{etype: EtString, valStr: "baz"},
+						},
+						argString: "foo.bar,'baz'",
+					},
+					{val: 1, etype: EtConst, valStr: "1"},
+					{etype: EtString, valStr: "sum"},
+				},
+				argString: "exclude(foo.bar,'baz'),1, 'sum'",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -554,6 +554,34 @@ func TestParseExpr(t *testing.T) {
 	}
 }
 
+func TestParseExprWhitespaceBeforeArgList(t *testing.T) {
+	tests := []struct {
+		s         string
+		target    string
+		etype     ExprType
+		remainder string
+	}{
+		{"someFunction (asd)", "someFunction", EtFunc, ""},
+		{"someFunction\t(asd)", "someFunction", EtFunc, ""},
+		{"foo.bar (baz)", "foo.bar", EtName, "(baz)"},
+		{"foo*bar (baz)", "foo*bar", EtName, "(baz)"},
+		{"metric1 (avg: 3)", "metric1", EtName, "(avg: 3)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			assert := assert.New(t)
+
+			e, remainder, err := ParseExpr(tt.s)
+			if assert.NoError(err) {
+				assert.Equal(tt.target, e.Target())
+				assert.Equal(tt.etype, e.Type())
+				assert.Equal(tt.remainder, remainder)
+			}
+		})
+	}
+}
+
 func TestDoGetBoolVar(t *testing.T) {
 	tests := []struct {
 		s string


### PR DESCRIPTION
`function ('foo')` does not parse. Whether a name starts a function call was decided by testing the byte immediately after it for `(`, so a name followed by whitespace parsed as a metric name instead. 

graphite-web accepts both spellings. Its `call` is `funcname + leftParen`, and pyparsing skips whitespace before each element of an `And`:

https://github.com/graphite-project/graphite-web/blob/1.1.10/webapp/graphite/render/grammar_unsafe.py#L86-L95

The whitespace is consumed only when `(` follows, so the non-call path returns its remainder unchanged.

---

See graphite web test showing a succesfull parse:
```
$ docker run -d --name gw -p 8080:80 graphiteapp/graphite-statsd >/dev/null && \
until curl -sf -o /dev/null "http://localhost:8080/render?target=x&format=json"; do sleep 2; done && \
curl -sG http://localhost:8080/render --data-urlencode "target=randomWalk ('a')" -d format=json -d from=-5min; echo; \
docker rm -f gw >/dev/null
[{"target": "a", "tags": {"name": "a"}, "datapoints": [[0, 1785872317], [-0.15573856844799938, 1785872377], [-0.38545492969748807, 1785872437], [-0.12892994452545037, 1785872497], [-0.5987020007736302, 1785872557]]}]

```